### PR TITLE
Remove deprecated throw definition

### DIFF
--- a/engine/src/audio/CodecRegistry.cpp
+++ b/engine/src/audio/CodecRegistry.cpp
@@ -139,7 +139,7 @@ namespace Audio {
     }
     
     Stream* CodecRegistry::open(const std::string& path, VSFileSystem::VSFileType type) const 
-        throw(Exception)
+       
     {
         Codec *codec = findByFile(path, type);
 		return codec->open(path, type);

--- a/engine/src/audio/CodecRegistry.cpp
+++ b/engine/src/audio/CodecRegistry.cpp
@@ -12,8 +12,7 @@
 template<> Audio::CodecRegistry* Singleton<Audio::CodecRegistry>::_singletonInstance = 0;
 
 namespace Audio {
-
-    CodecRegistry::CodecRegistry() throw()
+    CodecRegistry::CodecRegistry()
     {
     }
     
@@ -28,7 +27,7 @@ namespace Audio {
         codecPriority.clear();
     }
     
-    void CodecRegistry::add(Codec* codec, int priority) throw()
+    void CodecRegistry::add(Codec* codec, int priority)
     {
         if (codecPriority.find(codec) == codecPriority.end()) {
             codecPriority[codec] = priority;
@@ -53,7 +52,7 @@ namespace Audio {
         }
     }
     
-    void CodecRegistry::remove(Codec* codec) throw()
+    void CodecRegistry::remove(Codec* codec)
     {
         if (codecPriority.find(codec) != codecPriority.end()) {
             codecPriority.erase(codec);
@@ -68,7 +67,7 @@ namespace Audio {
         }
     }
     
-    Codec* CodecRegistry::findByName(const std::string& name) const throw(CodecNotFoundException)
+    Codec* CodecRegistry::findByName(const std::string& name) const
     {
         NameCodec::const_iterator it = nameCodec.find(name);
         if (it != nameCodec.end())
@@ -99,7 +98,7 @@ namespace Audio {
         }
     };
     
-    Codec* CodecRegistry::findByFile(const std::string& path, VSFileSystem::VSFileType type) const throw(CodecNotFoundException)
+    Codec* CodecRegistry::findByFile(const std::string& path, VSFileSystem::VSFileType type) const
     {
         std::vector<Codec*> candidates;
         
@@ -139,13 +138,12 @@ namespace Audio {
     }
     
     Stream* CodecRegistry::open(const std::string& path, VSFileSystem::VSFileType type) const 
-       
     {
         Codec *codec = findByFile(path, type);
 		return codec->open(path, type);
     }
     
-    CodecRegistration::CodecRegistration(Codec* _codec, int priority) throw()
+    CodecRegistration::CodecRegistration(Codec* _codec, int priority)
         : codec(_codec)
     {
         if (!CodecRegistry::getSingleton())

--- a/engine/src/audio/CodecRegistry.h
+++ b/engine/src/audio/CodecRegistry.h
@@ -89,7 +89,7 @@ namespace Audio {
          * Open the specified file with a suitable codec.
          * @see findByFile
          */
-        Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) const throw(Exception);
+        Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) const;
         
     };
     

--- a/engine/src/audio/CodecRegistry.h
+++ b/engine/src/audio/CodecRegistry.h
@@ -44,7 +44,7 @@ namespace Audio {
     public:
         /** Construct an empty registry 
          * @remarks End-users of the class shouldn't be using this. Singletons need it*/
-        CodecRegistry() throw();
+        CodecRegistry();
         
         ~CodecRegistry();
         
@@ -54,14 +54,14 @@ namespace Audio {
          *      that any further call will be a no-op. Previos priority will still apply.
          * @param codec The codec to be added to the registry.
          */
-        void add(Codec* codec, int priority = 0) throw();
+        void add(Codec* codec, int priority = 0);
         
         /**
          * Remove a codec from the registry
          * @remarks If the codec had already been removed, this is a no-op.
          * @param codec The codec to be removed from the registry.
          */
-        void remove(Codec* codec) throw();
+        void remove(Codec* codec);
         
         /**
          * Find a codec by its name
@@ -71,7 +71,7 @@ namespace Audio {
          *      @par Instead of returning null, if a codec of such characteristics cannot be found, 
          *      a CodecNotFound exception is risen.
          */
-        Codec* findByName(const std::string& name) const throw(CodecNotFoundException);
+        Codec* findByName(const std::string& name) const;
         
         /**
          * Find a codec that can handle the file.
@@ -83,7 +83,7 @@ namespace Audio {
          *      @par Instead of returning null, if a codec of such characteristics cannot be found, 
          *      an CodecNotFound exception is risen.
          */
-        Codec* findByFile(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) const throw(CodecNotFoundException);
+        Codec* findByFile(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) const;
         
         /**
          * Open the specified file with a suitable codec.
@@ -97,7 +97,7 @@ namespace Audio {
     {
         Codec *codec;
     public:
-        CodecRegistration(Codec* codec, int priority = 0) throw();
+        CodecRegistration(Codec* codec, int priority = 0);
         ~CodecRegistration();
     };
 

--- a/engine/src/audio/Exceptions.h
+++ b/engine/src/audio/Exceptions.h
@@ -26,7 +26,7 @@ namespace Audio {
         Exception(const Exception &other) : _message(other._message) {}
         explicit Exception(const std::string &message) : _message(message) {}
         virtual ~Exception() {}
-        virtual const char* what() const { return _message.c_str(); }
+        virtual const char* what() const noexcept { return _message.c_str(); }
     };
     
     /**

--- a/engine/src/audio/Exceptions.h
+++ b/engine/src/audio/Exceptions.h
@@ -25,8 +25,8 @@ namespace Audio {
         Exception() {};
         Exception(const Exception &other) : _message(other._message) {}
         explicit Exception(const std::string &message) : _message(message) {}
-        virtual ~Exception() throw() {}
-        virtual const char* what() const throw() { return _message.c_str(); }
+        virtual ~Exception() {}
+        virtual const char* what() const { return _message.c_str(); }
     };
     
     /**
@@ -168,7 +168,7 @@ namespace Audio {
             format(fmt)
         {}
         
-        const Format& getFormat() const throw() { return format; }
+        const Format& getFormat() const { return format; }
     };
 
     /**

--- a/engine/src/audio/Listener.cpp
+++ b/engine/src/audio/Listener.cpp
@@ -9,7 +9,7 @@
 
 namespace Audio {
 
-    Listener::Listener() throw() :
+    Listener::Listener() :
         cosAngleRange(-1,-1),
         position(0,0,0),
         atDirection(0,0,-1),
@@ -25,20 +25,20 @@ namespace Audio {
     {
     }
 
-    Range<Scalar> Listener::getAngleRange() const throw() 
+    Range<Scalar> Listener::getAngleRange() const
     { 
         return Range<Scalar>(Scalar(acos(cosAngleRange.min)), 
                              Scalar(acos(cosAngleRange.max))); 
     }
     
-    void Listener::setAngleRange(Range<Scalar> r) throw() 
+    void Listener::setAngleRange(Range<Scalar> r)
     { 
         cosAngleRange.min = Scalar(cos(r.min)); 
         cosAngleRange.max = Scalar(cos(r.max));
         dirty.attributes = 1; 
     }
 
-    void Listener::update(int flags) throw()
+    void Listener::update(int flags)
     {
         if (!dirty.attributes)
             flags &= ~RenderableListener::UPDATE_ATTRIBUTES;
@@ -65,7 +65,7 @@ namespace Audio {
         }
     }
 
-    Vector3 Listener::toLocalDirection(Vector3 dir) const throw()
+    Vector3 Listener::toLocalDirection(Vector3 dir) const
     {
         return worldToLocal * dir;
     }

--- a/engine/src/audio/Listener.h
+++ b/engine/src/audio/Listener.h
@@ -136,7 +136,7 @@ namespace Audio {
         SharedPtr<RenderableListener> getRenderable() const { return rendererDataPtr; }
         
         /** Set renderer-specific data to be associated (and destroyed) with this sound source */
-        void setRenderable(SharedPtr<RenderableListener>) { rendererDataPtr = ptr; dirty.setAll(); }
+        void setRenderable(SharedPtr<RenderableListener> ptr) { rendererDataPtr = ptr; dirty.setAll(); }
         
         /** Get user-specific data associated (and destroyed) with this listener */
         SharedPtr<UserData> getUserData() const { return userDataPtr; }

--- a/engine/src/audio/Listener.h
+++ b/engine/src/audio/Listener.h
@@ -75,30 +75,30 @@ namespace Audio {
         
     public:
         /** Construct a default listener with default parameters */
-        Listener() throw();
+        Listener();
         
         virtual ~Listener();
         
         /** Return the listener's central position in 3D space */
-        LVector3 getPosition() const throw() { return position; }
+        LVector3 getPosition() const { return position; }
         
         /** Set the listener's central position in 3D space */
-        void setPosition(LVector3 x) throw() { position = x; dirty.location = 1; }
+        void setPosition(LVector3 x) { position = x; dirty.location = 1; }
         
         /** Return the listener's front direction */
-        Vector3 getAtDirection() const throw() { return atDirection; }
+        Vector3 getAtDirection() const { return atDirection; }
         
         /** Return the listener's up direction */
-        Vector3 getUpDirection() const throw() { return upDirection; }
+        Vector3 getUpDirection() const { return upDirection; }
         
         /** Set the listener's orientation */
-        void setOrientation(Vector3 at, Vector3 up) throw() { atDirection = at; upDirection = up; dirty.location = 1; }
+        void setOrientation(Vector3 at, Vector3 up) { atDirection = at; upDirection = up; dirty.location = 1; }
         
         /** Return the listener's velocity */
-        Vector3 getVelocity() const throw() { return velocity; }
+        Vector3 getVelocity() const { return velocity; }
         
         /** Set the listener's velocity */
-        void setVelocity(Vector3 x) throw() { velocity = x; dirty.location = 1; }
+        void setVelocity(Vector3 x) { velocity = x; dirty.location = 1; }
         
         
         /** Return the listener's minimum/maximum perception angle
@@ -107,42 +107,42 @@ namespace Audio {
          *      will attenuate the sound until it reaches maximum attenuation by the maximum 
          *      perception angle. Notice that maximum attenuation may not be full silence.
          */
-        Range<Scalar> getAngleRange() const throw();
+        Range<Scalar> getAngleRange() const;
         
         /** @see getAngleRange */
-        void setAngleRange(Range<Scalar> r) throw();
+        void setAngleRange(Range<Scalar> r);
         
         /** @see getAngleRange @remarks This version returns cosine-angles rather than radians, much quicker */
-        Range<Scalar> getCosAngleRange() const throw() { return cosAngleRange; }
+        Range<Scalar> getCosAngleRange() const { return cosAngleRange; }
         
         /** @see getAngleRange @remarks This version takes cosine-angles rather than radians, much quicker */
-        void setCosAngleRange(Range<Scalar> r) throw() { cosAngleRange = r; dirty.attributes = 1; }
+        void setCosAngleRange(Range<Scalar> r) { cosAngleRange = r; dirty.attributes = 1; }
         
         /** Get the listener's radius */
-        Scalar getRadius() const throw() { return radius; }
+        Scalar getRadius() const { return radius; }
         
         /** Set the listener's radius */
-        void setRadius(Scalar r) throw() { radius = r; dirty.attributes = 1; }
+        void setRadius(Scalar r) { radius = r; dirty.attributes = 1; }
         
         
         /** Get the listener's gain */
-        Scalar getGain() const throw() { return gain; }
+        Scalar getGain() const { return gain; }
         
         /** Set the listener's gain */
-        void setGain(Scalar g) throw() { gain = g; dirty.gain = 1; }
+        void setGain(Scalar g) { gain = g; dirty.gain = 1; }
         
         
         /** Get renderer-specific data associated (and destroyed) with this sound source */
-        SharedPtr<RenderableListener> getRenderable() const throw() { return rendererDataPtr; }
+        SharedPtr<RenderableListener> getRenderable() const { return rendererDataPtr; }
         
         /** Set renderer-specific data to be associated (and destroyed) with this sound source */
-        void setRenderable(SharedPtr<RenderableListener> ptr) throw() { rendererDataPtr = ptr; dirty.setAll(); }
+        void setRenderable(SharedPtr<RenderableListener>) { rendererDataPtr = ptr; dirty.setAll(); }
         
         /** Get user-specific data associated (and destroyed) with this listener */
-        SharedPtr<UserData> getUserData() const throw() { return userDataPtr; }
+        SharedPtr<UserData> getUserData() const { return userDataPtr; }
         
         /** Set user-specific data to be associated (and destroyed) with this listener */
-        void setUserData(SharedPtr<UserData> ptr) throw() { userDataPtr = ptr; }
+        void setUserData(SharedPtr<UserData> ptr) { userDataPtr = ptr; }
         
         
         /** @see RenderableListener::update
@@ -150,7 +150,7 @@ namespace Audio {
          * @note It's not just a convenience, the abstract listener has to update
          *      its internal dirty flags and other things as well.
          */
-        void update(int flags) throw();
+        void update(int flags);
 
         
         /**
@@ -160,7 +160,7 @@ namespace Audio {
          * @note The attributes used are those set during the last update()
          * @note The behavior is unspecified if there was no previous call to update().
          */
-        Vector3 toLocalDirection(Vector3 dir) const throw();
+        Vector3 toLocalDirection(Vector3 dir) const;
         
         
     };

--- a/engine/src/audio/RenderableListener.cpp
+++ b/engine/src/audio/RenderableListener.cpp
@@ -7,7 +7,7 @@
 
 namespace Audio {
 
-    RenderableListener::RenderableListener(Listener *_listener) throw() : 
+    RenderableListener::RenderableListener(Listener *_listener) :
         listener(_listener)
     {
     }
@@ -19,7 +19,6 @@ namespace Audio {
     }
     
     void RenderableListener::update(int flags) 
-        throw()
     {
         try {
             updateImpl(flags);

--- a/engine/src/audio/RenderableListener.h
+++ b/engine/src/audio/RenderableListener.h
@@ -66,7 +66,7 @@ namespace Audio {
     protected:
         
         /** @see update. */
-        virtual void updateImpl(int flags) throw(Exception) = 0;
+        virtual void updateImpl(int flags) = 0;
     };
 
 };

--- a/engine/src/audio/RenderableListener.h
+++ b/engine/src/audio/RenderableListener.h
@@ -34,7 +34,7 @@ namespace Audio {
         
     protected:
         /** Internal constructor used by derived classes */
-        RenderableListener(Listener *listener) throw();
+        RenderableListener(Listener *listener);
         
     public:
         virtual ~RenderableListener();
@@ -48,7 +48,7 @@ namespace Audio {
         };
         
         /** Get the attached listener */
-        Listener* getListener() const throw() { return listener; }
+        Listener* getListener() const { return listener; }
         
         /** Update the underlying API with dirty attributes 
          * @param flags You may specify which attributes to update. Not all attributes are
@@ -58,7 +58,7 @@ namespace Audio {
          *      ignore them (just log them or something like that). Updates are non-critical
          *      and may fail silently.
          */
-        void update(int flags) throw();
+        void update(int flags);
         
         // The following section contains all the virtual functions that need be implemented
         // by a concrete class. All are protected, so the interface is independent

--- a/engine/src/audio/RenderableSource.cpp
+++ b/engine/src/audio/RenderableSource.cpp
@@ -8,7 +8,7 @@
 
 namespace Audio {
 
-    RenderableSource::RenderableSource(Source *_source) throw() : 
+    RenderableSource::RenderableSource(Source *_source) :
         source(_source)
     {
     }
@@ -20,7 +20,6 @@ namespace Audio {
     }
     
     void RenderableSource::startPlaying(Timestamp start) 
-       
     {
         try {
             startPlayingImpl(start);
@@ -32,7 +31,6 @@ namespace Audio {
     }
     
     void RenderableSource::stopPlaying() 
-        throw()
     {
         // Cannot be playing if an exception rises, 
         // as that implies a problem with the underlying API
@@ -43,7 +41,6 @@ namespace Audio {
     }
     
     bool RenderableSource::isPlaying() const 
-        throw()
     {
         try {
             return isPlayingImpl();
@@ -55,13 +52,11 @@ namespace Audio {
     }
     
     Timestamp RenderableSource::getPlayingTime() const 
-       
     {
         return getPlayingTimeImpl();
     }
     
     void RenderableSource::update(int flags, const Listener& sceneListener) 
-        throw()
     {
         try {
             updateImpl(flags, sceneListener);
@@ -71,7 +66,6 @@ namespace Audio {
     }
     
     void RenderableSource::seek(Timestamp time) 
-       
     {
         seekImpl(time);
     }

--- a/engine/src/audio/RenderableSource.cpp
+++ b/engine/src/audio/RenderableSource.cpp
@@ -20,7 +20,7 @@ namespace Audio {
     }
     
     void RenderableSource::startPlaying(Timestamp start) 
-        throw(Exception)
+       
     {
         try {
             startPlayingImpl(start);
@@ -55,7 +55,7 @@ namespace Audio {
     }
     
     Timestamp RenderableSource::getPlayingTime() const 
-        throw(Exception)
+       
     {
         return getPlayingTimeImpl();
     }
@@ -71,7 +71,7 @@ namespace Audio {
     }
     
     void RenderableSource::seek(Timestamp time) 
-        throw(Exception)
+       
     {
         seekImpl(time);
     }

--- a/engine/src/audio/RenderableSource.h
+++ b/engine/src/audio/RenderableSource.h
@@ -56,7 +56,7 @@ namespace Audio {
          * @remarks It just plays. Will not synchronize attributes with the underlying API.
          *      That must be done through a separate update() call.
          */
-        void startPlaying(Timestamp start = 0) throw(Exception);
+        void startPlaying(Timestamp start = 0);
         
         /** Stop a playing source
          * @remarks If the source is playing, stop it. Otherwise, do nothing.
@@ -69,7 +69,7 @@ namespace Audio {
         /** Get the playing position of a playing source 
          * @remarks Will throw if it's not playing!
          */
-        Timestamp getPlayingTime() const throw(Exception);
+        Timestamp getPlayingTime() const;
         
         /** Get the attached source */
         Source* getSource() const throw() { return source; }
@@ -82,7 +82,7 @@ namespace Audio {
          *       Seeking in non-streaming sources may not be supported at all.
          * @throws EndOfStreamException if you try to seek past the end
          */
-        void seek(Timestamp time) throw(Exception);
+        void seek(Timestamp time);
         
         /** Update the underlying API with dirty attributes 
          * @param flags You may specify which attributes to update. Not all attributes are
@@ -105,22 +105,22 @@ namespace Audio {
         /** @see startPlaying 
          * @param start The starting position.
          */
-        virtual void startPlayingImpl(Timestamp start) throw(Exception) = 0;
+        virtual void startPlayingImpl(Timestamp start) = 0;
         
         /** @see stopPlaying.*/
-        virtual void stopPlayingImpl() throw(Exception) = 0;
+        virtual void stopPlayingImpl() = 0;
         
         /** @see isPlaying.*/
-        virtual bool isPlayingImpl() const throw(Exception) = 0;
+        virtual bool isPlayingImpl() const = 0;
         
         /** @see getPlayingTime.*/
-        virtual Timestamp getPlayingTimeImpl() const throw(Exception) = 0;
+        virtual Timestamp getPlayingTimeImpl() const = 0;
         
         /** @see update. */
-        virtual void updateImpl(int flags, const Listener& sceneListener) throw(Exception) = 0;
+        virtual void updateImpl(int flags, const Listener& sceneListener) = 0;
         
         /** @see seek. */
-        virtual void seekImpl(Timestamp time) throw(Exception) = 0;
+        virtual void seekImpl(Timestamp time) = 0;
     };
 
 };

--- a/engine/src/audio/RenderableSource.h
+++ b/engine/src/audio/RenderableSource.h
@@ -38,7 +38,7 @@ namespace Audio {
         
     protected:
         /** Internal constructor used by derived classes */
-        RenderableSource(Source *source) throw();
+        RenderableSource(Source *source);
         
     public:
         virtual ~RenderableSource();
@@ -61,10 +61,10 @@ namespace Audio {
         /** Stop a playing source
          * @remarks If the source is playing, stop it. Otherwise, do nothing.
          */
-        void stopPlaying() throw();
+        void stopPlaying();
         
         /** Is the source still playing? */
-        bool isPlaying() const throw();
+        bool isPlaying() const;
         
         /** Get the playing position of a playing source 
          * @remarks Will throw if it's not playing!
@@ -72,7 +72,7 @@ namespace Audio {
         Timestamp getPlayingTime() const;
         
         /** Get the attached source */
-        Source* getSource() const throw() { return source; }
+        Source* getSource() const { return source; }
         
         /** Seek to the specified position
          * @note It may not be supported by the renderer on all sources.
@@ -95,7 +95,7 @@ namespace Audio {
          *      ignore them (just log them or something like that). Updates are non-critical
          *      and may fail silently.
          */
-        void update(int flags, const Listener& sceneListener) throw();
+        void update(int flags, const Listener& sceneListener);
         
         // The following section contains all the virtual functions that need be implemented
         // by a concrete Sound class. All are protected, so the interface is independent

--- a/engine/src/audio/Renderer.cpp
+++ b/engine/src/audio/Renderer.cpp
@@ -16,49 +16,41 @@ namespace Audio {
     }
     
     void Renderer::setMeterDistance(Scalar distance) 
-        throw()
     {
         meterDistance = distance;
     }
     
     Scalar Renderer::getMeterDistance() const 
-        throw()
     {
         return meterDistance;
     }
     
     void Renderer::setDopplerFactor(Scalar factor) 
-        throw()
     {
         dopplerFactor = factor;
     }
     
     Scalar Renderer::getDopplerFactor() const 
-        throw()
     {
         return dopplerFactor;
     }
     
     void Renderer::setOutputFormat(const Format &format) 
-       
     {
         outputFormat = format;
     }
     
     const Format& Renderer::getOutputFormat() const 
-        throw()
     {
         return outputFormat;
     }
     
     void Renderer::beginTransaction() 
-       
     {
         // intentionally blank
     }
     
     void Renderer::commitTransaction() 
-       
     {
         // intentionally blank
     }

--- a/engine/src/audio/Renderer.cpp
+++ b/engine/src/audio/Renderer.cpp
@@ -7,7 +7,7 @@
 
 namespace Audio {
 
-    Renderer::Renderer() throw(Exception)
+    Renderer::Renderer()
     {
     }
     
@@ -40,7 +40,7 @@ namespace Audio {
     }
     
     void Renderer::setOutputFormat(const Format &format) 
-        throw(Exception)
+       
     {
         outputFormat = format;
     }
@@ -52,13 +52,13 @@ namespace Audio {
     }
     
     void Renderer::beginTransaction() 
-        throw(Exception)
+       
     {
         // intentionally blank
     }
     
     void Renderer::commitTransaction() 
-        throw(Exception)
+       
     {
         // intentionally blank
     }

--- a/engine/src/audio/Renderer.h
+++ b/engine/src/audio/Renderer.h
@@ -44,7 +44,7 @@ namespace Audio {
         /** Initialize the renderer with default or config-driven settings.
          * @remarks End-users might want to use specific constructors of specific renderers.
          */
-        Renderer() throw(Exception);
+        Renderer();
         
         virtual ~Renderer();
         
@@ -64,7 +64,7 @@ namespace Audio {
         virtual SharedPtr<Sound> getSound(
             const std::string &name, 
             VSFileSystem::VSFileType type = VSFileSystem::UnknownFile, 
-            bool streaming = false) throw(Exception) = 0;
+            bool streaming = false) = 0;
         
         /** Return whether the specified sound has been created using this renderer or not */
         virtual bool owns(SharedPtr<Sound> sound) = 0;
@@ -75,7 +75,7 @@ namespace Audio {
          *      @par Attachment may mean resource allocation. Either immediate or deferred. So it may
          *      fail if resources are scarce.
          */
-        virtual void attach(SharedPtr<Source> source) throw(Exception) = 0;
+        virtual void attach(SharedPtr<Source> source) = 0;
         
         /** Attach a listener to this renderer
          * @remarks A listener may only be attached to one renderer. If the listener was attached already,
@@ -83,7 +83,7 @@ namespace Audio {
          *      @par Attachment may mean resource allocation. Either immediate or deferred. So it may
          *      fail if resources are scarce.
          */
-        virtual void attach(SharedPtr<Listener> listener) throw(Exception) = 0;
+        virtual void attach(SharedPtr<Listener> listener) = 0;
         
         /** Detach a source from this renderer.
          * @remarks Immediately frees any allocated resources.
@@ -132,7 +132,7 @@ namespace Audio {
          *          The effective output format, if known, must be reflected in
          *      subsequent calls to getOutputFormat.
          */
-        virtual void setOutputFormat(const Format &format) throw(Exception);
+        virtual void setOutputFormat(const Format &format);
         
         /** Gets the distance in world units that represents one meter.
          * @see setMeterDistance
@@ -146,10 +146,10 @@ namespace Audio {
          *      not to implement it, and perform state changes immediately. In any
          *      case, the result ought to be the same.
          */
-        virtual void beginTransaction() throw(Exception);
+        virtual void beginTransaction();
         
         /** @see begin() */
-        virtual void commitTransaction() throw(Exception);
+        virtual void commitTransaction();
     };
 
 };

--- a/engine/src/audio/Renderer.h
+++ b/engine/src/audio/Renderer.h
@@ -88,12 +88,12 @@ namespace Audio {
         /** Detach a source from this renderer.
          * @remarks Immediately frees any allocated resources.
          */
-        virtual void detach(SharedPtr<Source> source) throw() = 0;
+        virtual void detach(SharedPtr<Source> source) = 0;
         
         /** Detach a listener from this renderer.
          * @remarks Immediately frees any allocated resources.
          */
-        virtual void detach(SharedPtr<Listener> listener) throw() = 0;
+        virtual void detach(SharedPtr<Listener> listener) = 0;
         
         
         
@@ -101,12 +101,12 @@ namespace Audio {
          * @remarks This reference distance is required by environmental effect processing
          *      to accurately account for distance factors beyond simple gain falloff.
          */
-        virtual void setMeterDistance(Scalar distance) throw();
+        virtual void setMeterDistance(Scalar distance);
         
         /** Gets the distance in world units that represents one meter.
          * @see setMeterDistance
          */
-        virtual Scalar getMeterDistance() const throw();
+        virtual Scalar getMeterDistance() const;
         
         
         /** Sets how much the doppler effect will be accounted for.
@@ -116,12 +116,12 @@ namespace Audio {
          *      a disimulated effect, and above 1 an exaggerated effect.
          *          The spec is purposefully vague on the specifics.
          */
-        virtual void setDopplerFactor(Scalar factor) throw();
+        virtual void setDopplerFactor(Scalar factor);
         
         /** Gets how much the doppler effect will be accounted for.
          * @see setDopplerFactor
          */
-        virtual Scalar getDopplerFactor() const throw();
+        virtual Scalar getDopplerFactor() const;
         
         
         
@@ -137,7 +137,7 @@ namespace Audio {
         /** Gets the distance in world units that represents one meter.
          * @see setMeterDistance
          */
-        virtual const Format& getOutputFormat() const throw();
+        virtual const Format& getOutputFormat() const;
         
         /**
          * Begins a transaction

--- a/engine/src/audio/Scene.cpp
+++ b/engine/src/audio/Scene.cpp
@@ -7,7 +7,7 @@
 
 namespace Audio {
 
-    Scene::Scene(const std::string &nam) throw() :
+    Scene::Scene(const std::string &nam) :
         name(nam)
     {
     }

--- a/engine/src/audio/Scene.h
+++ b/engine/src/audio/Scene.h
@@ -43,7 +43,7 @@ namespace Audio {
         /** Attach a source to this scene.
          * @remarks The must be stopped. Adding a playing source is an error.
          */
-        virtual void add(SharedPtr<Source> source) throw(Exception) = 0;
+        virtual void add(SharedPtr<Source> source) = 0;
         
         /** Detach a source from this scene
          * @remarks The source is implicitly stopped.

--- a/engine/src/audio/Scene.h
+++ b/engine/src/audio/Scene.h
@@ -33,12 +33,12 @@ namespace Audio {
     
     protected:
         /** Internal constructor used by derived classes */
-        Scene(const std::string &name) throw();
+        Scene(const std::string &name);
         
     public:
         virtual ~Scene();
         
-        const std::string& getName() const throw() { return name; }
+        const std::string& getName() const { return name; }
         
         /** Attach a source to this scene.
          * @remarks The must be stopped. Adding a playing source is an error.
@@ -48,10 +48,10 @@ namespace Audio {
         /** Detach a source from this scene
          * @remarks The source is implicitly stopped.
          */
-        virtual void remove(SharedPtr<Source> source) throw(NotFoundException) = 0;
+        virtual void remove(SharedPtr<Source> source) = 0;
         
         /** Get the scene's listener */
-        virtual Listener& getListener() throw() = 0;
+        virtual Listener& getListener() = 0;
     };
 
 };

--- a/engine/src/audio/SceneManager.cpp
+++ b/engine/src/audio/SceneManager.cpp
@@ -130,7 +130,7 @@ namespace Audio {
     }
     
     SharedPtr<Source> SceneManager::createSource(SharedPtr<Sound> sound, bool looping) 
-        throw(Exception)
+       
     {
         if (!internalRenderer()->owns(sound))
             throw Exception("Invalid sound: incompatible renderers used");
@@ -139,13 +139,13 @@ namespace Audio {
     }
     
     SharedPtr<Source> SceneManager::createSource(SharedPtr<SourceTemplate> tpl) 
-        throw(Exception)
+       
     {
         return createSource(tpl, tpl->getSoundName());
     }
     
     SharedPtr<Source> SceneManager::createSource(SharedPtr<SourceTemplate> tpl, const std::string &name) 
-        throw(Exception)
+       
     {
         SharedPtr<Source> source = createSource(
             internalRenderer()->getSound(
@@ -250,7 +250,7 @@ namespace Audio {
     }
     
     void SceneManager::setRenderer(SharedPtr<Renderer> renderer) 
-        throw(Exception)
+       
     {
         if (data->renderer.get()) {
             // Detach all active sources
@@ -287,7 +287,7 @@ namespace Audio {
     }
     
     void SceneManager::setMaxSources(unsigned int n) 
-        throw(Exception)
+       
     {
         data->maxSources = n;
     }
@@ -298,7 +298,7 @@ namespace Audio {
             LVector3 position,
             Vector3 direction,
             Vector3 velocity,
-            Scalar radius) throw(Exception)
+            Scalar radius)
     {
         if (tpl->isLooping())
             throw(Exception("Cannot fire a looping source and forget!"));
@@ -322,7 +322,7 @@ namespace Audio {
             LVector3 position,
             Vector3 direction,
             Vector3 velocity,
-            Scalar radius) throw(Exception)
+            Scalar radius)
     {
         if (tpl->isLooping())
             throw(Exception("Cannot fire a looping source and forget!"));
@@ -346,7 +346,7 @@ namespace Audio {
     }
 
     void SceneManager::setMinGain(float gain) 
-        throw(Exception)
+       
     {
         assert(gain >= 0.f);
         data->minGain = gain;
@@ -359,7 +359,7 @@ namespace Audio {
     }
 
     void SceneManager::setMaxDistance(double distance) 
-        throw(Exception)
+       
     {
         assert(distance >= 0.f);
         data->maxDistance = distance;
@@ -389,7 +389,7 @@ namespace Audio {
                 data->activeScenes.end() ) );
     }
     
-    void SceneManager::commit() throw(Exception)
+    void SceneManager::commit()
     {
         Timestamp realTime         = getRealTime();
         bool needActivation        = ((realTime - getActivationFrequency()) >= data->lastActivationTime);
@@ -452,7 +452,7 @@ namespace Audio {
     };
     
     void SceneManager::activationPhaseImpl() 
-        throw(Exception)
+       
     {
         // Just clear the active source set and recreate it from scratch.
         // Use a "source ref heap" to find the most relevant sources (using the approximated
@@ -560,7 +560,7 @@ namespace Audio {
     }
     
     void SceneManager::updateSourcesImpl(bool withAttributes) 
-        throw(Exception)
+       
     {
         // Two-pass stuff.
         
@@ -585,7 +585,7 @@ namespace Audio {
     }
     
     void SceneManager::updateListenerImpl(bool withAttributes)
-        throw(Exception)
+       
     {
         // Update root listener
         RenderableListener::UpdateFlags updateFlags = 
@@ -655,7 +655,7 @@ namespace Audio {
     }
 
     void SceneManager::notifySourcePlaying(SharedPtr<Source> source, SharedPtr<Scene> scene, bool playing) 
-        throw(Exception)
+       
     {
         // If the source is within maxDistance from its scene's listener,
         // schedule an immediate activation phase

--- a/engine/src/audio/SceneManager.cpp
+++ b/engine/src/audio/SceneManager.cpp
@@ -113,7 +113,7 @@ namespace Audio {
     
     using namespace __impl;
 
-    SceneManager::SceneManager() throw() :
+    SceneManager::SceneManager() :
         data(new SceneManagerData)
     {
     }
@@ -130,7 +130,6 @@ namespace Audio {
     }
     
     SharedPtr<Source> SceneManager::createSource(SharedPtr<Sound> sound, bool looping) 
-       
     {
         if (!internalRenderer()->owns(sound))
             throw Exception("Invalid sound: incompatible renderers used");
@@ -139,13 +138,11 @@ namespace Audio {
     }
     
     SharedPtr<Source> SceneManager::createSource(SharedPtr<SourceTemplate> tpl) 
-       
     {
         return createSource(tpl, tpl->getSoundName());
     }
     
     SharedPtr<Source> SceneManager::createSource(SharedPtr<SourceTemplate> tpl, const std::string &name) 
-       
     {
         SharedPtr<Source> source = createSource(
             internalRenderer()->getSound(
@@ -165,7 +162,6 @@ namespace Audio {
     }
     
     void SceneManager::destroySource(SharedPtr<Source> source) 
-        throw()
     {
         // By simply unreferencing, it should get destroyed when all references are released.
         // Which is good for multithreading - never destroy something that is being referenced.
@@ -184,7 +180,6 @@ namespace Audio {
     }
     
     void SceneManager::addScene(SharedPtr<Scene> scene) 
-        throw(DuplicateObjectException)
     {
         if (   data->activeScenes.count(scene->getName()) 
             || data->inactiveScenes.count(scene->getName()) )
@@ -194,7 +189,6 @@ namespace Audio {
     }
     
     SharedPtr<Scene> SceneManager::createScene(const std::string &name) 
-        throw(DuplicateObjectException)
     {
         SharedPtr<Scene> scenePtr(new SimpleScene(name));
         addScene(scenePtr);
@@ -202,7 +196,6 @@ namespace Audio {
     }
     
     SharedPtr<Scene> SceneManager::getScene(const std::string &name) const 
-        throw(NotFoundException)
     {
         SceneManagerData::SceneMap::const_iterator it;
         
@@ -218,7 +211,6 @@ namespace Audio {
     }
     
     void SceneManager::destroyScene(const std::string &name) 
-        throw(NotFoundException)
     {
         // By simply unreferencing, it should get destroyed when all references are released.
         // Which is good for multithreading - never destroy something that is being referenced.
@@ -229,7 +221,6 @@ namespace Audio {
     }
     
     void SceneManager::setSceneActive(const std::string &name, bool active) 
-        throw(NotFoundException)
     {
         // Simply move the pointer from one map to the other.
         // The next update will take care of activating sources as necessary.
@@ -244,13 +235,11 @@ namespace Audio {
     }
     
     bool SceneManager::getSceneActive(const std::string &name) 
-        throw(NotFoundException)
     {
         return data->activeScenes.count(name) > 0;
     }
     
     void SceneManager::setRenderer(SharedPtr<Renderer> renderer) 
-       
     {
         if (data->renderer.get()) {
             // Detach all active sources
@@ -275,19 +264,16 @@ namespace Audio {
     }
     
     SharedPtr<Renderer> SceneManager::getRenderer() const 
-        throw()
     {
         return data->renderer;
     }
     
     unsigned int SceneManager::getMaxSources() const 
-        throw()
     {
         return data->maxSources;
     }
     
     void SceneManager::setMaxSources(unsigned int n) 
-       
     {
         data->maxSources = n;
     }
@@ -340,33 +326,28 @@ namespace Audio {
     }
     
     float SceneManager::getMinGain() const 
-        throw()
     {
         return data->minGain;
     }
 
     void SceneManager::setMinGain(float gain) 
-       
     {
         assert(gain >= 0.f);
         data->minGain = gain;
     }
     
     double SceneManager::getMaxDistance() const 
-        throw()
     {
         return data->maxDistance;
     }
 
     void SceneManager::setMaxDistance(double distance) 
-       
     {
         assert(distance >= 0.f);
         data->maxDistance = distance;
     }
     
     SharedPtr<SceneManager::SceneIterator> SceneManager::getSceneIterator() const
-        throw()
     {
         return SharedPtr<SceneIterator>(
             new ChainingIterator<VirtualValuesIterator<SceneManagerData::SceneMap::iterator> >(
@@ -381,7 +362,6 @@ namespace Audio {
     }
     
     SharedPtr<SceneManager::SceneIterator> SceneManager::getActiveSceneIterator() const
-        throw()
     {
         return SharedPtr<SceneIterator>(
             new VirtualValuesIterator<SceneManagerData::SceneMap::iterator>(
@@ -452,7 +432,6 @@ namespace Audio {
     };
     
     void SceneManager::activationPhaseImpl() 
-       
     {
         // Just clear the active source set and recreate it from scratch.
         // Use a "source ref heap" to find the most relevant sources (using the approximated
@@ -560,7 +539,6 @@ namespace Audio {
     }
     
     void SceneManager::updateSourcesImpl(bool withAttributes) 
-       
     {
         // Two-pass stuff.
         
@@ -585,7 +563,6 @@ namespace Audio {
     }
     
     void SceneManager::updateListenerImpl(bool withAttributes)
-       
     {
         // Update root listener
         RenderableListener::UpdateFlags updateFlags = 
@@ -601,61 +578,51 @@ namespace Audio {
     }
 
     Duration SceneManager::getPositionUpdateFrequency() const
-        throw()
     {
         return data->positionUpdateFrequency;
     }
     
     Duration SceneManager::getListenerUpdateFrequency() const
-        throw()
     {
         return data->listenerUpdateFrequency;
     }
     
     Duration SceneManager::getAttributeUpdateFrequency() const
-        throw()
     {
         return data->attributeUpdateFrequency;
     }
     
     Duration SceneManager::getActivationFrequency() const
-        throw()
     {
         return data->activationFrequency;
     }
     
     void SceneManager::setPositionUpdateFrequency(Duration interval) const
-        throw()
     {
         data->positionUpdateFrequency = interval;
     }
     
     void SceneManager::setListenerUpdateFrequency(Duration interval) const
-        throw()
     {
         data->listenerUpdateFrequency = interval;
     }
     
     void SceneManager::setAttributeUpdateFrequency(Duration interval) const
-        throw()
     {
         data->attributeUpdateFrequency = interval;
     }
     
     void SceneManager::setActivationFrequency(Duration interval) const
-        throw()
     {
         data->activationFrequency = interval;
     }
     
     SharedPtr<Listener> SceneManager::getRootListener() const
-        throw()
     {
         return data->rootListener;
     }
 
     void SceneManager::notifySourcePlaying(SharedPtr<Source> source, SharedPtr<Scene> scene, bool playing) 
-       
     {
         // If the source is within maxDistance from its scene's listener,
         // schedule an immediate activation phase

--- a/engine/src/audio/SceneManager.h
+++ b/engine/src/audio/SceneManager.h
@@ -76,7 +76,7 @@ namespace Audio {
          *      Instead, end-users should use the Root class to find manager plugins they
          *      like.
          */
-        SceneManager() throw();
+        SceneManager();
         
         virtual ~SceneManager();
         
@@ -101,7 +101,7 @@ namespace Audio {
         SharedPtr<Source> createSource(SharedPtr<SourceTemplate> tpl, const std::string &name);
         
         /** Destroy a source created with this manager */
-        virtual void destroySource(SharedPtr<Source> source) throw();
+        virtual void destroySource(SharedPtr<Source> source);
         
         
         
@@ -142,19 +142,19 @@ namespace Audio {
             Scalar radius);
         
         /** Create a new named scene */
-        virtual SharedPtr<Scene> createScene(const std::string &name) throw(DuplicateObjectException);
+        virtual SharedPtr<Scene> createScene(const std::string &name);
         
         /** Get an existing scene by its name */
-        virtual SharedPtr<Scene> getScene(const std::string &name) const throw(NotFoundException);
+        virtual SharedPtr<Scene> getScene(const std::string &name) const;
         
         /** Destroy an existing scene by its name */
-        virtual void destroyScene(const std::string &name) throw(NotFoundException);
+        virtual void destroyScene(const std::string &name);
         
         /** Sets the active state of a scene */
-        virtual void setSceneActive(const std::string &name, bool active) throw(NotFoundException);
+        virtual void setSceneActive(const std::string &name, bool active);
         
         /** Get the active state of a scene */
-        virtual bool getSceneActive(const std::string &name) throw(NotFoundException);
+        virtual bool getSceneActive(const std::string &name);
         
         /** Get the root listener
          * @remarks Renderers can only have one listener. Sources attached to scenes
@@ -168,13 +168,13 @@ namespace Audio {
          *      to the left (what would be required if the listeners of each scene
          *      were rotated, since they're "artificial" listeners).
          */
-        virtual SharedPtr<Listener> getRootListener() const throw();
+        virtual SharedPtr<Listener> getRootListener() const;
         
         /** Get an iterator over all scenes */
-        virtual SharedPtr<SceneIterator> getSceneIterator() const throw();
+        virtual SharedPtr<SceneIterator> getSceneIterator() const;
         
         /** Get an iterator over all active scenes */
-        virtual SharedPtr<SceneIterator> getActiveSceneIterator() const throw();
+        virtual SharedPtr<SceneIterator> getActiveSceneIterator() const;
         
         /** Set a new renderer
          * @param renderer A new renderer to be used.
@@ -188,7 +188,7 @@ namespace Audio {
         virtual void setRenderer(SharedPtr<Renderer> renderer);
         
         /** Get the current renderer */
-        SharedPtr<Renderer> getRenderer() const throw();
+        SharedPtr<Renderer> getRenderer() const;
         
         
         /********* Scene cycle **********/
@@ -210,7 +210,7 @@ namespace Audio {
          *      to be updated). This value specifies how often they're updated, however the
          *      actual interval may vary depending on the implementation (it's a mere guideline).
          */
-        Duration getPositionUpdateFrequency() const throw();
+        Duration getPositionUpdateFrequency() const;
         
         /** Return listener update frequency 
          * @remarks Position updates are a very important kind of update that needs to be
@@ -220,7 +220,7 @@ namespace Audio {
          *      This value specifies how often they're updated, however the
          *      actual interval may vary depending on the implementation (it's a mere guideline).
          */
-        Duration getListenerUpdateFrequency() const throw();
+        Duration getListenerUpdateFrequency() const;
         
         /** Return attribute update frequency 
          * @remarks Source attribute updates are rare but necessary.
@@ -229,7 +229,7 @@ namespace Audio {
          *      This value specifies how often they're updated, however the
          *      actual interval may vary depending on the implementation (it's a mere guideline).
          */
-        Duration getAttributeUpdateFrequency() const throw();
+        Duration getAttributeUpdateFrequency() const;
         
         /** Return source activation frequency 
          * @remarks Sources may become active or inactive over time, and depending on the impementation
@@ -240,19 +240,19 @@ namespace Audio {
          *      activation passes are however necessary (but perhaps not that often) since otherwise
          *      sources that didn't start off as active may never become so.
          */
-        Duration getActivationFrequency() const throw();
+        Duration getActivationFrequency() const;
         
         /** @see getPositionUpdateFrequency */
-        virtual void setPositionUpdateFrequency(Duration interval) const throw();
+        virtual void setPositionUpdateFrequency(Duration interval) const;
         
         /** @see getListenerUpdateFrequency */
-        virtual void setListenerUpdateFrequency(Duration interval) const throw();
+        virtual void setListenerUpdateFrequency(Duration interval) const;
         
         /** @see getAttributeUpdateFrequency */
-        virtual void setAttributeUpdateFrequency(Duration interval) const throw();
+        virtual void setAttributeUpdateFrequency(Duration interval) const;
         
         /** @see getActivationFrequency */
-        virtual void setActivationFrequency(Duration interval) const throw();
+        virtual void setActivationFrequency(Duration interval) const;
         
         
         /********* Culling parameters **********/
@@ -266,7 +266,7 @@ namespace Audio {
          *      to compensate this when setting the "MaxSources" attribute. However,
          *      this compensation may not be perfect.
          */
-        virtual unsigned int getMaxSources() const throw();
+        virtual unsigned int getMaxSources() const;
         
         /** Set the maximum number of simultaneous sources that can be playing at a time
          * @param n The maximum number of simultaneous playing sources desired.
@@ -288,7 +288,7 @@ namespace Audio {
          *      culling rule based on actual gain), and as such may be difficult without aid.
          *      @see For more culling options: get/setMaxDistance
          */
-        virtual float getMinGain() const throw();
+        virtual float getMinGain() const;
     
         /** Set the minimum gain that would be culled off
          * @param gain The new minimum gain.
@@ -302,7 +302,7 @@ namespace Audio {
          *      to conserve resources.
          *      @see For more culling options: get/setMinGain
          */
-        virtual double getMaxDistance() const throw();
+        virtual double getMaxDistance() const;
     
         /** Set the maximum distance of active sources
          * @param distance The new limit.
@@ -318,7 +318,7 @@ namespace Audio {
     
     protected:
         /** Add a new scene @see createScene */
-        void addScene(SharedPtr<Scene> scene) throw(DuplicateObjectException);
+        void addScene(SharedPtr<Scene> scene);
         
         /** Synchronize activation state with the scenes */
         virtual void activationPhaseImpl();

--- a/engine/src/audio/SceneManager.h
+++ b/engine/src/audio/SceneManager.h
@@ -85,12 +85,12 @@ namespace Audio {
          * @note The sound must be associated to the correct renderer, or bad things will happen.
          * @see Renderer, which creates sounds.
          */
-        virtual SharedPtr<Source> createSource(SharedPtr<Sound> sound, bool looping = false) throw(Exception);
+        virtual SharedPtr<Source> createSource(SharedPtr<Sound> sound, bool looping = false);
         
         /** Create a new source based on the specified template
          * @remarks All location information will hold unspecified values, so you have to fill them in.
          */
-        SharedPtr<Source> createSource(SharedPtr<SourceTemplate> tpl) throw(Exception);
+        SharedPtr<Source> createSource(SharedPtr<SourceTemplate> tpl);
         
         /** Create a new source based on the specified template, but overriding its sound resource.
          * @remarks All location information will hold unspecified values, so you have to fill them in.
@@ -98,7 +98,7 @@ namespace Audio {
          *      on many different streams. Eg: a "music" template for spawning music tracks, a "radio"
          *      template for spawning radio voiceovers, etc...
          */
-        SharedPtr<Source> createSource(SharedPtr<SourceTemplate> tpl, const std::string &name) throw(Exception);
+        SharedPtr<Source> createSource(SharedPtr<SourceTemplate> tpl, const std::string &name);
         
         /** Destroy a source created with this manager */
         virtual void destroySource(SharedPtr<Source> source) throw();
@@ -120,7 +120,7 @@ namespace Audio {
             LVector3 position,
             Vector3 direction,
             Vector3 velocity,
-            Scalar radius) throw(Exception);
+            Scalar radius);
         
         /** Convenience API to play a source once and forget. 
          * @param tpl The source template from which a source should be instanced
@@ -139,7 +139,7 @@ namespace Audio {
             LVector3 position,
             Vector3 direction,
             Vector3 velocity,
-            Scalar radius) throw(Exception);
+            Scalar radius);
         
         /** Create a new named scene */
         virtual SharedPtr<Scene> createScene(const std::string &name) throw(DuplicateObjectException);
@@ -185,7 +185,7 @@ namespace Audio {
          * @note Overriding implementations must call the base implementation, since 
          *      getRenderer is not overridable.
          */
-        virtual void setRenderer(SharedPtr<Renderer> renderer) throw(Exception);
+        virtual void setRenderer(SharedPtr<Renderer> renderer);
         
         /** Get the current renderer */
         SharedPtr<Renderer> getRenderer() const throw();
@@ -202,7 +202,7 @@ namespace Audio {
          *      a requirement.
          *      @par The process may be lengthy and throw various exceptions.
          */
-        virtual void commit() throw(Exception);
+        virtual void commit();
         
         /** Return position update frequency 
          * @remarks Source position updates are a very important kind of update that needs to be
@@ -275,7 +275,7 @@ namespace Audio {
          *      is too high, the closest possible one will be set instead).
          * @see getMaxSources
          */
-        virtual void setMaxSources(unsigned int n) throw(Exception);
+        virtual void setMaxSources(unsigned int n);
         
         /** Get the minimum gain that would be culled off
          * @remarks This value specifies the minimum gain of active sources. If a source
@@ -294,7 +294,7 @@ namespace Audio {
          * @param gain The new minimum gain.
          * @see getMinGain
          */
-        virtual void setMinGain(float gain) throw(Exception);
+        virtual void setMinGain(float gain);
         
         /** Get the maximum distance of active sources
          * @remarks This value specifies the maximum distance of active sources. If a source
@@ -308,29 +308,29 @@ namespace Audio {
          * @param distance The new limit.
          * @see getMaxDistance
          */
-        virtual void setMaxDistance(double distance) throw(Exception);
+        virtual void setMaxDistance(double distance);
         
         
         /*********** Notification events ************/
         
         /** Notify the scene manager of a source that starts or stops playing. */
-        virtual void notifySourcePlaying(SharedPtr<Source> source, SharedPtr<Scene> scene, bool playing) throw(Exception);
+        virtual void notifySourcePlaying(SharedPtr<Source> source, SharedPtr<Scene> scene, bool playing);
     
     protected:
         /** Add a new scene @see createScene */
         void addScene(SharedPtr<Scene> scene) throw(DuplicateObjectException);
         
         /** Synchronize activation state with the scenes */
-        virtual void activationPhaseImpl() throw(Exception);
+        virtual void activationPhaseImpl();
         
         /** Synchronize source positions/attributes with the renderer */
-        virtual void updateSourcesImpl(bool withAttributes) throw(Exception);
+        virtual void updateSourcesImpl(bool withAttributes);
         
         /** Synchronize listeners
          * @remarks Since renderer implementations require one listener, this only updates
          *      the root listener. Scene listeners fall under the category of position updates.
          */
-        virtual void updateListenerImpl(bool withAttributes) throw(Exception);
+        virtual void updateListenerImpl(bool withAttributes);
     };
 
 };

--- a/engine/src/audio/SimpleScene.cpp
+++ b/engine/src/audio/SimpleScene.cpp
@@ -26,7 +26,7 @@ namespace Audio {
     }
 
     void SimpleScene::add(SharedPtr<Source> source) 
-        throw(Exception)
+       
     {
         attach(dynamic_cast<SimpleSource*>(source.get()));
     }
@@ -44,7 +44,7 @@ namespace Audio {
     }
     
     void SimpleScene::notifySourcePlaying(SharedPtr<Source> source, bool playing) 
-        throw(Exception)
+       
     {
         if (playing) 
             activeSources.insert(source);

--- a/engine/src/audio/SimpleScene.cpp
+++ b/engine/src/audio/SimpleScene.cpp
@@ -10,7 +10,7 @@
 
 namespace Audio {
 
-    SimpleScene::SimpleScene(const std::string &name) throw() :
+    SimpleScene::SimpleScene(const std::string &name) :
         Scene(name)
     {
     }
@@ -26,25 +26,21 @@ namespace Audio {
     }
 
     void SimpleScene::add(SharedPtr<Source> source) 
-       
     {
         attach(dynamic_cast<SimpleSource*>(source.get()));
     }
     
     void SimpleScene::remove(SharedPtr<Source> source) 
-        throw(NotFoundException)
     {
         detach(dynamic_cast<SimpleSource*>(source.get()));
     }
     
     Listener& SimpleScene::getListener() 
-        throw()
     {
         return listener;
     }
     
     void SimpleScene::notifySourcePlaying(SharedPtr<Source> source, bool playing) 
-       
     {
         if (playing) 
             activeSources.insert(source);
@@ -55,27 +51,23 @@ namespace Audio {
     }
     
     void SimpleScene::attach(SimpleSource *source) 
-        throw()
     {
         source->notifySceneAttached(this);
     }
     
     void SimpleScene::detach(SimpleSource *source) 
-        throw()
     {
         source->notifySceneAttached(0);
     }
     
     /** Gets an iterator over active sources */ 
     SimpleScene::SourceIterator SimpleScene::getActiveSources() 
-        throw()
     {
         return activeSources.begin();
     }
     
     /** Gets the ending iterator of active sources */
     SimpleScene::SourceIterator SimpleScene::getActiveSourcesEnd() 
-        throw()
     {
         return activeSources.end();
     }

--- a/engine/src/audio/SimpleScene.h
+++ b/engine/src/audio/SimpleScene.h
@@ -42,7 +42,7 @@ namespace Audio {
         //
     
         /** Construct a new, empty scene */
-        SimpleScene(const std::string &name) throw();
+        SimpleScene(const std::string &name);
         
         virtual ~SimpleScene();
         
@@ -54,10 +54,10 @@ namespace Audio {
         /** @copydoc Scene::remove 
          * @remarks source MUST be a SimpleSource
          */
-        virtual void remove(SharedPtr<Source> source) throw(NotFoundException);
+        virtual void remove(SharedPtr<Source> source);
         
         /** @copydoc Scene::getListener */
-        virtual Listener& getListener() throw();
+        virtual Listener& getListener();
         
         
         //
@@ -68,14 +68,14 @@ namespace Audio {
         virtual void notifySourcePlaying(SharedPtr<Source> source, bool playing);
         
         /** Gets an iterator over active sources */ 
-        SourceIterator getActiveSources() throw();
+        SourceIterator getActiveSources();
         
         /** Gets the ending iterator of active sources */
-        SourceIterator getActiveSourcesEnd() throw();
+        SourceIterator getActiveSourcesEnd();
         
     protected:
-        void attach(SimpleSource *source) throw();
-        void detach(SimpleSource *source) throw();
+        void attach(SimpleSource *source);
+        void detach(SimpleSource *source);
     };
 
 };

--- a/engine/src/audio/SimpleScene.h
+++ b/engine/src/audio/SimpleScene.h
@@ -49,7 +49,7 @@ namespace Audio {
         /** @copydoc Scene::add 
          * @remarks source MUST be a SimpleSource
          */
-        virtual void add(SharedPtr<Source> source) throw(Exception);
+        virtual void add(SharedPtr<Source> source);
         
         /** @copydoc Scene::remove 
          * @remarks source MUST be a SimpleSource
@@ -65,7 +65,7 @@ namespace Audio {
         //
         
         /** Notify the scene of a source that starts or stops playing. */
-        virtual void notifySourcePlaying(SharedPtr<Source> source, bool playing) throw(Exception);
+        virtual void notifySourcePlaying(SharedPtr<Source> source, bool playing);
         
         /** Gets an iterator over active sources */ 
         SourceIterator getActiveSources() throw();

--- a/engine/src/audio/SimpleSound.cpp
+++ b/engine/src/audio/SimpleSound.cpp
@@ -22,7 +22,7 @@ namespace Audio {
     }
 
     void SimpleSound::loadStream() 
-        throw(Exception)
+       
     {
         if (isStreamLoaded())
             throw(ResourceAlreadyLoadedException());
@@ -56,7 +56,7 @@ namespace Audio {
     }
     
     void SimpleSound::readBuffer(SoundBuffer &buffer) 
-        throw(Exception)
+       
     {
         if (buffer.getFormat() == getFormat()) {
             // Same formats, so all we have to do is read bytes ;)

--- a/engine/src/audio/SimpleSound.cpp
+++ b/engine/src/audio/SimpleSound.cpp
@@ -11,7 +11,6 @@
 namespace Audio {
 
     SimpleSound::SimpleSound(const std::string& name, VSFileSystem::VSFileType _type, bool streaming) 
-        throw()
         : Sound(name, streaming),
           type(_type)
     {
@@ -22,7 +21,6 @@ namespace Audio {
     }
 
     void SimpleSound::loadStream() 
-       
     {
         if (isStreamLoaded())
             throw(ResourceAlreadyLoadedException());
@@ -40,7 +38,6 @@ namespace Audio {
     }
     
     void SimpleSound::closeStream() 
-        throw(ResourceNotLoadedException)
     {
         if (!isStreamLoaded())
             throw(ResourceNotLoadedException());
@@ -48,7 +45,6 @@ namespace Audio {
     }
     
     SharedPtr<Stream> SimpleSound::getStream() const 
-        throw(ResourceNotLoadedException)
     {
         if (!isStreamLoaded())
             throw(ResourceNotLoadedException());
@@ -56,7 +52,6 @@ namespace Audio {
     }
     
     void SimpleSound::readBuffer(SoundBuffer &buffer) 
-       
     {
         if (buffer.getFormat() == getFormat()) {
             // Same formats, so all we have to do is read bytes ;)
@@ -81,7 +76,6 @@ namespace Audio {
     }
     
     void SimpleSound::abortLoad()
-        throw()
     {
         // Intentionally blank
     }

--- a/engine/src/audio/SimpleSound.h
+++ b/engine/src/audio/SimpleSound.h
@@ -40,7 +40,7 @@ namespace Audio {
         
     protected:
         /** Internal constructor used by derived classes */
-        SimpleSound(const std::string& name, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile, bool streaming = false) throw();
+        SimpleSound(const std::string& name, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile, bool streaming = false);
         
     public:
         virtual ~SimpleSound();
@@ -66,13 +66,13 @@ namespace Audio {
          * @remarks Calling this when isStreamLoaded() returns false will raise an
          *      ResourceNotLoadedException.
          */
-        void closeStream() throw(ResourceNotLoadedException);
+        void closeStream();
         
         /** Get a pointer to the stream
          * @remarks Calling this when isStreamLoaded() returns false will raise an
          *      ResourceNotLoadedException.
          */
-        SharedPtr<Stream> getStream() const throw(ResourceNotLoadedException);
+        SharedPtr<Stream> getStream() const;
         
         /** Read from the stream into the buffer 
          * @remarks Will throw EndOfStreamException when the end of the stream
@@ -84,7 +84,7 @@ namespace Audio {
         // functions provided by SimpleSound.
     protected:
         /** @copydoc Sound::abortLoad */
-        virtual void abortLoad() throw();
+        virtual void abortLoad();
 
     };
 

--- a/engine/src/audio/SimpleSound.h
+++ b/engine/src/audio/SimpleSound.h
@@ -60,7 +60,7 @@ namespace Audio {
          * @remarks Calling this when the stream has already been initialized will
          *      raise an ReasourceAlreadyLoadedException.
          */
-        void loadStream() throw(Exception);
+        void loadStream();
         
         /** Uninitialize the stream
          * @remarks Calling this when isStreamLoaded() returns false will raise an
@@ -78,7 +78,7 @@ namespace Audio {
          * @remarks Will throw EndOfStreamException when the end of the stream
          *      is reached. Any other exception is probably fatal.
          */
-        void readBuffer(SoundBuffer &buffer) throw(Exception);
+        void readBuffer(SoundBuffer &buffer);
         
         // The following section contains basic Sound interface implementation 
         // functions provided by SimpleSound.

--- a/engine/src/audio/SimpleSource.cpp
+++ b/engine/src/audio/SimpleSource.cpp
@@ -28,7 +28,7 @@ namespace Audio {
         return scene;
     }
     
-    void SimpleSource::startPlayingImpl(Timestamp start) throw(Exception)
+    void SimpleSource::startPlayingImpl(Timestamp start)
     {
         // If it's playing, must stop and restart - cannot simply play again.
         if (isPlaying())
@@ -41,7 +41,7 @@ namespace Audio {
             getScene()->notifySourcePlaying(shared_from_this(), true);
     }
     
-    void SimpleSource::stopPlayingImpl() throw(Exception)
+    void SimpleSource::stopPlayingImpl()
     {
         if (isPlaying()) {
             playing = false;
@@ -51,7 +51,7 @@ namespace Audio {
         }
     }
     
-    bool SimpleSource::isPlayingImpl() const throw(Exception)
+    bool SimpleSource::isPlayingImpl() const
     {
         return playing;
     }

--- a/engine/src/audio/SimpleSource.cpp
+++ b/engine/src/audio/SimpleSource.cpp
@@ -11,19 +11,19 @@ namespace Audio {
     {
     }
 
-    SimpleSource::SimpleSource(SharedPtr<Sound> sound, bool looping) throw() :
+    SimpleSource::SimpleSource(SharedPtr<Sound> sound, bool looping) :
         Source(sound, looping),
         playing(false),
         scene(0)
     {
     }
     
-    void SimpleSource::notifySceneAttached(SimpleScene *scn) throw()
+    void SimpleSource::notifySceneAttached(SimpleScene *scn)
     {
         scene = scn;
     }
     
-    SimpleScene* SimpleSource::getScene() const throw()
+    SimpleScene* SimpleSource::getScene() const
     {
         return scene;
     }

--- a/engine/src/audio/SimpleSource.h
+++ b/engine/src/audio/SimpleSource.h
@@ -47,13 +47,13 @@ namespace Audio {
     protected:
         
         /** @copydoc Source::startPlayingImpl */
-        virtual void startPlayingImpl(Timestamp start) throw(Exception);
+        virtual void startPlayingImpl(Timestamp start);
         
         /** @copydoc Source::stopPlayingImpl */
-        virtual void stopPlayingImpl() throw(Exception);
+        virtual void stopPlayingImpl();
         
         /** @copydoc Source::isPlayingImpl*/
-        virtual bool isPlayingImpl() const throw(Exception);
+        virtual bool isPlayingImpl() const;
     };
 
 };

--- a/engine/src/audio/SimpleSource.h
+++ b/engine/src/audio/SimpleSource.h
@@ -33,13 +33,13 @@ namespace Audio {
         virtual ~SimpleSource();
     
         /** Construct a simple source */
-        SimpleSource(SharedPtr<Sound> sound, bool looping = false) throw();
+        SimpleSource(SharedPtr<Sound> sound, bool looping = false);
         
         /** Notify attachment to a scene */
-        void notifySceneAttached(SimpleScene *scene) throw();
+        void notifySceneAttached(SimpleScene *scene);
         
         /** Get the scene to which it is attached */
-        SimpleScene* getScene() const throw();
+        SimpleScene* getScene() const;
         
         // The following section contains all the virtual functions that need be implemented
         // by a concrete Sound class. All are protected, so the stream interface is independent

--- a/engine/src/audio/Sound.cpp
+++ b/engine/src/audio/Sound.cpp
@@ -22,7 +22,7 @@ namespace Audio {
         unload();
     }
 
-    void Sound::load(bool wait) throw(Exception)
+    void Sound::load(bool wait)
     {
         if (!isLoaded()) {
             if (!isLoading())
@@ -33,7 +33,7 @@ namespace Audio {
     }
     
     void Sound::waitLoad() 
-        throw(Exception)
+       
     {
         while (isLoading())
             Audio::sleep(10);

--- a/engine/src/audio/Sound.cpp
+++ b/engine/src/audio/Sound.cpp
@@ -9,7 +9,7 @@
 
 namespace Audio {
 
-    Sound::Sound(const std::string& _name, bool streaming) throw() :
+    Sound::Sound(const std::string& _name, bool streaming) :
         name(_name)
     {
         flags.loaded = false;
@@ -33,14 +33,12 @@ namespace Audio {
     }
     
     void Sound::waitLoad() 
-       
     {
         while (isLoading())
             Audio::sleep(10);
     }
     
     void Sound::unload() 
-        throw()
     {
         if (isLoading()) {
             abortLoad();
@@ -54,14 +52,12 @@ namespace Audio {
     }
 
     void Sound::onLoaded(bool success) 
-        throw()
     {
         flags.loaded = success;
         flags.loading = false;
     }
     
     void Sound::abortLoad() 
-        throw()
     {
         // Do nothing, there's no background load
     }

--- a/engine/src/audio/Sound.h
+++ b/engine/src/audio/Sound.h
@@ -83,7 +83,7 @@ namespace Audio {
          *      unloaded (memory short), or an error ocurred during load and it never
          *      became loaded.
          */
-        void load(bool wait = true) throw(Exception);
+        void load(bool wait = true);
         
         /** Unload the resource if loaded */
         void unload() throw();
@@ -106,12 +106,12 @@ namespace Audio {
          *      Implementations are likely to have better ways to do this, so they're
          *      welcome to override this method.
          */
-        virtual void waitLoad() throw(Exception);
+        virtual void waitLoad();
         
         /** Load the resource
          * @note Assume it is unloaded and not loading
          */
-        virtual void loadImpl(bool wait) throw(Exception) = 0;
+        virtual void loadImpl(bool wait) = 0;
         
         /** Abort an in-progress background load procedure
          * @note Although no exceptions should be risen, the abort request may

--- a/engine/src/audio/Sound.h
+++ b/engine/src/audio/Sound.h
@@ -46,29 +46,29 @@ namespace Audio {
         
     protected:
         /** Internal constructor used by derived classes */
-        Sound(const std::string& name, bool streaming) throw();
+        Sound(const std::string& name, bool streaming);
         
         /** Protected Write access to the sound's format, for implementations. */
-        Format& getFormat() throw() { return format; };
+        Format& getFormat() { return format; };
         
         
     public:
         virtual ~Sound();
         
         /** Return the path of the associated file. */
-        const std::string& getName() const throw() { return name; };
+        const std::string& getName() const { return name; };
         
         /** Return the format of the sound resource. */
-        const Format& getFormat() const throw() { return format; };
+        const Format& getFormat() const { return format; };
         
         /** Return whether the resource has been loaded or not */
-        bool isLoaded() const throw() { return flags.loaded; }
+        bool isLoaded() const { return flags.loaded; }
         
         /** Return whether the resource is being loaded in the background */
-        bool isLoading() const throw() { return flags.loading; }
+        bool isLoading() const { return flags.loading; }
         
         /** Return whether the resource is being loaded in the background */
-        bool isStreaming() const throw() { return flags.streaming; }
+        bool isStreaming() const { return flags.streaming; }
         
         /** Load the resource if not loaded 
          * @param wait If true, the function will return only when the resource
@@ -86,7 +86,7 @@ namespace Audio {
         void load(bool wait = true);
         
         /** Unload the resource if loaded */
-        void unload() throw();
+        void unload();
         
         // The following section contains all the virtual functions that need be implemented
         // by a concrete Sound class. All are protected, so the stream interface is independent
@@ -99,7 +99,7 @@ namespace Audio {
          *      The method guaranteed to be threadsafe.
          * @param success Whether or not the process succeeded in loading the resource
          */
-        virtual void onLoaded(bool success) throw();
+        virtual void onLoaded(bool success);
         
         /** Wait for background loading to finish
          * @remarks The base implementation checks for completion periodically.
@@ -118,13 +118,13 @@ namespace Audio {
          *      not be carried out for various reasons. The caller should check
          *      that on return by calling isLoaded() / isLoading().
          */
-        virtual void abortLoad() throw() = 0;
+        virtual void abortLoad() = 0;
         
         
         /** Unload the resource.
          * @note Assume it is loaded
          */
-        virtual void unloadImpl() throw() = 0;
+        virtual void unloadImpl() = 0;
         
     };
 

--- a/engine/src/audio/SoundBuffer.cpp
+++ b/engine/src/audio/SoundBuffer.cpp
@@ -71,7 +71,7 @@ namespace Audio {
     }
     
     void SoundBuffer::reformat(const Format &newFormat) 
-        throw(Exception)
+       
     {
         if (newFormat != format)
             throw(NotImplementedException("Format conversion"));

--- a/engine/src/audio/SoundBuffer.cpp
+++ b/engine/src/audio/SoundBuffer.cpp
@@ -12,7 +12,6 @@
 namespace Audio {
 
     SoundBuffer::SoundBuffer() 
-        throw()
         : buffer(0),
           byteCapacity(0),
           bytesUsed(0)
@@ -20,7 +19,6 @@ namespace Audio {
     }
     
     SoundBuffer::SoundBuffer(unsigned int capacity, const Format &format) 
-        throw(OutOfMemoryException)
         : buffer(0),
           byteCapacity(0),
           bytesUsed(0)
@@ -29,7 +27,6 @@ namespace Audio {
     }
     
     SoundBuffer::SoundBuffer(const SoundBuffer &other)
-        throw(OutOfMemoryException)
     {
         bytesUsed = byteCapacity = other.bytesUsed;
         buffer = malloc(byteCapacity);
@@ -40,7 +37,6 @@ namespace Audio {
     }
     
     SoundBuffer& SoundBuffer::operator=(const SoundBuffer &other) 
-        throw(OutOfMemoryException)
     {
         bytesUsed = byteCapacity = other.bytesUsed;
         buffer = realloc(buffer, byteCapacity);
@@ -53,7 +49,6 @@ namespace Audio {
     }
     
     void SoundBuffer::reserve(unsigned int capacity)
-        throw(OutOfMemoryException)
     {
         byteCapacity = capacity;
         bytesUsed = 0;
@@ -64,21 +59,18 @@ namespace Audio {
     }
     
     void SoundBuffer::reserve(unsigned int capacity, const Format &_format)
-        throw(OutOfMemoryException)
     {
         format = _format;
         reserve(capacity * _format.frameSize());
     }
     
     void SoundBuffer::reformat(const Format &newFormat) 
-       
     {
         if (newFormat != format)
             throw(NotImplementedException("Format conversion"));
     }
     
     void SoundBuffer::swap(SoundBuffer &other) 
-        throw()
     {
         std::swap(buffer, other.buffer);
         std::swap(byteCapacity, other.byteCapacity);
@@ -87,7 +79,6 @@ namespace Audio {
     }
 
     void SoundBuffer::optimize() 
-        throw()
     {
         if (bytesUsed == 0) {
             if (buffer) {

--- a/engine/src/audio/SoundBuffer.h
+++ b/engine/src/audio/SoundBuffer.h
@@ -34,57 +34,57 @@ namespace Audio {
         
     public:
         /** Create an empty buffer (zero capacity, default format) */
-        SoundBuffer() throw();
+        SoundBuffer();
         
         /** Create a buffer of specified sample capacity and format */
-        SoundBuffer(unsigned int capacity, const Format &format) throw(OutOfMemoryException);
+        SoundBuffer(unsigned int capacity, const Format &format);
         
         /** Create a copy of the other buffer
          * @remarks Only used bytes will be copied. 
          */
-        SoundBuffer(const SoundBuffer &other) throw(OutOfMemoryException);
+        SoundBuffer(const SoundBuffer &other);
         
         /** Set a buffer's capacity.
          * @param capacity The buffer's capacity in bytes
          * @remarks Destroys the current data in the buffer.
          */
-        void reserve(unsigned int capacity) throw(OutOfMemoryException);
+        void reserve(unsigned int capacity);
         
         /** Set a buffer's capacity and format.
          * @param capacity The buffer's capacity in samples (or frames) for 'format'
          * @param format The new format associated to the buffer
          * @remarks Destroys the current data in the buffer.
          */
-        void reserve(unsigned int capacity, const Format &format) throw(OutOfMemoryException);
+        void reserve(unsigned int capacity, const Format &format);
         
         /** Get a buffer's byte capacity */
-        unsigned int getByteCapacity() const throw() { return byteCapacity; }
+        unsigned int getByteCapacity() const { return byteCapacity; }
         
         /** Get a buffer's sample capacity 
          * @remarks Frame capacity actually, which is not the same for multichannel formats. 
          */
-        unsigned int getSampleCapacity() const throw() { return byteCapacity / format.frameSize(); }
+        unsigned int getSampleCapacity() const { return byteCapacity / format.frameSize(); }
         
         /** Get the portion of the buffer actually used for holding useful data */
-        unsigned int getUsedBytes() const throw()  { return bytesUsed; }
+        unsigned int getUsedBytes() const  { return bytesUsed; }
         
         /** Get write access to the buffer */
-        void* getBuffer() throw() { return buffer; }
+        void* getBuffer() { return buffer; }
         
         /** Get read access to the buffer */
-        const void* getBuffer() const throw() { return buffer; }
+        const void* getBuffer() const { return buffer; }
         
         /** Get the buffer's format */
         const Format& getFormat() const { return format; }
         
         /** Set the format of the stream mantaining the capacity yet destroying all current data */
-        void setFormat(const Format &newFormat) throw() { format = newFormat; bytesUsed = 0; }
+        void setFormat(const Format &newFormat) { format = newFormat; bytesUsed = 0; }
         
         /** Set the portion of the buffer actually used for holding useful data */
-        void setUsedBytes(unsigned int used) throw() { bytesUsed = used; }
+        void setUsedBytes(unsigned int used) { bytesUsed = used; }
         
         /** Get a buffer's sample capacity for a certain format */
-        unsigned int getSampleCount() const throw() { return bytesUsed / format.frameSize(); }
+        unsigned int getSampleCount() const { return bytesUsed / format.frameSize(); }
         
         /** Reformat the samples in the buffer without reallocating if possible (inplace) 
          * @remarks If the new format requires more bytes than the buffer's byte capacity,
@@ -97,15 +97,15 @@ namespace Audio {
         void reformat(const Format &newFormat);
         
         /** Copy the given buffer as if SoundBuffer(buffer) was called */
-        SoundBuffer& operator=(const SoundBuffer &other) throw(OutOfMemoryException);
+        SoundBuffer& operator=(const SoundBuffer &other);
         
         /** Swap buffer contents and format 
          * It's an inherently quick operation, since it only swaps pointers and descriptors.
          */
-        void swap(SoundBuffer &other) throw();
+        void swap(SoundBuffer &other);
         
         /** Free extra memory allocated */
-        void optimize() throw();
+        void optimize();
         void clear();
     };
 

--- a/engine/src/audio/SoundBuffer.h
+++ b/engine/src/audio/SoundBuffer.h
@@ -94,7 +94,7 @@ namespace Audio {
          *      requires less bytes only the used bytes count will be modified leaving
          *      the same byte capacity.
          */
-        void reformat(const Format &newFormat) throw(Exception);
+        void reformat(const Format &newFormat);
         
         /** Copy the given buffer as if SoundBuffer(buffer) was called */
         SoundBuffer& operator=(const SoundBuffer &other) throw(OutOfMemoryException);

--- a/engine/src/audio/Source.cpp
+++ b/engine/src/audio/Source.cpp
@@ -48,7 +48,7 @@ namespace Audio {
         return timestamp;
     }
 
-    void Source::startPlaying(Timestamp start) throw(Exception)
+    void Source::startPlaying(Timestamp start)
     {
         dirty.setAll();
         startPlayingImpl( setLastKnownPlayingTime(start) );
@@ -80,7 +80,7 @@ namespace Audio {
         }
     }
     
-    void Source::continuePlaying() throw(Exception)
+    void Source::continuePlaying()
     {
         if (rendererDataPtr.get() && isPlaying() && !isActive()) {
             // Must notify the listener, if any
@@ -207,7 +207,7 @@ namespace Audio {
     }
     
     void Source::seek(Timestamp time) 
-        throw(Exception)
+       
     {
         if (rendererDataPtr.get() && isPlaying() && isActive()) {
             rendererDataPtr->seek(time);

--- a/engine/src/audio/Source.cpp
+++ b/engine/src/audio/Source.cpp
@@ -11,7 +11,7 @@
 
 namespace Audio {
 
-    Source::Source(SharedPtr<Sound> sound, bool _looping) throw() :
+    Source::Source(SharedPtr<Sound> sound, bool _looping) :
         soundPtr(sound),
         
         // Some safe defaults
@@ -41,7 +41,7 @@ namespace Audio {
     {
     }
 
-    Timestamp Source::setLastKnownPlayingTime(Timestamp timestamp) throw()
+    Timestamp Source::setLastKnownPlayingTime(Timestamp timestamp)
     {
         lastKnownPlayingTime = timestamp;
         lastKnownPlayingTimeTime = getRealTime();
@@ -54,14 +54,14 @@ namespace Audio {
         startPlayingImpl( setLastKnownPlayingTime(start) );
     }
     
-    void Source::stopPlaying() throw()
+    void Source::stopPlaying()
     {
         // Pause first to stop the renderable
         pausePlaying();
         stopPlayingImpl();
     }
     
-    void Source::pausePlaying() throw()
+    void Source::pausePlaying()
     {
         if (rendererDataPtr.get() && isActive()) {
             try {
@@ -96,7 +96,7 @@ namespace Audio {
         }
     }
     
-    Timestamp Source::getPlayingTime() const throw()
+    Timestamp Source::getPlayingTime() const
     {
         try {
             if (rendererDataPtr.get() && isActive())
@@ -108,7 +108,7 @@ namespace Audio {
         }
     }
 
-    Timestamp Source::getWouldbePlayingTime() const throw()
+    Timestamp Source::getWouldbePlayingTime() const
     {
         try {
             if (rendererDataPtr.get() && isActive())
@@ -117,7 +117,7 @@ namespace Audio {
         return lastKnownPlayingTime + getRealTime() - lastKnownPlayingTimeTime;
     }
 
-    bool Source::isPlaying() const throw()
+    bool Source::isPlaying() const
     {
         try {
             return isPlayingImpl();
@@ -126,7 +126,7 @@ namespace Audio {
         }
     }
 
-    bool Source::isActive() const throw()
+    bool Source::isActive() const
     {
         try {
             return rendererDataPtr.get() && rendererDataPtr->isPlaying();
@@ -135,13 +135,13 @@ namespace Audio {
         }
     }
 
-    Range<Scalar> Source::getAngleRange() const throw() 
+    Range<Scalar> Source::getAngleRange() const
     { 
         return Range<Scalar>(Scalar(acos(cosAngleRange.min)), 
                              Scalar(acos(cosAngleRange.max))); 
     }
     
-    void Source::setAngleRange(Range<Scalar> r) throw() 
+    void Source::setAngleRange(Range<Scalar> r)
     { 
         cosAngleRange.min = Scalar(cos(r.min)); 
         cosAngleRange.max = Scalar(cos(r.max));
@@ -149,7 +149,6 @@ namespace Audio {
     }
     
     void Source::updateRenderable(int flags, const Listener& sceneListener) 
-        throw()
     {
         if (rendererDataPtr.get()) {
             int oflags = flags;
@@ -193,7 +192,6 @@ namespace Audio {
     }
     
     void Source::setRenderable(SharedPtr<RenderableSource> ptr) 
-        throw() 
     { 
         // Notify at/detachment to listener, if any
         if (sourceListenerPtr.get() != 0 && sourceListenerPtr->wantAttachEvents())
@@ -207,7 +205,6 @@ namespace Audio {
     }
     
     void Source::seek(Timestamp time) 
-       
     {
         if (rendererDataPtr.get() && isPlaying() && isActive()) {
             rendererDataPtr->seek(time);

--- a/engine/src/audio/Source.h
+++ b/engine/src/audio/Source.h
@@ -201,7 +201,7 @@ namespace Audio {
          * @remarks Rewind and play from the beginning. If the source is playing, it is reset.
          *      May not take effect immediately.
          */
-        void startPlaying(Timestamp start = 0) throw(Exception);
+        void startPlaying(Timestamp start = 0);
         
         /** Stop a playing source
          * @remarks If the source is playing, stop it. Otherwise, do nothing.
@@ -223,7 +223,7 @@ namespace Audio {
          * @remarks If the source is playing but inactive, continue playing. Otherwise, do nothing.
          * @see pausePlaying
          */
-        void continuePlaying() throw(Exception);
+        void continuePlaying();
         
         /** Is the source still playing? */
         bool isPlaying() const throw();
@@ -283,7 +283,7 @@ namespace Audio {
          *       Seeking in non-streaming sources may not be supported at all.
          * @throws EndOfStreamException if you try to seek past the end
          */
-        void seek(Timestamp time) throw(Exception);
+        void seek(Timestamp time);
         
     protected:
         /** Set the last known playing time, update the measurement timestamp as well.
@@ -299,13 +299,13 @@ namespace Audio {
         /** @see startPlaying 
          * @param start The starting position.
          */
-        virtual void startPlayingImpl(Timestamp start) throw(Exception) = 0;
+        virtual void startPlayingImpl(Timestamp start) = 0;
         
         /** @see stopPlaying.*/
-        virtual void stopPlayingImpl() throw(Exception) = 0;
+        virtual void stopPlayingImpl() = 0;
         
         /** @see isPlaying.*/
-        virtual bool isPlayingImpl() const throw(Exception) = 0;
+        virtual bool isPlayingImpl() const = 0;
     
         // The following section contains package-private stuff
         // They're intended for plugin developers, and not end users

--- a/engine/src/audio/Source.h
+++ b/engine/src/audio/Source.h
@@ -104,50 +104,50 @@ namespace Audio {
         
     protected:
         /** Internal constructor used by derived classes */
-        Source(SharedPtr<Sound> sound, bool looping = false) throw();
+        Source(SharedPtr<Sound> sound, bool looping = false);
         
     public:
         virtual ~Source();
         
         /** Return the source's central position in 3D space */
-        LVector3 getPosition() const throw() { return position; }
+        LVector3 getPosition() const { return position; }
         
         /** Set the source's central position in 3D space */
-        void setPosition(LVector3 x) throw() { position = x; dirty.location = 1; }
+        void setPosition(LVector3 x) { position = x; dirty.location = 1; }
         
         /** Return the source's main propagation direction */
-        Vector3 getDirection() const throw() { return direction; }
+        Vector3 getDirection() const { return direction; }
         
         /** Set the source's main propagation direction */
-        void setDirection(Vector3 x) throw() { direction = x; dirty.location = 1; }
+        void setDirection(Vector3 x) { direction = x; dirty.location = 1; }
         
         /** Return the source's velocity */
-        Vector3 getVelocity() const throw() { return velocity; }
+        Vector3 getVelocity() const { return velocity; }
         
         /** Set the source's velocity */
-        void setVelocity(Vector3 x) throw() { velocity = x; dirty.location = 1; }
+        void setVelocity(Vector3 x) { velocity = x; dirty.location = 1; }
         
         /** Return the source's minimum/maximum propagation angle
          * @remarks Sound will fully propagate in directions within minimum
          *      directional drift. Further drift will attenuate the sound
          *      until it (practically) disappears by the maximum propagation angle.
          */
-        Range<Scalar> getAngleRange() const throw();
+        Range<Scalar> getAngleRange() const;
         
         /** @see getAngleRange */
-        void setAngleRange(Range<Scalar> r) throw();
+        void setAngleRange(Range<Scalar> r);
         
         /** @see getAngleRange @remarks This version returns cosine-angles rather than radians, much quicker */
-        Range<Scalar> getCosAngleRange() const throw() { return cosAngleRange; }
+        Range<Scalar> getCosAngleRange() const { return cosAngleRange; }
         
         /** @see getAngleRange @remarks This version takes cosine-angles rather than radians, much quicker */
-        void setCosAngleRange(Range<Scalar> r) throw() { cosAngleRange = r; dirty.attributes = 1; }
+        void setCosAngleRange(Range<Scalar> r) { cosAngleRange = r; dirty.attributes = 1; }
         
         /** Get the source's radius */
-        Scalar getRadius() const throw() { return radius; }
+        Scalar getRadius() const { return radius; }
         
         /** Set the source's radius */
-        void setRadius(Scalar r) throw() { radius = r; dirty.attributes = 1; }
+        void setRadius(Scalar r) { radius = r; dirty.attributes = 1; }
         
         /** Get the source's frequency-dependant radius ratios 
          * @remarks Sound propagation goes different for low and high frequencies than
@@ -155,46 +155,46 @@ namespace Audio {
          *      volume that is generating high/low frequency vibrations. This will affect
          *      propagation of those frequencies over distance.
          */
-        PerFrequency<Scalar> getPerFrequencyRadiusRatios() const throw() { return pfRadiusRatios; }
+        PerFrequency<Scalar> getPerFrequencyRadiusRatios() const { return pfRadiusRatios; }
         
         /** Set the source's frequency-dependant radius ratios
          * @see getRadiusRatios 
          */
-        void setPerFrequencyRadiusRatios(PerFrequency<Scalar> val) throw() { pfRadiusRatios = val; dirty.attributes = 1; }
+        void setPerFrequencyRadiusRatios(PerFrequency<Scalar> val) { pfRadiusRatios = val; dirty.attributes = 1; }
         
         /** Get the source's refernece frequencies */
-        PerFrequency<Scalar> getReferenceFreqs() const throw() { return referenceFreqs; }
+        PerFrequency<Scalar> getReferenceFreqs() const { return referenceFreqs; }
         
         /** Set the source's reference frequencies */
-        void setReferenceFreqs(PerFrequency<Scalar> val) throw() { referenceFreqs = val; dirty.attributes = 1; }
+        void setReferenceFreqs(PerFrequency<Scalar> val) { referenceFreqs = val; dirty.attributes = 1; }
         
         /** Get the source's main gain */
-        Scalar getGain() const throw() { return gain; }
+        Scalar getGain() const { return gain; }
         
         /** Set the source's main gain */
-        void setGain(Scalar g) throw() { gain = g; dirty.gain = 1; }
+        void setGain(Scalar g) { gain = g; dirty.gain = 1; }
         
         /** Is the source in looping mode? */
-        bool isLooping() const throw() { return flags.looping != 0; }
+        bool isLooping() const { return flags.looping != 0; }
         
         /** Set the source's looping mode */
-        void setLooping(bool loop) throw() { flags.looping = loop ? 1 : 0; dirty.soundAttributes = 1; }
+        void setLooping(bool loop) { flags.looping = loop ? 1 : 0; dirty.soundAttributes = 1; }
         
         /** Is the source using distance attenuation? */
-        bool isAttenuated() const throw() { return flags.attenuated != 0; }
+        bool isAttenuated() const { return flags.attenuated != 0; }
         
         /** Set whether the source uses distance attenuation */
-        void setAttenuated(bool attenuated) throw() { flags.attenuated = attenuated ? 1 : 0; dirty.attributes = 1; }
+        void setAttenuated(bool attenuated) { flags.attenuated = attenuated ? 1 : 0; dirty.attributes = 1; }
         
         /** Is the source's position always relative to the root listener?
          * @remarks Relative sources are useful for interphase sounds, music,
          *      comm streams, and all those sources which are not anchored
          *      to a real 3D object, but rather to the listener itself.
          */
-        bool isRelative() const throw() { return flags.relative != 0; }
+        bool isRelative() const { return flags.relative != 0; }
         
         /** Set whether the source's position is always relative to the root listener. */
-        void setRelative(bool relative) throw() { flags.relative = relative ? 1 : 0; dirty.attributes = 1; }
+        void setRelative(bool relative) { flags.relative = relative ? 1 : 0; dirty.attributes = 1; }
         
         /** Play the source
          * @param start an optional timestamp to start playing from.
@@ -208,7 +208,7 @@ namespace Audio {
          *      @par Remembers the playing time so that a call to getWouldbePlayingTime can
          *      return the correct time.
          */
-        void stopPlaying() throw();
+        void stopPlaying();
         
         /** Pause a playing source
          * @remarks If the source is active, make it inactive. Otherwise, do nothing.
@@ -217,7 +217,7 @@ namespace Audio {
          *      as if the source hadn't been stopped (at getWouldBePlayingTime).
          * @see getWouldBePlayingTime
          */
-        void pausePlaying() throw();
+        void pausePlaying();
         
         /** Continue playing a source
          * @remarks If the source is playing but inactive, continue playing. Otherwise, do nothing.
@@ -226,54 +226,54 @@ namespace Audio {
         void continuePlaying();
         
         /** Is the source still playing? */
-        bool isPlaying() const throw();
+        bool isPlaying() const;
         
         /** Is the attached renderable playing this source? */
-        bool isActive() const throw();
+        bool isActive() const;
         
         /** Get the playing position of a playing or paused source */
-        Timestamp getPlayingTime() const throw();
+        Timestamp getPlayingTime() const;
         
         /** Get the playing position of a playing or paused source. For a paused source, extrapolate
          * from the last known playing time and elapsed time since the measurement was done.
          */
-        Timestamp getWouldbePlayingTime() const throw();
+        Timestamp getWouldbePlayingTime() const;
         
         /** Get renderer-specific data associated (and destroyed) with this sound source */
-        SharedPtr<RenderableSource> getRenderable() const throw() { return rendererDataPtr; }
+        SharedPtr<RenderableSource> getRenderable() const { return rendererDataPtr; }
         
         /** Set renderer-specific data to be associated (and destroyed) with this sound source */
-        void setRenderable(SharedPtr<RenderableSource> ptr) throw();
+        void setRenderable(SharedPtr<RenderableSource> ptr);
         
         /** Get user-specific data associated (and destroyed) with this sound source */
-        SharedPtr<UserData> getUserDataPtr() const throw() { return userDataPtr; }
+        SharedPtr<UserData> getUserDataPtr() const { return userDataPtr; }
         
         /** Set user-specific data to be associated (and destroyed) with this sound source */
-        void setUserDataLong(SharedPtr<UserData> ptr) throw() { userDataPtr = ptr; }
+        void setUserDataLong(SharedPtr<UserData> ptr) { userDataPtr = ptr; }
         
         /** Get user-specific data associated with this sound source */
-        long getUserDataLong() const throw() { return userDataLong; }
+        long getUserDataLong() const { return userDataLong; }
         
         /** Get user-specific data associated with this sound source */
-        void setUserDataLong(long data) throw() { userDataLong = data; }
+        void setUserDataLong(long data) { userDataLong = data; }
         
         /** Get an event listener associated with this sound source */
-        SharedPtr<SourceListener> getSourceListener() const throw() { return sourceListenerPtr; }
+        SharedPtr<SourceListener> getSourceListener() const { return sourceListenerPtr; }
         
         /** Set an event listener to be associated with this sound source */
-        void setSourceListener(SharedPtr<SourceListener> ptr) throw() { sourceListenerPtr = ptr; }
+        void setSourceListener(SharedPtr<SourceListener> ptr) { sourceListenerPtr = ptr; }
         
         /** Get the associated sound stream */
-        SharedPtr<Sound> getSound() const throw() { return soundPtr; }
+        SharedPtr<Sound> getSound() const { return soundPtr; }
         
         /** Set the associated sound stream - Only for SceneManagers to call */
-        void setSound(SharedPtr<Sound> ptr) throw() { soundPtr = ptr; dirty.soundPtr = 1; }
+        void setSound(SharedPtr<Sound> ptr) { soundPtr = ptr; dirty.soundPtr = 1; }
         
         /** Convenience function to update the attached renderable, if present, and active. 
          * @param flags see RenderableSource::UpdateFlags
          * @param sceneListener the listener to which this source is associated
          */
-        void updateRenderable(int flags, const Listener& sceneListener) throw();
+        void updateRenderable(int flags, const Listener& sceneListener);
         
         /** Seek to the specified position
          * @note It may not be supported by the renderer on all sources.
@@ -289,7 +289,7 @@ namespace Audio {
         /** Set the last known playing time, update the measurement timestamp as well.
          * @return the parameter, for chaining.
          */
-        Timestamp setLastKnownPlayingTime(Timestamp timestamp) throw();
+        Timestamp setLastKnownPlayingTime(Timestamp timestamp);
         
         // The following section contains all the virtual functions that need be implemented
         // by a concrete Sound class. All are protected, so the stream interface is independent
@@ -323,7 +323,7 @@ namespace Audio {
          *          All other events take place immediately, so they're
          *      automatically handled by Source's implementation.
          */
-        void _notifyPlaying() throw();
+        void _notifyPlaying();
     };
 
 };

--- a/engine/src/audio/SourceTemplate.cpp
+++ b/engine/src/audio/SourceTemplate.cpp
@@ -9,7 +9,7 @@
 
 namespace Audio {
 
-    SourceTemplate::SourceTemplate(const std::string &sound, VSFileSystem::VSFileType type, bool _looping) throw() :
+    SourceTemplate::SourceTemplate(const std::string &sound, VSFileSystem::VSFileType type, bool _looping) :
         soundName(sound),
         soundType(type),
         cosAngleRange(-1,-1),
@@ -27,13 +27,13 @@ namespace Audio {
     {
     }
 
-    Range<Scalar> SourceTemplate::getAngleRange() const throw() 
+    Range<Scalar> SourceTemplate::getAngleRange() const
     { 
         return Range<Scalar>(Scalar(acos(cosAngleRange.min)), 
                              Scalar(acos(cosAngleRange.max))); 
     }
     
-    void SourceTemplate::setAngleRange(Range<Scalar> r) throw() 
+    void SourceTemplate::setAngleRange(Range<Scalar> r)
     { 
         cosAngleRange.min = Scalar(cos(r.min)); 
         cosAngleRange.max = Scalar(cos(r.max));

--- a/engine/src/audio/SourceTemplate.h
+++ b/engine/src/audio/SourceTemplate.h
@@ -58,37 +58,37 @@ namespace Audio {
         SourceTemplate(
             const std::string &soundName, 
             VSFileSystem::VSFileType type = VSFileSystem::UnknownFile, 
-            bool looping = false) throw();
+            bool looping = false);
         
         ~SourceTemplate();
         
         /** Get the sound resource name */
-        std::string getSoundName() const throw() { return soundName; }
+        std::string getSoundName() const { return soundName; }
         
         /** Set the sound resource name */
-        void setSoundName(const std::string &newName) throw() { soundName = newName; }
+        void setSoundName(const std::string &newName) { soundName = newName; }
         
         /** Get the sound file type */
-        VSFileSystem::VSFileType getSoundType() const throw() { return soundType; }
+        VSFileSystem::VSFileType getSoundType() const { return soundType; }
         
         /** Set the sound file type */
-        void setSoundType(VSFileSystem::VSFileType type) throw() { soundType = type; }
+        void setSoundType(VSFileSystem::VSFileType type) { soundType = type; }
         
         /** Return the source's minimum/maximum propagation angle
          * @remarks Sound will fully propagate in directions within minimum
          *      directional drift. Further drift will attenuate the sound
          *      until it (practically) disappears by the maximum propagation angle.
          */
-        Range<Scalar> getAngleRange() const throw();
+        Range<Scalar> getAngleRange() const;
         
         /** @see getAngleRange */
-        void setAngleRange(Range<Scalar> r) throw();
+        void setAngleRange(Range<Scalar> r);
         
         /** @see getAngleRange @remarks This version returns cosine-angles rather than radians, much quicker */
-        Range<Scalar> getCosAngleRange() const throw() { return cosAngleRange; }
+        Range<Scalar> getCosAngleRange() const { return cosAngleRange; }
         
         /** @see getAngleRange @remarks This version takes cosine-angles rather than radians, much quicker */
-        void setCosAngleRange(Range<Scalar> r) throw() { cosAngleRange = r; }
+        void setCosAngleRange(Range<Scalar> r) { cosAngleRange = r; }
         
         /** Get the source's frequency-dependant radius ratios 
          * @remarks Sound propagation goes different for low and high frequencies than
@@ -96,50 +96,50 @@ namespace Audio {
          *      volume that is generating high/low frequency vibrations. This will affect
          *      propagation of those frequencies over distance.
          */
-        PerFrequency<Scalar> getPerFrequencyRadiusRatios() const throw() { return pfRadiusRatios; }
+        PerFrequency<Scalar> getPerFrequencyRadiusRatios() const { return pfRadiusRatios; }
         
         /** Set the source's frequency-dependant radius ratios
          * @see getRadiusRatios 
          */
-        void setPerFrequencyRadiusRatios(PerFrequency<Scalar> val) throw() { pfRadiusRatios = val; }
+        void setPerFrequencyRadiusRatios(PerFrequency<Scalar> val) { pfRadiusRatios = val; }
         
         /** Get the source's refernece frequencies */
-        PerFrequency<Scalar> getReferenceFreqs() const throw() { return referenceFreqs; }
+        PerFrequency<Scalar> getReferenceFreqs() const { return referenceFreqs; }
         
         /** Set the source's reference frequencies */
-        void setReferenceFreqs(PerFrequency<Scalar> val) throw() { referenceFreqs = val; }
+        void setReferenceFreqs(PerFrequency<Scalar> val) { referenceFreqs = val; }
         
         /** Get the source's main gain */
-        Scalar getGain() const throw() { return gain; }
+        Scalar getGain() const { return gain; }
         
         /** Set the source's main gain */
-        void setGain(Scalar g) throw() { gain = g; }
+        void setGain(Scalar g) { gain = g; }
         
         /** Is the source in looping mode? */
-        bool isLooping() const throw() { return flags.looping != 0; }
+        bool isLooping() const { return flags.looping != 0; }
         
         /** Set the source's looping mode */
-        void setLooping(bool loop) throw() { flags.looping = loop ? 1 : 0; }
+        void setLooping(bool loop) { flags.looping = loop ? 1 : 0; }
         
         /** Is the source's position always relative to the root listener?
          * @see Source::isRelative()
          */
-        bool isRelative() const throw() { return flags.relative != 0; }
+        bool isRelative() const { return flags.relative != 0; }
         
         /** Set whether the source's position is always relative to the root listener */
-        void setRelative(bool relative) throw() { flags.relative = relative ? 1 : 0; }
+        void setRelative(bool relative) { flags.relative = relative ? 1 : 0; }
         
         /** Is the source using distance attenuation? */
-        bool isAttenuated() const throw() { return flags.attenuated != 0; }
+        bool isAttenuated() const { return flags.attenuated != 0; }
         
         /** Set whether the source will use distance attenuation */
-        void setAttenuated(bool loop) throw() { flags.attenuated = (loop ? 1 : 0); }
+        void setAttenuated(bool loop) { flags.attenuated = (loop ? 1 : 0); }
         
         /** Is the source in streaming mode? */
-        bool isStreaming() const throw() { return flags.streaming != 0; }
+        bool isStreaming() const { return flags.streaming != 0; }
         
         /** Set the source's streaming mode */
-        void setStreaming(bool stream) throw() { flags.streaming = stream ? 1 : 0; }
+        void setStreaming(bool stream) { flags.streaming = stream ? 1 : 0; }
         
     };
 

--- a/engine/src/audio/Stream.cpp
+++ b/engine/src/audio/Stream.cpp
@@ -14,7 +14,7 @@ namespace Audio {
 
     using std::min;
 
-    Stream::Stream(const std::string& path) throw(Exception)
+    Stream::Stream(const std::string& path)
     {
     }
     
@@ -22,7 +22,7 @@ namespace Audio {
     {
     }
 
-    double Stream::getLength() throw(Exception)
+    double Stream::getLength()
     {
         return getLengthImpl();
     }
@@ -32,12 +32,12 @@ namespace Audio {
         return getPositionImpl();
     }
 
-    void Stream::seek(double position) throw(Exception)
+    void Stream::seek(double position)
     {
         seekImpl(position);
     }
 
-    unsigned int Stream::read(void *buffer, unsigned int bufferSize) throw(Exception)
+    unsigned int Stream::read(void *buffer, unsigned int bufferSize)
     {
         void *rbuffer;
         void *rbufferEnd;

--- a/engine/src/audio/Stream.cpp
+++ b/engine/src/audio/Stream.cpp
@@ -27,7 +27,7 @@ namespace Audio {
         return getLengthImpl();
     }
 
-    double Stream::getPosition() const throw()
+    double Stream::getPosition() const
     {
         return getPositionImpl();
     }

--- a/engine/src/audio/Stream.h
+++ b/engine/src/audio/Stream.h
@@ -47,16 +47,16 @@ namespace Audio {
         Stream(const std::string& path);
         
         /** Internal write access to stream format, for derived classes */
-        Format& getFormatInternal() throw() { return streamFormat; }
+        Format& getFormatInternal() { return streamFormat; }
     
     public:
         virtual ~Stream();
         
         /** Return the path of the associated file. */
-        const std::string& getPath() const throw() { return filePath; };
+        const std::string& getPath() const { return filePath; };
         
         /** Return the format of the stream. */
-        const Format& getFormat() const throw() { return streamFormat; }
+        const Format& getFormat() const { return streamFormat; }
         
         /** 
          * Return the length of the stream.
@@ -78,7 +78,7 @@ namespace Audio {
         unsigned int read(void *buffer, unsigned int bufferSize);
         
         /** Get the stream's current position, in seconds */
-        double getPosition() const throw();
+        double getPosition() const;
         
         /** 
          * Set the stream's position, in seconds
@@ -97,7 +97,7 @@ namespace Audio {
         virtual double getLengthImpl() const = 0;
         
         /** @see getPosition */
-        virtual double getPositionImpl() const throw() = 0;
+        virtual double getPositionImpl() const = 0;
         
         /** @see seek */
         virtual void seekImpl(double position) = 0;

--- a/engine/src/audio/Stream.h
+++ b/engine/src/audio/Stream.h
@@ -44,7 +44,7 @@ namespace Audio {
         
     protected:
         /** Internal constructor used by derived classes */
-        Stream(const std::string& path) throw(Exception);
+        Stream(const std::string& path);
         
         /** Internal write access to stream format, for derived classes */
         Format& getFormatInternal() throw() { return streamFormat; }
@@ -64,7 +64,7 @@ namespace Audio {
          *      a file without parsing it entirely, and as such it cannot be const. 
          *      So use sparingly.
          */
-        double getLength() throw(Exception);
+        double getLength();
         
         /**
          * Fill the specified buffer with data from the stream, and advance.
@@ -75,7 +75,7 @@ namespace Audio {
          * @param bufferSize the size of the memory area pointed to by buffer, and the maximum amount
          *      of data to be extracted from the stream, if available.
          */
-        unsigned int read(void *buffer, unsigned int bufferSize) throw(Exception);
+        unsigned int read(void *buffer, unsigned int bufferSize);
         
         /** Get the stream's current position, in seconds */
         double getPosition() const throw();
@@ -86,7 +86,7 @@ namespace Audio {
          *      to be as requested, but an approximation given codec limitations. The only exception
          *      being seek(0), which is guaranteed to seek to the beginning of the stream.
          */
-        void seek(double position) throw(Exception);
+        void seek(double position);
         
         // The following section contains all the virtual functions that need be implemented
         // by a concrete Stream class. All are protected, so the stream interface is independent
@@ -94,13 +94,13 @@ namespace Audio {
     protected:
         
         /** @see getLength */
-        virtual double getLengthImpl() const throw(Exception) = 0;
+        virtual double getLengthImpl() const = 0;
         
         /** @see getPosition */
         virtual double getPositionImpl() const throw() = 0;
         
         /** @see seek */
-        virtual void seekImpl(double position) throw(Exception) = 0;
+        virtual void seekImpl(double position) = 0;
         
         /**
          * Get the stream's current reading buffer.
@@ -112,7 +112,7 @@ namespace Audio {
          *      @par Asking the buffer where nextBufferImpl() has never been called would raise
          *      a NoBuffer exception.
          */
-        virtual void getBufferImpl(void *&buffer, unsigned int &bufferSize) throw(Exception) = 0;
+        virtual void getBufferImpl(void *&buffer, unsigned int &bufferSize) = 0;
         
         /**
          * Advance the stream by reading a new buffer.
@@ -121,7 +121,7 @@ namespace Audio {
          *      a NoBuffer exception.
          * @see getBufferImpl
          */
-        virtual void nextBufferImpl() throw(Exception) = 0;
+        virtual void nextBufferImpl() = 0;
     };
 
 };

--- a/engine/src/audio/TemplateManager.cpp
+++ b/engine/src/audio/TemplateManager.cpp
@@ -40,7 +40,7 @@ namespace Audio {
                  */
                 Duration expirationTime;
                 
-                void computeExpirationTime() throw()
+                void computeExpirationTime()
                 {
                     assert(parsed.get());
                     expirationTime = 10 + min(600UL, 2UL * parsed->root.numChildren());
@@ -55,7 +55,7 @@ namespace Audio {
                     touch();
                 }
                 
-                void touch() const throw()
+                void touch() const
                 {
                     lastUsageTime = getRealTime();
                 }
@@ -73,7 +73,6 @@ namespace Audio {
             string defaultDefinitionFile;
             
             SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path)
-               
             {
                 DefinitionMap::iterator it = loadedDefinitions.find(path);
                 if (it != loadedDefinitions.end()) {
@@ -87,7 +86,6 @@ namespace Audio {
             }
             
             SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path) const
-               
             {
                 DefinitionMap::const_iterator it = loadedDefinitions.find(path);
                 if (it != loadedDefinitions.end()) {
@@ -151,7 +149,7 @@ namespace Audio {
     
     using namespace __impl;
 
-    TemplateManager::TemplateManager() throw() :
+    TemplateManager::TemplateManager() :
         data(new TemplateManagerData)
     {
     }
@@ -180,13 +178,11 @@ namespace Audio {
     }
 
     SharedPtr<XMLDOM::XMLDocument> TemplateManager::getDefinitionFile(const std::string &path) const 
-        throw(ResourceNotLoadedException)
     {
         return ((const TemplateManagerData &)*data).getDefinitionFile(path);
     }
     
     SharedPtr<XMLDOM::XMLDocument> TemplateManager::getDefinitionFile(const std::string &path) 
-       
     {
         try {
             return data->getDefinitionFile(path);
@@ -197,19 +193,16 @@ namespace Audio {
     }
 
     void TemplateManager::setDefaultDefinitionFile(const std::string &x) 
-        throw()
     {
         data->defaultDefinitionFile = x;
     }
     
     const std::string& TemplateManager::getDefaultDefinitionFile() const 
-        throw()
     {
         return data->defaultDefinitionFile;
     }
 
     SharedPtr<SourceTemplate> TemplateManager::getSourceTemplate(const std::string &name) 
-       
     {
         SharedPtr<SourceTemplate> rv;
         
@@ -226,7 +219,6 @@ namespace Audio {
     }
     
     SharedPtr<SourceTemplate> TemplateManager::loadSourceTemplate(const std::string &name) 
-       
     {
         string::size_type sep = name.find_first_of(':');
         SharedPtr<XMLDOM::XMLDocument> def;
@@ -285,14 +277,12 @@ namespace Audio {
     
     
     void TemplateManager::addSourceTemplate(const string &name, SharedPtr<SourceTemplate> tpl, bool perm) 
-        throw(ResourceAlreadyLoadedException)
     {
         static string empty;
         addSourceTemplate(empty, name, tpl, perm);
     }
 
     void TemplateManager::addSourceTemplate(const string &path, const string &name, SharedPtr<SourceTemplate> tpl, bool perm) 
-        throw(ResourceAlreadyLoadedException)
     {
         string key(path + ":" + name);
         SharedPtr<SourceTemplate> rv;

--- a/engine/src/audio/TemplateManager.cpp
+++ b/engine/src/audio/TemplateManager.cpp
@@ -46,7 +46,7 @@ namespace Audio {
                     expirationTime = 10 + min(600UL, 2UL * parsed->root.numChildren());
                 }
                 
-                void load(const string &path) throw(Exception)
+                void load(const string &path)
                 {
                     XMLDOM::VSFileXMLSerializer serializer;
                     serializer.initialise();
@@ -73,7 +73,7 @@ namespace Audio {
             string defaultDefinitionFile;
             
             SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path)
-                throw(Exception)
+               
             {
                 DefinitionMap::iterator it = loadedDefinitions.find(path);
                 if (it != loadedDefinitions.end()) {
@@ -87,7 +87,7 @@ namespace Audio {
             }
             
             SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path) const
-                throw(Exception)
+               
             {
                 DefinitionMap::const_iterator it = loadedDefinitions.find(path);
                 if (it != loadedDefinitions.end()) {
@@ -160,7 +160,7 @@ namespace Audio {
     {
     }
 
-    void TemplateManager::addDefinitionFile(const string &path, bool persistent) throw(Exception)
+    void TemplateManager::addDefinitionFile(const string &path, bool persistent)
     {
         // Add an unparsed definition, for lazy loading.
         if (data->loadedDefinitions.count(path) == 0) {
@@ -169,7 +169,7 @@ namespace Audio {
         }
     }
     
-    void TemplateManager::addDefinitionFile(const string &path, SharedPtr<XMLDOM::XMLDocument> definition) throw(Exception)
+    void TemplateManager::addDefinitionFile(const string &path, SharedPtr<XMLDOM::XMLDocument> definition)
     {
         if (data->loadedDefinitions.count(path) == 0) {
             TemplateManagerData::DefinitionFileInfo &info = data->loadedDefinitions[path];
@@ -186,7 +186,7 @@ namespace Audio {
     }
     
     SharedPtr<XMLDOM::XMLDocument> TemplateManager::getDefinitionFile(const std::string &path) 
-        throw(Exception)
+       
     {
         try {
             return data->getDefinitionFile(path);
@@ -209,7 +209,7 @@ namespace Audio {
     }
 
     SharedPtr<SourceTemplate> TemplateManager::getSourceTemplate(const std::string &name) 
-        throw(Exception)
+       
     {
         SharedPtr<SourceTemplate> rv;
         
@@ -226,7 +226,7 @@ namespace Audio {
     }
     
     SharedPtr<SourceTemplate> TemplateManager::loadSourceTemplate(const std::string &name) 
-        throw(Exception)
+       
     {
         string::size_type sep = name.find_first_of(':');
         SharedPtr<XMLDOM::XMLDocument> def;

--- a/engine/src/audio/TemplateManager.h
+++ b/engine/src/audio/TemplateManager.h
@@ -61,16 +61,16 @@ namespace Audio {
         
         
         /** Add a definition file, persistent or not */
-        void addDefinitionFile(const std::string &path, bool persistent) throw(Exception);
+        void addDefinitionFile(const std::string &path, bool persistent);
         
         /** Add a definition document under a specified path, always persistent (as there is no way to reload) */
-        void addDefinitionFile(const std::string &path, SharedPtr<XMLDOM::XMLDocument> definition) throw(Exception);
+        void addDefinitionFile(const std::string &path, SharedPtr<XMLDOM::XMLDocument> definition);
         
         /** Get an already loaded definition file, fail if not found or not loaded */
         SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path) const throw(ResourceNotLoadedException);
         
         /** Get an already loaded definition file, load if not loaded */
-        SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path) throw(Exception);
+        SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path);
         
         
         /** Set default definition file
@@ -85,7 +85,7 @@ namespace Audio {
         const std::string& getDefaultDefinitionFile() const throw();
         
         /** Get a source template by its key */
-        SharedPtr<SourceTemplate> getSourceTemplate(const std::string &name) throw(Exception);
+        SharedPtr<SourceTemplate> getSourceTemplate(const std::string &name);
         
         /** Add a manually-created template 
           * @param name the name portion of the template's key
@@ -120,7 +120,7 @@ namespace Audio {
     protected:
     
         /** Get a source template by its key */
-        SharedPtr<SourceTemplate> loadSourceTemplate(const std::string &name) throw(Exception);
+        SharedPtr<SourceTemplate> loadSourceTemplate(const std::string &name);
         
         
     };

--- a/engine/src/audio/TemplateManager.h
+++ b/engine/src/audio/TemplateManager.h
@@ -55,7 +55,7 @@ namespace Audio {
         /** Construct a new manager 
          * @remarks End-users of the class shouldn't be using this. Singletons need it.
          */
-        TemplateManager() throw();
+        TemplateManager();
         
         ~TemplateManager();
         
@@ -67,7 +67,7 @@ namespace Audio {
         void addDefinitionFile(const std::string &path, SharedPtr<XMLDOM::XMLDocument> definition);
         
         /** Get an already loaded definition file, fail if not found or not loaded */
-        SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path) const throw(ResourceNotLoadedException);
+        SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path) const;
         
         /** Get an already loaded definition file, load if not loaded */
         SharedPtr<XMLDOM::XMLDocument> getDefinitionFile(const std::string &path);
@@ -77,12 +77,12 @@ namespace Audio {
          * @remarks when a template named without its source definition file is requested, it is assumed
          *      to come from this definition file.
          */
-        void setDefaultDefinitionFile(const std::string &x) throw();
+        void setDefaultDefinitionFile(const std::string &x);
         
         /** Get the default definition file
          * @see setDefaultDefinitionFile
          */
-        const std::string& getDefaultDefinitionFile() const throw();
+        const std::string& getDefaultDefinitionFile() const;
         
         /** Get a source template by its key */
         SharedPtr<SourceTemplate> getSourceTemplate(const std::string &name);
@@ -99,7 +99,7 @@ namespace Audio {
           *       this resource.
           * @throws ResourceAlreadyLoadedException, when the key already has an associated template.
           */
-        void addSourceTemplate(const std::string &name, SharedPtr<SourceTemplate> tpl, bool perm = true) throw(ResourceAlreadyLoadedException);
+        void addSourceTemplate(const std::string &name, SharedPtr<SourceTemplate> tpl, bool perm = true);
     
         /** Add a manually-created template 
           * @param path the path portion of the template's key
@@ -115,7 +115,7 @@ namespace Audio {
           *       this resource.
           * @throws ResourceAlreadyLoadedException, when the key already has an associated template.
           */
-        void addSourceTemplate(const std::string &path, const std::string &name, SharedPtr<SourceTemplate> tpl, bool perm = true) throw(ResourceAlreadyLoadedException);
+        void addSourceTemplate(const std::string &path, const std::string &name, SharedPtr<SourceTemplate> tpl, bool perm = true);
     
     protected:
     

--- a/engine/src/audio/codecs/Codec.cpp
+++ b/engine/src/audio/codecs/Codec.cpp
@@ -11,16 +11,16 @@ namespace Audio {
     {
     }
     
-    Codec::Codec(const std::string &_name) throw() : name(_name)
+    Codec::Codec(const std::string &_name) : name(_name)
     {
     }
     
-    const std::string& Codec::getName() const throw()
+    const std::string& Codec::getName() const
     {
         return name;
     }
     
-    const std::vector<std::string>* Codec::getExtensions() const throw()
+    const std::vector<std::string>* Codec::getExtensions() const
     {
         return 0;
     }

--- a/engine/src/audio/codecs/Codec.h
+++ b/engine/src/audio/codecs/Codec.h
@@ -92,7 +92,7 @@ namespace Audio {
          *      if it returns true, this can still fail. Be prepared to catch exceptions
          *      and deal with them accordingly.
          */
-        virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw(Exception) = 0;
+        virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) = 0;
     };
 
 };

--- a/engine/src/audio/codecs/Codec.h
+++ b/engine/src/audio/codecs/Codec.h
@@ -31,7 +31,7 @@ namespace Audio {
     
     protected:
         /** Internal constructor */
-        Codec(const std::string& name) throw();
+        Codec(const std::string& name);
     
     public:
         /** Back-appendable collection of std::string, optimally for static readonly data */
@@ -41,7 +41,7 @@ namespace Audio {
         virtual ~Codec();
         
         /** Return the descriptive name of the codec. */
-        const std::string& getName() const throw();
+        const std::string& getName() const;
         
         /** Return a list of supported extensions. 
          * @remarks 
@@ -58,7 +58,7 @@ namespace Audio {
          *      the final test canHandle(path,true) should never be skipped, even if the file
          *      includes an extension within the returned set.
          */
-        virtual const Extensions* getExtensions() const throw();
+        virtual const Extensions* getExtensions() const;
         
         /**
          * Returns whether this codec instanc can handle the specified file.
@@ -80,7 +80,7 @@ namespace Audio {
          *      value will be less accurate. Whenever in doubt, the function will return
          *      success (true).
          */
-        virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw() = 0;
+        virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) = 0;
         
         /**
          * Returns an instance of the Stream class attached to this codec and the specified

--- a/engine/src/audio/codecs/FFCodec.cpp
+++ b/engine/src/audio/codecs/FFCodec.cpp
@@ -22,7 +22,7 @@ namespace Audio {
     {
     }
     
-    bool FFCodec::canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type) throw()
+    bool FFCodec::canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type)
     {
         if (canOpen) {
             // I don't really know a way to test files in ffmpeg

--- a/engine/src/audio/codecs/FFCodec.cpp
+++ b/engine/src/audio/codecs/FFCodec.cpp
@@ -34,7 +34,7 @@ namespace Audio {
         }
     }
     
-    Stream* FFCodec::open(const std::string& path, VSFileSystem::VSFileType type) throw(Exception)
+    Stream* FFCodec::open(const std::string& path, VSFileSystem::VSFileType type)
     {
         size_t sep = path.find_last_of('|');
         int streamIndex = (sep != std::string::npos) ? atoi(path.c_str() + sep + 1) : 0;

--- a/engine/src/audio/codecs/FFCodec.h
+++ b/engine/src/audio/codecs/FFCodec.h
@@ -23,7 +23,7 @@ namespace Audio {
         virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw();
         
         /** @see Codec::open */
-        virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw(Exception);
+        virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
     };
 
 };

--- a/engine/src/audio/codecs/FFCodec.h
+++ b/engine/src/audio/codecs/FFCodec.h
@@ -20,7 +20,7 @@ namespace Audio {
         virtual ~FFCodec();
         
         /** @see Codec::canHandle */
-        virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw();
+        virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
         
         /** @see Codec::open */
         virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);

--- a/engine/src/audio/codecs/FFStream.cpp
+++ b/engine/src/audio/codecs/FFStream.cpp
@@ -75,7 +75,7 @@ namespace Audio {
             VSFileSystem::VSFileType filetype;
             int audioStreamIndex;
             
-            FFData(const std::string &path, VSFileSystem::VSFileType type, Format &fmt, int streamIdx) throw(Exception) :
+            FFData(const std::string &path, VSFileSystem::VSFileType type, Format &fmt, int streamIdx) :
                 pFormatCtx(0),
                 pCodecCtx(0),
                 pCodec(0),
@@ -298,7 +298,7 @@ namespace Audio {
         };
     }
 
-    FFStream::FFStream(const std::string& path, int streamIndex, VSFileSystem::VSFileType type) throw(Exception)
+    FFStream::FFStream(const std::string& path, int streamIndex, VSFileSystem::VSFileType type)
         : Stream(path)
     {
         ffData = new __impl::FFData(path, type, getFormatInternal(), streamIndex);
@@ -310,7 +310,7 @@ namespace Audio {
         delete ffData;
     }
 
-    double FFStream::getLengthImpl() const throw(Exception)
+    double FFStream::getLengthImpl() const
     {
         return double(ffData->streamSize) / getFormat().sampleFrequency;
     }
@@ -320,7 +320,7 @@ namespace Audio {
         return double(ffData->sampleBufferStart) / getFormat().sampleFrequency;
     }
     
-    void FFStream::seekImpl(double position) throw(Exception)
+    void FFStream::seekImpl(double position)
     {
         if (position < 0)
             position = 0;
@@ -367,7 +367,7 @@ namespace Audio {
         }
     }
     
-    void FFStream::getBufferImpl(void *&buffer, unsigned int &bufferSize) throw(Exception)
+    void FFStream::getBufferImpl(void *&buffer, unsigned int &bufferSize)
     {
         if (!ffData->hasFrame())
             throw NoBufferException();
@@ -376,7 +376,7 @@ namespace Audio {
         bufferSize = ffData->sampleSize * ffData->sampleBufferSize;
     }
     
-    void FFStream::nextBufferImpl() throw(Exception)
+    void FFStream::nextBufferImpl()
     {
         if (!ffData->hasPacket())
             ffData->readPacket();

--- a/engine/src/audio/codecs/FFStream.cpp
+++ b/engine/src/audio/codecs/FFStream.cpp
@@ -179,27 +179,27 @@ namespace Audio {
                     av_close_input_file(pFormatCtx);
             }
             
-            bool saneTimeStamps() const throw()
+            bool saneTimeStamps() const
             {
                 return pStream->time_base.num != 0;
             }
             
-            int64_t timeToPts(double time) const throw()
+            int64_t timeToPts(double time) const
             {
                 return int64_t(floor(time * pStream->time_base.den / pStream->time_base.num));
             }
             
-            double ptsToTime(int64_t pts) const throw()
+            double ptsToTime(int64_t pts) const
             {
                 return double(pts) * pStream->time_base.num / pStream->time_base.den;
             }
             
-            bool hasFrame() const throw()
+            bool hasFrame() const
             {
                 return sampleBuffer && sampleBufferSize;
             }
             
-            bool hasPacket() const throw()
+            bool hasPacket() const
             {
                 #if (LIBAVCODEC_VERSION_MAJOR >= 53)
                 return packetBuffer && packetBufferSize 
@@ -209,7 +209,7 @@ namespace Audio {
                 #endif                
             }
             
-            void readPacket() throw(EndOfStreamException)
+            void readPacket()
             {
                 // Read the next packet, skipping all packets that aren't for this stream
                 #if (LIBAVCODEC_VERSION_MAJOR >= 53)
@@ -233,7 +233,7 @@ namespace Audio {
                     sampleBufferStart = uint64_t(floor(ptsToTime(packet.pts) * pCodecCtx->sample_rate));
             }
             
-            void syncPts() throw(EndOfStreamException)
+            void syncPts()
             {
                 if (!hasPacket())
                     throw EndOfStreamException();
@@ -245,7 +245,7 @@ namespace Audio {
                     streamSize = sampleBufferStart;
             }
             
-            void decodeFrame() throw(PacketDecodeException)
+            void decodeFrame()
             {
                 if (!hasPacket())
                     throw PacketDecodeException();
@@ -315,7 +315,7 @@ namespace Audio {
         return double(ffData->streamSize) / getFormat().sampleFrequency;
     }
     
-    double FFStream::getPositionImpl() const throw()
+    double FFStream::getPositionImpl() const
     {
         return double(ffData->sampleBufferStart) / getFormat().sampleFrequency;
     }

--- a/engine/src/audio/codecs/FFStream.h
+++ b/engine/src/audio/codecs/FFStream.h
@@ -48,7 +48,7 @@ namespace Audio {
         virtual double getLengthImpl() const;
         
         /** @see Stream::getPositionImpl */
-        virtual double getPositionImpl() const throw();
+        virtual double getPositionImpl() const;
         
         /** @see Stream::seekImpl */
         virtual void seekImpl(double position);

--- a/engine/src/audio/codecs/FFStream.h
+++ b/engine/src/audio/codecs/FFStream.h
@@ -38,26 +38,26 @@ namespace Audio {
          *      default, the first audio stream is opened.
          * @param type the file type, used by resource management APIs
          */
-        FFStream(const std::string& path, int streamIndex = 0, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw(Exception);
+        FFStream(const std::string& path, int streamIndex = 0, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
         
         virtual ~FFStream();
         
     protected:
         
         /** @see Stream::getLengthImpl */
-        virtual double getLengthImpl() const throw(Exception);
+        virtual double getLengthImpl() const;
         
         /** @see Stream::getPositionImpl */
         virtual double getPositionImpl() const throw();
         
         /** @see Stream::seekImpl */
-        virtual void seekImpl(double position) throw(Exception);
+        virtual void seekImpl(double position);
         
         /** @see Stream::getBufferImpl */
-        virtual void getBufferImpl(void *&buffer, unsigned int &bufferSize) throw(Exception);
+        virtual void getBufferImpl(void *&buffer, unsigned int &bufferSize);
         
         /** @see Stream::nextBufferImpl */
-        virtual void nextBufferImpl() throw(Exception);
+        virtual void nextBufferImpl();
     };
 
 };

--- a/engine/src/audio/codecs/OggCodec.cpp
+++ b/engine/src/audio/codecs/OggCodec.cpp
@@ -53,7 +53,7 @@ namespace Audio {
         }
     }
     
-    Stream* OggCodec::open(const std::string& path, VSFileSystem::VSFileType type) throw(Exception)
+    Stream* OggCodec::open(const std::string& path, VSFileSystem::VSFileType type)
     {
         return new OggStream(path, type);
     }

--- a/engine/src/audio/codecs/OggCodec.cpp
+++ b/engine/src/audio/codecs/OggCodec.cpp
@@ -23,7 +23,7 @@ namespace Audio {
     {
     }
     
-    const Codec::Extensions* OggCodec::getExtensions() const throw()
+    const Codec::Extensions* OggCodec::getExtensions() const
     {
         static Extensions ext;
         if (ext.empty() == 0) {
@@ -32,7 +32,7 @@ namespace Audio {
         return &ext;
     }
     
-    bool OggCodec::canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type) throw()
+    bool OggCodec::canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type)
     {
         if (canOpen) {
             try {

--- a/engine/src/audio/codecs/OggCodec.h
+++ b/engine/src/audio/codecs/OggCodec.h
@@ -26,7 +26,7 @@ namespace Audio {
         virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw();
         
         /** @see Codec::open */
-        virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw(Exception);
+        virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
     };
 
 };

--- a/engine/src/audio/codecs/OggCodec.h
+++ b/engine/src/audio/codecs/OggCodec.h
@@ -20,10 +20,10 @@ namespace Audio {
         virtual ~OggCodec();
         
         /** @see Codec::getExtensions */ 
-        virtual const Extensions* getExtensions() const throw();
+        virtual const Extensions* getExtensions() const;
         
         /** @see Codec::canHandle */
-        virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw();
+        virtual bool canHandle(const std::string& path, bool canOpen, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
         
         /** @see Codec::open */
         virtual Stream* open(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);

--- a/engine/src/audio/codecs/OggStream.cpp
+++ b/engine/src/audio/codecs/OggStream.cpp
@@ -24,7 +24,7 @@
 
 namespace Audio {
 
-    OggStream::OggStream(const std::string& path, VSFileSystem::VSFileType type) throw(Exception)
+    OggStream::OggStream(const std::string& path, VSFileSystem::VSFileType type)
         : Stream(path)
     {
         if ( file.OpenReadOnly(path, type) <= VSFileSystem::Ok )
@@ -46,7 +46,7 @@ namespace Audio {
         delete oggData;
     }
 
-    double OggStream::getLengthImpl() const throw(Exception)
+    double OggStream::getLengthImpl() const
     {
         return duration;
     }
@@ -56,7 +56,7 @@ namespace Audio {
         return ov_time_tell( &oggData->vorbisFile );
     }
     
-    void OggStream::seekImpl(double position) throw(Exception)
+    void OggStream::seekImpl(double position)
     {
         if (position >= duration)
             throw EndOfStreamException();
@@ -74,7 +74,7 @@ namespace Audio {
         }
     }
     
-    void OggStream::getBufferImpl(void *&buffer, unsigned int &bufferSize) throw(Exception)
+    void OggStream::getBufferImpl(void *&buffer, unsigned int &bufferSize)
     {
         if (readBufferAvail == 0)
             throw NoBufferException();
@@ -83,7 +83,7 @@ namespace Audio {
         bufferSize = readBufferAvail;
     }
     
-    void OggStream::nextBufferImpl() throw(Exception)
+    void OggStream::nextBufferImpl()
     {
         int curStream = oggData->streamIndex;
         long ovr;

--- a/engine/src/audio/codecs/OggStream.cpp
+++ b/engine/src/audio/codecs/OggStream.cpp
@@ -51,7 +51,7 @@ namespace Audio {
         return duration;
     }
     
-    double OggStream::getPositionImpl() const throw()
+    double OggStream::getPositionImpl() const
     {
         return ov_time_tell( &oggData->vorbisFile );
     }

--- a/engine/src/audio/codecs/OggStream.h
+++ b/engine/src/audio/codecs/OggStream.h
@@ -43,26 +43,26 @@ namespace Audio {
          *      using the special path form "[path]|[stream number]". By default, the
          *      first audio stream is opened.
          */
-        OggStream(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw(Exception);
+        OggStream(const std::string& path, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
         
         virtual ~OggStream();
         
     protected:
         
         /** @see Stream::getLengthImpl */
-        virtual double getLengthImpl() const throw(Exception);
+        virtual double getLengthImpl() const;
         
         /** @see Stream::getPositionImpl */
         virtual double getPositionImpl() const throw();
         
         /** @see Stream::seekImpl */
-        virtual void seekImpl(double position) throw(Exception);
+        virtual void seekImpl(double position);
         
         /** @see Stream::getBufferImpl */
-        virtual void getBufferImpl(void *&buffer, unsigned int &bufferSize) throw(Exception);
+        virtual void getBufferImpl(void *&buffer, unsigned int &bufferSize);
         
         /** @see Stream::nextBufferImpl */
-        virtual void nextBufferImpl() throw(Exception);
+        virtual void nextBufferImpl();
     };
 
 };

--- a/engine/src/audio/codecs/OggStream.h
+++ b/engine/src/audio/codecs/OggStream.h
@@ -53,7 +53,7 @@ namespace Audio {
         virtual double getLengthImpl() const;
         
         /** @see Stream::getPositionImpl */
-        virtual double getPositionImpl() const throw();
+        virtual double getPositionImpl() const;
         
         /** @see Stream::seekImpl */
         virtual void seekImpl(double position);

--- a/engine/src/audio/renderers/OpenAL/BorrowedOpenALRenderer.h
+++ b/engine/src/audio/renderers/OpenAL/BorrowedOpenALRenderer.h
@@ -34,15 +34,15 @@ namespace Audio {
          * @param device The OpenAL device associated to this context
          * @param context The OpenAL context associated to this renderer
          */
-        BorrowedOpenALRenderer(ALCdevice *device = 0, ALCcontext *context = 0) throw(Exception);
+        BorrowedOpenALRenderer(ALCdevice *device = 0, ALCcontext *context = 0);
         
         ~BorrowedOpenALRenderer();
         
         
-        virtual void setOutputFormat(const Format &format) throw(Exception);
+        virtual void setOutputFormat(const Format &format);
         
     protected:
-        virtual void checkContext() throw(Exception);
+        virtual void checkContext();
     };
 
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALHelpers.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALHelpers.cpp
@@ -18,7 +18,6 @@ namespace Audio {
         namespace OpenAL {
             
             void _checkAlErrorAt(ALenum error, const char *filename, int lineno)
-                throw (Exception)
             {
                 switch(error) {
                 case AL_NO_ERROR : return;
@@ -50,13 +49,11 @@ namespace Audio {
             }
             
             void _clearAlError()
-                throw()
             {
                 alGetError();
             }
             
             ALenum asALFormat(const Format &format)
-                throw (Exception)
             {
                 ALenum alformat;
                 switch(format.bitsPerSample) {

--- a/engine/src/audio/renderers/OpenAL/OpenALHelpers.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALHelpers.h
@@ -12,9 +12,9 @@ namespace Audio {
     namespace __impl {
         namespace OpenAL {
             
-            void _checkAlErrorAt(ALenum error, const char *filename, int lineno) throw (Exception);
-            void _clearAlError() throw();
-            ALenum asALFormat(const Format &format) throw(Exception);
+            void _checkAlErrorAt(ALenum error, const char *filename, int lineno);
+            void _clearAlError();
+            ALenum asALFormat(const Format &format);
             
         }
     }

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableListener.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableListener.cpp
@@ -21,7 +21,6 @@ namespace Audio {
     }
     
     void OpenALRenderableListener::updateImpl(int flags) 
-        throw(Exception)
     {
         if (flags & UPDATE_LOCATION) {
             const Vector3 pos(getListener()->getPosition()); // no option but to cast it down to float :(

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableListener.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableListener.h
@@ -27,7 +27,7 @@ namespace Audio {
     
     protected:
         /** @see RenderableListener::update. */
-        virtual void updateImpl(int flags) throw(Exception);
+        virtual void updateImpl(int flags);
     };
 
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableSource.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableSource.cpp
@@ -39,7 +39,6 @@ namespace Audio {
     }
     
     void OpenALRenderableSource::startPlayingImpl(Timestamp start) 
-        throw(Exception)
     {
         if (!isPlayingImpl()) {
             // Make sure we have an attached sound
@@ -57,13 +56,11 @@ namespace Audio {
     }
     
     void OpenALRenderableSource::stopPlayingImpl() 
-        throw(Exception)
     {
         alSourceStop(alSource);
     }
     
     bool OpenALRenderableSource::isPlayingImpl() const 
-        throw(Exception)
     {
         ALint state = 0;
         alGetSourcei(getALSource(), AL_SOURCE_STATE, &state);
@@ -71,7 +68,6 @@ namespace Audio {
     }
     
     Timestamp OpenALRenderableSource::getPlayingTimeImpl() const 
-        throw(Exception)
     {
         ALfloat offs = -1.f;
         alGetSourcef(getALSource(), AL_SEC_OFFSET, &offs);
@@ -83,7 +79,6 @@ namespace Audio {
     }
     
     void OpenALRenderableSource::updateImpl(int flags, const Listener& sceneListener) 
-        throw(Exception)
     {
         Source *source = getSource();
         ALSourceHandle als = getALSource();
@@ -137,7 +132,6 @@ namespace Audio {
     }
     
     void OpenALRenderableSource::attachALBuffers()
-        throw(Exception)
     {
         if (!alBuffersAttached) {
             SharedPtr<Sound> sound = getSource()->getSound();
@@ -158,7 +152,6 @@ namespace Audio {
     }
     
     void OpenALRenderableSource::seekImpl(Timestamp time)
-        throw(Exception)
     {
         // Tell the AL to jump to the specified position
         // NOTE: lots of implementations don't support it

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableSource.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableSource.h
@@ -32,22 +32,22 @@ namespace Audio {
     
     protected:
         /** @see RenderableSource::startPlayingImpl. */
-        virtual void startPlayingImpl(Timestamp start) throw(Exception);
+        virtual void startPlayingImpl(Timestamp start);
         
         /** @see RenderableSource::stopPlayingImpl. */
-        virtual void stopPlayingImpl() throw(Exception);
+        virtual void stopPlayingImpl();
         
         /** @see RenderableSource::isPlayingImpl. */
-        virtual bool isPlayingImpl() const throw(Exception);
+        virtual bool isPlayingImpl() const;
         
         /** @see RenderableSource::getPlayingTimeImpl. */
-        virtual Timestamp getPlayingTimeImpl() const throw(Exception);
+        virtual Timestamp getPlayingTimeImpl() const;
         
         /** @see RenderableSource::updateImpl. */
-        virtual void updateImpl(int flags, const Listener& sceneListener) throw(Exception);
+        virtual void updateImpl(int flags, const Listener& sceneListener);
         
         /** @see RenderableSource::seekImpl. */
-        virtual void seekImpl(Timestamp time) throw(Exception);
+        virtual void seekImpl(Timestamp time);
         
         /** Derived classes may use the underlying AL source handle to set additional attributes */
         ALuint getALSource() const { return alSource; }
@@ -55,7 +55,7 @@ namespace Audio {
         /** Attach AL buffers from the source's AL sound, if not attached already.
          * @note It will fail with an assertion if the attached sound isn't an OpenAL sound.
          */
-        void attachALBuffers() throw(Exception);
+        void attachALBuffers();
     };
 
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableStreamingSource.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableStreamingSource.cpp
@@ -42,7 +42,6 @@ namespace Audio {
     }
     
     void OpenALRenderableStreamingSource::startPlayingImpl(Timestamp start) 
-        throw(Exception)
     {
         if (!isPlayingImpl()) {
             SharedPtr<Sound> sound = getSource()->getSound();
@@ -72,7 +71,6 @@ namespace Audio {
     }
     
     void OpenALRenderableStreamingSource::stopPlayingImpl() 
-        throw(Exception)
     {
         shouldPlay = false;
         startedPlaying = false;
@@ -81,7 +79,6 @@ namespace Audio {
     }
     
     bool OpenALRenderableStreamingSource::isPlayingImpl() const 
-        throw(Exception)
     {
         // According to the AL, streaming sounds can cease to be 
         // in the playing state because of buffer starvation. However,
@@ -97,7 +94,6 @@ namespace Audio {
     }
     
     Timestamp OpenALRenderableStreamingSource::getPlayingTimeImpl() const 
-        throw(Exception)
     {
         ALfloat offs = -1.f;
         alGetSourcef(getALSource(), AL_SEC_OFFSET, &offs);
@@ -112,7 +108,6 @@ namespace Audio {
     }
     
     void OpenALRenderableStreamingSource::seekImpl(Timestamp time) 
-        throw(Exception)
     {
         // Seek the stream to the specified position
         atEos = false;
@@ -121,7 +116,6 @@ namespace Audio {
     }
     
     void OpenALRenderableStreamingSource::updateImpl(int flags, const Listener& sceneListener) 
-        throw(Exception)
     {
         Source *source = getSource();
         ALSourceHandle als = getALSource();
@@ -204,7 +198,6 @@ namespace Audio {
     }
     
     void OpenALRenderableStreamingSource::queueALBuffers()
-        throw(Exception)
     {
         SharedPtr<Sound> sound = getSource()->getSound();
         

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableStreamingSource.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableStreamingSource.h
@@ -43,22 +43,22 @@ namespace Audio {
         
     protected:
         /** @see RenderableSource::startPlayingImpl. */
-        virtual void startPlayingImpl(Timestamp start) throw(Exception);
+        virtual void startPlayingImpl(Timestamp start);
         
         /** @see RenderableSource::stopPlayingImpl. */
-        virtual void stopPlayingImpl() throw(Exception);
+        virtual void stopPlayingImpl();
         
         /** @see RenderableSource::isPlayingImpl. */
-        virtual bool isPlayingImpl() const throw(Exception);
+        virtual bool isPlayingImpl() const;
         
         /** @see RenderableSource::getPlayingTimeImpl. */
-        virtual Timestamp getPlayingTimeImpl() const throw(Exception);
+        virtual Timestamp getPlayingTimeImpl() const;
         
         /** @see RenderableSource::updateImpl. */
-        virtual void updateImpl(int flags, const Listener& sceneListener) throw(Exception);
+        virtual void updateImpl(int flags, const Listener& sceneListener);
         
         /** @see RenderableSource::seekImpl. */
-        virtual void seekImpl(Timestamp time) throw(Exception);
+        virtual void seekImpl(Timestamp time);
         
         /** Derived classes may use the underlying AL source handle to set additional attributes */
         ALuint getALSource() const { return alSource; }
@@ -68,7 +68,7 @@ namespace Audio {
          * @note It will not throw an EndOfStream exception, even if the sound reaches the end 
          *      and it's not a looping source.
          */
-        void queueALBuffers() throw(Exception);
+        void queueALBuffers();
     };
 
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderer.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderer.cpp
@@ -122,7 +122,6 @@ namespace Audio {
                 }
                 
                 void openDevice(const char *deviceSpecifier)
-                    throw (Exception)
                 {
                     if (alDevice)
                         throw Exception("Trying to open a device without closing the previous one first");
@@ -148,7 +147,6 @@ namespace Audio {
                 }
                 
                 void closeDevice()
-                    throw (Exception)
                 {
                     if (alContext)
                         throw Exception("Trying to close device without closing the previous one first");
@@ -161,7 +159,6 @@ namespace Audio {
                 }
                 
                 void openContext(const Format &format)
-                    throw (Exception)
                 {
                     if (alContext)
                         throw Exception("Trying to open context without closing the previous one first");
@@ -186,14 +183,12 @@ namespace Audio {
                 }
                 
                 void commit() 
-                    throw (Exception)
                 {
                     alcProcessContext(alContext);
                     checkAlError();
                 }
                 
                 void suspend()
-                    throw (Exception)
                 {
                     // FIXME: There's a residual error here on Windows. Can't track down where it's from.
                     alGetError();
@@ -204,7 +199,6 @@ namespace Audio {
                 }
                 
                 void closeContext()
-                    throw (Exception)
                 {
                     if (alContext) {
                         alcMakeContextCurrent(NULL);
@@ -214,7 +208,7 @@ namespace Audio {
                     }
                 }
                 
-                RendererData() throw() :
+                RendererData() :
                     alDevice(NULL),
                     alContext(NULL)
                 {
@@ -232,8 +226,7 @@ namespace Audio {
 
     using namespace __impl::OpenAL;
 
-    OpenALRenderer::OpenALRenderer() 
-        throw(Exception) :
+    OpenALRenderer::OpenALRenderer() :
         data(new RendererData)
     {
     }
@@ -246,7 +239,6 @@ namespace Audio {
             const std::string &name, 
             VSFileSystem::VSFileType type, 
             bool streaming) 
-        throw(Exception)
     {
         checkContext();
         SharedPtr<Sound> sound = data->lookupSound(type,name);
@@ -277,7 +269,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::attach(SharedPtr<Source> source) 
-        throw(Exception)
     {
         checkContext();
         source->setRenderable( SharedPtr<RenderableSource>(
@@ -289,7 +280,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::attach(SharedPtr<Listener> listener) 
-        throw(Exception)
     {
         checkContext();
         listener->setRenderable( SharedPtr<RenderableListener>(
@@ -297,21 +287,18 @@ namespace Audio {
     }
     
     void OpenALRenderer::detach(SharedPtr<Source> source) 
-        throw()
     {
         // Just clear it... RenderableListener's destructor will handle everything fine.
         source->setRenderable( SharedPtr<RenderableSource>() );
     }
     
     void OpenALRenderer::detach(SharedPtr<Listener> listener) 
-        throw()
     {
         // Just clear it... RenderableListener's destructor will handle everything fine.
         listener->setRenderable( SharedPtr<RenderableListener>() );
     }
     
     void OpenALRenderer::setMeterDistance(Scalar distance) 
-        throw()
     {
         // ToDo
         // Nothing yet - this is an extension to OpenAL 1.1's specs and in this phase
@@ -324,7 +311,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::setDopplerFactor(Scalar factor) 
-        throw()
     {
         Renderer::setDopplerFactor(factor);
         
@@ -333,7 +319,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::setOutputFormat(const Format &format) 
-        throw(Exception)
     {
         if (!data->alDevice)
             data->openDevice(NULL);
@@ -343,7 +328,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::checkContext()
-        throw(Exception)
     {
         if (!data->alDevice)
             data->openDevice(NULL);
@@ -354,7 +338,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::beginTransaction() 
-        throw(Exception)
     {
         data->suspend();
         
@@ -363,13 +346,11 @@ namespace Audio {
     }
     
     void OpenALRenderer::commitTransaction() 
-        throw(Exception)
     {
         data->commit();
     }
     
     void OpenALRenderer::initContext()
-        throw(Exception)
     {
         // Set the distance model
         alDistanceModel(AL_INVERSE_DISTANCE_CLAMPED);
@@ -380,7 +361,6 @@ namespace Audio {
     }
     
     void OpenALRenderer::setupDopplerEffect()
-        throw(Exception)
     {
         clearAlError();
         
@@ -400,8 +380,7 @@ namespace Audio {
         checkAlError();
     }
     
-    BorrowedOpenALRenderer::BorrowedOpenALRenderer(ALCdevice *device, ALCcontext *context) 
-        throw(Exception) :
+    BorrowedOpenALRenderer::BorrowedOpenALRenderer(ALCdevice *device, ALCcontext *context) :
         OpenALRenderer()
     {
         if (device) 
@@ -423,17 +402,14 @@ namespace Audio {
     }
 
     void BorrowedOpenALRenderer::setOutputFormat(const Format &format) 
-        throw(Exception)
     {
         // No-op... format is given by the borrowed context
         Renderer::setOutputFormat(format);
     }
     
     void BorrowedOpenALRenderer::checkContext()
-        throw(Exception)
     {
         // No-op... context has been borrowed
     }
 
-    
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderer.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderer.h
@@ -33,7 +33,7 @@ namespace Audio {
         
     public:
         /** Initialize the renderer with default or config-driven settings. */
-        OpenALRenderer() throw(Exception);
+        OpenALRenderer();
         
         virtual ~OpenALRenderer();
         
@@ -41,47 +41,47 @@ namespace Audio {
         virtual SharedPtr<Sound> getSound(
             const std::string &name, 
             VSFileSystem::VSFileType type = VSFileSystem::UnknownFile, 
-            bool streaming = false) throw(Exception);
+            bool streaming = false);
         
         /** @copydoc Renderer::owns */
         virtual bool owns(SharedPtr<Sound> sound);
         
         /** @copydoc Renderer::attach(SharedPtr<Source>) */
-        virtual void attach(SharedPtr<Source> source) throw(Exception);
+        virtual void attach(SharedPtr<Source> source);
         
         /** @copydoc Renderer::attach(SharedPtr<Listener>) */
-        virtual void attach(SharedPtr<Listener> listener) throw(Exception);
+        virtual void attach(SharedPtr<Listener> listener);
         
         /** @copydoc Renderer::detach(SharedPtr<Source>) */
-        virtual void detach(SharedPtr<Source> source) throw();
+        virtual void detach(SharedPtr<Source> source);
         
         /** @copydoc Renderer::detach(SharedPtr<Listener>) */
-        virtual void detach(SharedPtr<Listener> listener) throw();
+        virtual void detach(SharedPtr<Listener> listener);
         
         /** @copydoc Renderer::setMeterDistance */
-        virtual void setMeterDistance(Scalar distance) throw();
+        virtual void setMeterDistance(Scalar distance);
         
         /** @copydoc Renderer::setDopplerFactor */
-        virtual void setDopplerFactor(Scalar factor) throw();
+        virtual void setDopplerFactor(Scalar factor);
         
         /** @copydoc Renderer::setOutputFormat */
-        virtual void setOutputFormat(const Format &format) throw(Exception);
+        virtual void setOutputFormat(const Format &format);
         
         /** @copydoc Renderer::beginTransaction */
-        virtual void beginTransaction() throw(Exception);
+        virtual void beginTransaction();
         
         /** @copydoc Renderer::commitTransaction */
-        virtual void commitTransaction() throw(Exception);
+        virtual void commitTransaction();
     protected:
     
         /** Makes sure the AL context is valid, creating one if necessary */
-        virtual void checkContext() throw(Exception);
+        virtual void checkContext();
         
         /** Sets expected defaults into the context */
-        virtual void initContext() throw(Exception);
+        virtual void initContext();
         
         /** Sets doppler effect globals into the context */
-        void setupDopplerEffect() throw(Exception);
+        void setupDopplerEffect();
     };
     
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALSimpleSound.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALSimpleSound.cpp
@@ -22,8 +22,7 @@ using namespace Audio::__impl::OpenAL;
 
 namespace Audio {
 
-    OpenALSimpleSound::OpenALSimpleSound(const std::string& name, VSFileSystem::VSFileType type)
-        throw() :
+    OpenALSimpleSound::OpenALSimpleSound(const std::string& name, VSFileSystem::VSFileType type) :
         SimpleSound(name, type, false),
         bufferHandle(AL_NULL_BUFFER)
     {
@@ -34,7 +33,6 @@ namespace Audio {
     }
 
     void OpenALSimpleSound::loadImpl(bool wait) 
-        throw(Exception)
     {
         // just in case
         unloadImpl();
@@ -151,7 +149,6 @@ namespace Audio {
     }
     
     void OpenALSimpleSound::unloadImpl() 
-        throw()
     {
         if (bufferHandle == AL_NULL_BUFFER) 
             return;

--- a/engine/src/audio/renderers/OpenAL/OpenALSimpleSound.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALSimpleSound.h
@@ -28,7 +28,7 @@ namespace Audio {
         
     public:
         /** Internal constructor used by derived classes */
-        OpenALSimpleSound(const std::string& name, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile) throw();
+        OpenALSimpleSound(const std::string& name, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile);
         
         /** Package-private: the OpenAL renderer package uses this, YOU DON'T */
         ALBufferHandle getAlBuffer() const { return bufferHandle; }
@@ -41,10 +41,10 @@ namespace Audio {
         // about sending the samples to where they're needed.
     protected:
         /** @copydoc Sound::loadImpl */
-        virtual void loadImpl(bool wait) throw(Exception);
+        virtual void loadImpl(bool wait);
         
         /** @copydoc Sound::unloadImpl */
-        virtual void unloadImpl() throw();
+        virtual void unloadImpl();
     };
 
 };

--- a/engine/src/audio/renderers/OpenAL/OpenALStreamingSound.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALStreamingSound.cpp
@@ -27,8 +27,7 @@ using namespace Audio::__impl::OpenAL;
 namespace Audio {
     
     OpenALStreamingSound::OpenALStreamingSound(const std::string& name, VSFileSystem::VSFileType type,
-            unsigned int _bufferSamples)
-        throw() :
+            unsigned int _bufferSamples) :
         SimpleSound(name, type, true),
         bufferSamples(_bufferSamples)
     {
@@ -41,7 +40,6 @@ namespace Audio {
     }
 
     void OpenALStreamingSound::loadImpl(bool wait) 
-        throw(Exception)
     {
         // just in case
         unloadImpl();
@@ -92,7 +90,6 @@ namespace Audio {
     }
     
     void OpenALStreamingSound::flushBuffers()
-        throw()
     {
         // Mark as detached, so that readAndFlip() knows to initialize the source
         // and streaming indices
@@ -104,7 +101,6 @@ namespace Audio {
     }
     
     void OpenALStreamingSound::unloadImpl() 
-        throw()
     {
         if (isStreamLoaded())
             closeStream();
@@ -113,7 +109,6 @@ namespace Audio {
     }
     
     ALBufferHandle OpenALStreamingSound::readAndFlip()
-        throw(Exception)
     {
         if (!isLoaded())
             throw ResourceNotLoadedException(getName());
@@ -147,7 +142,6 @@ namespace Audio {
     }
     
     void OpenALStreamingSound::unqueueBuffer(ALBufferHandle buffer) 
-        throw(Exception)
     {
         if (playBufferIndex < NUM_BUFFERS && buffer == bufferHandles[playBufferIndex]) {
             playBufferIndex = (playBufferIndex + 1) % NUM_BUFFERS;
@@ -155,7 +149,6 @@ namespace Audio {
     }
     
     void OpenALStreamingSound::seek(double position)
-        throw(Exception)
     {
         if (!isLoaded())
             throw ResourceNotLoadedException(getName());
@@ -164,7 +157,6 @@ namespace Audio {
     }
     
     Timestamp OpenALStreamingSound::getTimeBase() const
-        throw()
     {
         return bufferStarts[playBufferIndex];
     }

--- a/engine/src/audio/renderers/OpenAL/OpenALStreamingSound.h
+++ b/engine/src/audio/renderers/OpenAL/OpenALStreamingSound.h
@@ -54,7 +54,7 @@ namespace Audio {
          *      samples below which a read would be triggered.
          */
         OpenALStreamingSound(const std::string& name, VSFileSystem::VSFileType type = VSFileSystem::UnknownFile,
-            unsigned int bufferSamples = 0) throw();
+            unsigned int bufferSamples = 0);
         
     public:
         virtual ~OpenALStreamingSound();
@@ -64,10 +64,10 @@ namespace Audio {
         // about sending the samples to where they're needed.
     protected:
         /** @copydoc Sound::loadImpl */
-        virtual void loadImpl(bool wait) throw(Exception);
+        virtual void loadImpl(bool wait);
         
         /** @copydoc Sound::unloadImpl */
-        virtual void unloadImpl() throw();
+        virtual void unloadImpl();
         
         // The following section contains package-private methods.
         // Only OpenAL renderer classes should access them, NOT YOU
@@ -85,7 +85,7 @@ namespace Audio {
          *      You may seek the stream and keep going, for instance, for a looping stream.
          *      Any other exception would be fatal.
          */
-        ALBufferHandle readAndFlip() throw(Exception);
+        ALBufferHandle readAndFlip();
         
         /** Notify a dequeued buffer
          *
@@ -93,22 +93,22 @@ namespace Audio {
          *      as dequeued, allowing readAndFlip() to use it for new data. The caller is 
          *      expected to have detached the buffer from the source.
          */
-        void unqueueBuffer(ALBufferHandle buffer) throw(Exception);
+        void unqueueBuffer(ALBufferHandle buffer);
         
         /** Reset the buffer queue */
-        void flushBuffers() throw();
+        void flushBuffers();
         
         /** Get the time base of the stream
          *
          * @returns The timestamp of the first unreturned buffer's starting point.
          */
-        Timestamp getTimeBase() const throw();
+        Timestamp getTimeBase() const;
         
         /** 
          * Set the stream's position, in seconds
          * @see Stream::seek(double)
          */
-        void seek(double position) throw(Exception);
+        void seek(double position);
     };
 
 };

--- a/engine/src/audio/utils.cpp
+++ b/engine/src/audio/utils.cpp
@@ -13,18 +13,18 @@
 
 namespace Audio {
 
-    Timestamp getGameTime() throw()
+    Timestamp getGameTime()
     {
         return Timestamp(UniverseUtil::GetGameTime());
     }
     
-    Timestamp getRealTime() throw()
+    Timestamp getRealTime()
     {
         return Timestamp(realTime());
     }
     
 
-    Scalar estimateGain(const Source &src, const Listener &listener) throw()
+    Scalar estimateGain(const Source &src, const Listener &listener)
     {
         // Base priority is source gain
         Scalar gain = src.getGain();

--- a/engine/src/audio/utils.h
+++ b/engine/src/audio/utils.h
@@ -12,10 +12,10 @@ namespace Audio {
     class Source;
 
     /** Get the game time stamp - ie, the time as it elapses in the game's universe */
-    Timestamp getGameTime() throw();
+    Timestamp getGameTime();
     
     /** Get the current real time stamp */
-    Timestamp getRealTime() throw();
+    Timestamp getRealTime();
 
     /** Estimate a distant source's gain
      * @remarks Computes source attenuation relative to a listener.
@@ -24,7 +24,7 @@ namespace Audio {
      *      may make the final attenuation differ significantly, so this should only
      *      be used for culling purposes.
      */
-    Scalar estimateGain(const Source &src, const Listener &listener) throw();
+    Scalar estimateGain(const Source &src, const Listener &listener);
     
     /** Make the thread sleep for at least 'ms' milliseconds.
      * @remarks sleep(0) is a very common way to implement a waiting loop:

--- a/engine/src/gfx/aligned.h
+++ b/engine/src/gfx/aligned.h
@@ -37,8 +37,8 @@ public:
     
     static const int _OVERHEAD = (sizeof(T) + ALIGN-1) / ALIGN + sizeof(size_t);
     
-    aligned_allocator() throw() {}
-    template<typename A> explicit aligned_allocator(const A &other) throw() : std::allocator<T>(other) {}
+    aligned_allocator() {}
+    template<typename A> explicit aligned_allocator(const A &other) : std::allocator<T>(other) {}
     
     typename std::allocator<T>::pointer address ( typename std::allocator<T>::reference x ) const
     {

--- a/engine/src/gfx/mesh_gfx.cpp
+++ b/engine/src/gfx/mesh_gfx.cpp
@@ -53,8 +53,8 @@ private:
 public: Exception() {}
     Exception( const Exception &other ) : _message( other._message ) {}
     explicit Exception( const std::string &message ) : _message( message ) {}
-    virtual ~Exception() throw () {}
-    virtual const char * what() const throw ()
+    virtual ~Exception() {}
+    virtual const char * what() const
     {
         return _message.c_str();
     }

--- a/engine/src/gfx/mesh_gfx.cpp
+++ b/engine/src/gfx/mesh_gfx.cpp
@@ -54,7 +54,7 @@ public: Exception() {}
     Exception( const Exception &other ) : _message( other._message ) {}
     explicit Exception( const std::string &message ) : _message( message ) {}
     virtual ~Exception() {}
-    virtual const char * what() const
+    virtual const char * what() const noexcept
     {
         return _message.c_str();
     }

--- a/engine/src/gfx/technique.cpp
+++ b/engine/src/gfx/technique.cpp
@@ -41,7 +41,7 @@ public:
     Exception() {}
     Exception( const Exception &other ) : _message( other._message ) {}
     explicit Exception( const std::string &message ) : _message( message ) {}
-    virtual const char * what() const
+    virtual const char * what() const noexcept
     {
         return _message.c_str();
     }

--- a/engine/src/gfx/technique.cpp
+++ b/engine/src/gfx/technique.cpp
@@ -37,11 +37,11 @@ class Exception : public std::exception
 private:
     std::string _message;
 public:
-    virtual ~Exception() throw () {}
+    virtual ~Exception() {}
     Exception() {}
     Exception( const Exception &other ) : _message( other._message ) {}
     explicit Exception( const std::string &message ) : _message( message ) {}
-    virtual const char * what() const throw ()
+    virtual const char * what() const
     {
         return _message.c_str();
     }

--- a/engine/src/gfx/vid_file.cpp
+++ b/engine/src/gfx/vid_file.cpp
@@ -85,7 +85,7 @@ private:
         }
     }
 
-    void nextFrame(bool skip=false) throw (VidFile::Exception)
+    void nextFrame(bool skip=false)
     {
         int bytesDecoded;
         int frameFinished;
@@ -202,7 +202,7 @@ public:
             av_close_input_file( pFormatCtx );
     }
 
-    void open( const std::string &path ) throw (VidFile::Exception)
+    void open( const std::string &path )
     {
         if (pCodecCtx != 0) throw VidFile::Exception( "Already open" );
         //Initialize libavcodec/libavformat if necessary
@@ -375,7 +375,7 @@ public:
 #endif /* !HAVE_FFMPEG */
 /* ************************************ */
 
-VidFile::VidFile() throw () :
+VidFile::VidFile() :
     impl( NULL )
 {}
 
@@ -385,7 +385,7 @@ VidFile::~VidFile()
         delete impl;
 }
 
-bool VidFile::isOpen() const throw ()
+bool VidFile::isOpen() const
 {
     return impl != NULL;
 }
@@ -400,7 +400,7 @@ void VidFile::open( const std::string &path, size_t maxDimension, bool forcePOT 
 #endif
 }
 
-void VidFile::close() throw ()
+void VidFile::close()
 {
     if (impl) {
         delete impl;
@@ -408,32 +408,32 @@ void VidFile::close() throw ()
     }
 }
 
-float VidFile::getFrameRate() const throw ()
+float VidFile::getFrameRate() const
 {
     return impl ? impl->frameRate : 0;
 }
 
-float VidFile::getDuration() const throw ()
+float VidFile::getDuration() const
 {
     return impl ? impl->duration : 0;
 }
 
-int VidFile::getWidth() const throw ()
+int VidFile::getWidth() const
 {
     return impl ? impl->width : 0;
 }
 
-int VidFile::getHeight() const throw ()
+int VidFile::getHeight() const
 {
     return impl ? impl->height : 0;
 }
 
-void* VidFile::getFrameBuffer() const throw ()
+void* VidFile::getFrameBuffer() const
 {
     return impl ? impl->frameBuffer : 0;
 }
 
-int VidFile::getFrameBufferStride() const throw ()
+int VidFile::getFrameBufferStride() const
 {
     return impl ? impl->frameBufferStride : 0;
 }

--- a/engine/src/gfx/vid_file.cpp
+++ b/engine/src/gfx/vid_file.cpp
@@ -390,7 +390,7 @@ bool VidFile::isOpen() const throw ()
     return impl != NULL;
 }
 
-void VidFile::open( const std::string &path, size_t maxDimension, bool forcePOT ) throw (Exception)
+void VidFile::open( const std::string &path, size_t maxDimension, bool forcePOT )
 {
 #ifdef HAVE_FFMPEG
     if (!impl)
@@ -438,7 +438,7 @@ int VidFile::getFrameBufferStride() const throw ()
     return impl ? impl->frameBufferStride : 0;
 }
 
-bool VidFile::seek( float time ) throw (Exception)
+bool VidFile::seek( float time )
 {
     return (impl != 0) && impl->seek( time );
 }

--- a/engine/src/gfx/vid_file.h
+++ b/engine/src/gfx/vid_file.h
@@ -21,8 +21,8 @@ private:
 public: Exception() {}
         Exception( const Exception &other ) : _message( other._message ) {}
         explicit Exception( const std::string &message ) : _message( message ) {}
-        virtual ~Exception() throw () {}
-        virtual const char * what() const throw ()
+        virtual ~Exception() {}
+        virtual const char * what() const
         {
             return _message.c_str();
         }
@@ -57,13 +57,13 @@ public: EndOfStreamException() {}
     };
 
 public: 
-    VidFile() throw ();
+    VidFile();
     ~VidFile();
 
-    bool isOpen() const throw ();
+    bool isOpen() const;
 
     void open( const std::string &path, size_t maxDimension = 65535, bool forcePOT = false );
-    void close() throw ();
+    void close();
 
 /** Seeks to the specified time
  * @Returns true if frame changed, false otherwise.
@@ -72,12 +72,12 @@ public:
  */
     bool seek( float time );
 
-    float getFrameRate() const throw ();
-    float getDuration() const throw ();
-    int getWidth() const throw ();
-    int getHeight() const throw ();
-    void * getFrameBuffer() const throw ();
-    int getFrameBufferStride() const throw ();
+    float getFrameRate() const;
+    float getDuration() const;
+    int getWidth() const;
+    int getHeight() const;
+    void * getFrameBuffer() const;
+    int getFrameBufferStride() const;
 
 private:
     VidFileImpl *impl;

--- a/engine/src/gfx/vid_file.h
+++ b/engine/src/gfx/vid_file.h
@@ -62,7 +62,7 @@ public:
 
     bool isOpen() const throw ();
 
-    void open( const std::string &path, size_t maxDimension = 65535, bool forcePOT = false ) throw (Exception);
+    void open( const std::string &path, size_t maxDimension = 65535, bool forcePOT = false );
     void close() throw ();
 
 /** Seeks to the specified time
@@ -70,7 +70,7 @@ public:
  * @Throws EndOfStreamException when time lays past the end.
  * @Throws FrameDecodeException when an error occurs during frame decode.
  */
-    bool seek( float time ) throw (Exception);
+    bool seek( float time );
 
     float getFrameRate() const throw ();
     float getDuration() const throw ();

--- a/engine/src/gfx/vid_file.h
+++ b/engine/src/gfx/vid_file.h
@@ -22,7 +22,7 @@ public: Exception() {}
         Exception( const Exception &other ) : _message( other._message ) {}
         explicit Exception( const std::string &message ) : _message( message ) {}
         virtual ~Exception() {}
-        virtual const char * what() const
+        virtual const char * what() const noexcept
         {
             return _message.c_str();
         }

--- a/engine/vs_cubemap_gen/src/errors/errors.h
+++ b/engine/vs_cubemap_gen/src/errors/errors.h
@@ -20,7 +20,7 @@ public: Exception() {}
     Exception( const Exception &other ) : _message( other._message ) {}
     explicit Exception( const std::string &message ) : _message( message ) {}
     virtual ~Exception() {}
-    virtual const char * what() const
+    virtual const char * what() const noexcept
     {
         return _message.c_str();
     }

--- a/engine/vs_cubemap_gen/src/errors/errors.h
+++ b/engine/vs_cubemap_gen/src/errors/errors.h
@@ -19,8 +19,8 @@ private:
 public: Exception() {}
     Exception( const Exception &other ) : _message( other._message ) {}
     explicit Exception( const std::string &message ) : _message( message ) {}
-    virtual ~Exception() throw () {}
-    virtual const char * what() const throw ()
+    virtual ~Exception() {}
+    virtual const char * what() const
     {
         return _message.c_str();
     }

--- a/engine/vs_cubemap_gen/src/texture/mem_texture_impl/coords.h
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture_impl/coords.h
@@ -81,7 +81,7 @@ public:
 class ccoords
 {
     float x_, y_, z_;
-    void check_invariants(); //throw() ... but only for debugging
+    void check_invariants();
 public:
     //default ctor & dtor ok
     ccoords( float x, foat y, float z ): x_(x), y_(y), z(_z)


### PR DESCRIPTION
Partially solves #45.
Since we moved C++11, we're receiving a plethora of compilation warnings. This PR addresses one specific warning that is printed a lot:
`warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]`

Be warned, the PR is big, so review it when you have some free time.

Gameplay tests are yet to be done.