### PR TITLE
Removed support of Ubuntu 14.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,6 @@ compiler:
 jobs:
     include:
         - os: linux
-          dist: trusty
-          compiler: gcc
-          name: "Ubuntu 14.04 LTS - GCC"
-        - os: linux
-          dist: trusty
-          compiler: clang
-          name: "Ubuntu 14.04 LTS - Clang"
-        - os: linux
           dist: xenial
           compiler: gcc
           name: "Ubuntu 16.04 LTS - GCC"


### PR DESCRIPTION
Removed Ubuntu 14.04 LTS from Travis-CI, thus officially dropping support of **compilation** on that distro.

Currently this PR is a preparation/offer and will be merged after finishing the [vote on the matter](https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/40#issuecomment-623743970)

@vegastrike/core-reviewers 