### PR TITLE
Bug Fixes

### DIFF
--- a/engine/src/cmd/collide2/Ice/IcePoint.h
+++ b/engine/src/cmd/collide2/Ice/IcePoint.h
@@ -212,7 +212,7 @@
 									if(y<min)	y=min;
 			                                                    else if(y>max)	y=max;
 									if(z<min)	z=min;
-			                                                     elseif(z>max)	z=max;
+			                                                     else if(z>max)	z=max;
 									return *this;
 								}
 

--- a/engine/src/vs_math.h
+++ b/engine/src/vs_math.h
@@ -42,9 +42,6 @@
  #define M_1_PI (1/M_PI)
 #endif
 
-#if defined (HAVE_MATH_H)
- #include <math.h>
-#endif
 #define FINITE( x ) ( std::isfinite( x ) )
 #define ISNAN( x ) ( std:: isnan( x ) )
 


### PR DESCRIPTION
- 16.04 seems to stil be breaking; we don't need `math.h` in
  vs_math.h since `cmath` is included, so just use the one as the
  math functions (std::isnan, std::isfinite) come from cmath.
- Typo in IcePoint - need a space between `else` and `if`