### PR TITLE
Set -fno-PIE by default as a Ubuntu/Mint workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,21 +264,40 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 
-   *TIPS:*
+   __TIPS__:
 
-   To enable/disable compile-time options with cmake, use `cmake -D<option>`. Example:
+   To enable verbose output for debugging purposes (will show compilation commands), supply the `-v` flag:
+
+   ```bash
+   cmake --build . -v
+   ```
+
+   To enable/disable compile-time options with cmake, use `cmake -D<option>=<value>`. Example:
 
    ```bash
    cmake ../engine -COMPILE_WITH_FPIE=ON -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
    ```
-   In the above example, a non-Ubuntu/Mint packager has wisely decided to compile a
-   Position Independent Executable because his OS isn't
-   [buggy](https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711) when doing so.
 
-   To enable verbose output for debugging purposes (will show compilation commands), supply the `-v` flag:
-   ```bash
-   cmake --build . -v
-   ```
+   __NOTE__:
+
+   On some Ubuntu versions and derivatives, a bug exists whereby enabling
+   PIE compilation (Position Independent Executables) results in the
+   `file` utility incorrectly recognising the compiled vegastrike binary
+   as a shared library instead of a position independent shared executable
+   object.
+
+   The effect of the bug is that vegastrike can still be started from the
+   command line but that it will not be recognised as an executable by GUI
+   file managers such as Nautilus and Dolphin.
+
+   To avoid this scenario, turn off this flag by default and let packagers
+   on other distributions turn this on if their OS is able to correctly deal
+   with Position Independent Executables.
+
+   For more info, see:
+
+   - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
+   - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
 
 [Link to list of dependencies in wiki](http://vegastrike.sourceforge.net/wiki/HowTo:Compile_from_CVS)
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    To enable/disable compile-time options with cmake, use `cmake -D<option>=<value>`. Example:
 
    ```bash
-   cmake ../engine -DCOMPILE_WITH_FPIE=ON -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
+   cmake ../engine -DENABLE_PIE=ON -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
    ```
 
    __NOTE__:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ccmake ../engine
    # (configure/edit options to taste in ccmake, press 'c' to save the selected options
    # and press 'g' to update the build configuration files used by the make build tool)
-   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on your system)
+   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on the system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 
@@ -260,7 +260,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ```bash
    mkdir build & cd build
    cmake ../engine
-   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on your system)
+   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on the system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    To enable/disable compile-time options with cmake, use `cmake -D<option>=<value>`. Example:
 
    ```bash
-   cmake ../engine -COMPILE_WITH_FPIE=ON -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
+   cmake ../engine -DCOMPILE_WITH_FPIE=ON -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
    ```
 
    __NOTE__:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ccmake ../engine
    # (configure/edit options to taste in ccmake, press 'c' to save the selected options
    # and press 'g' to update the build configuration files used by the make build tool)
-   make -jN # (where N is the number of available CPU threads/cores on your system)
+   cmake --build . -jN # (where N is the number of available CPU threads/cores on your system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 
@@ -260,13 +260,24 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ```bash
    mkdir build & cd build
    cmake ../engine
-   make -jN # (where N is the number of available CPU threads/cores on your system)
+   cmake --build . -jN # (where N is the number of available CPU threads/cores on your system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
+
+   *TIPS:*
+
    To enable/disable compile-time options with cmake, use `cmake -D<option>`. Example:
 
    ```bash
-   cmake ../engine -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
+   cmake ../engine -COMPILE_WITH_FPIE=ON -DUSE_PYTHON_3=ON -DCPU_SMP=2 -DCPUINTEL_native=ON -CMAKE_BUILD_TYPE=Debug
+   ```
+   In the above example, a non-Ubuntu/Mint packager has wisely decided to compile a
+   Position Independent Executable because his OS isn't
+   [buggy](https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711) when doing so.
+
+   To enable verbose output for debugging purposes (will show compilation commands), supply the `-v` flag:
+   ```bash
+   cmake --build . -v
    ```
 
 [Link to list of dependencies in wiki](http://vegastrike.sourceforge.net/wiki/HowTo:Compile_from_CVS)

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ccmake ../engine
    # (configure/edit options to taste in ccmake, press 'c' to save the selected options
    # and press 'g' to update the build configuration files used by the make build tool)
-   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on the system)
+   cmake --build . -j $(nproc) # (where $(nproc) returns the number of available CPU threads/cores on the system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 
@@ -260,7 +260,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ```bash
    mkdir build & cd build
    cmake ../engine
-   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on the system)
+   cmake --build . -j $(nproc) # (where $(nproc) returns the number of available CPU threads/cores on the system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ccmake ../engine
    # (configure/edit options to taste in ccmake, press 'c' to save the selected options
    # and press 'g' to update the build configuration files used by the make build tool)
-   cmake --build . -jN # (where N is the number of available CPU threads/cores on your system)
+   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on your system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 
@@ -260,7 +260,7 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
    ```bash
    mkdir build & cd build
    cmake ../engine
-   cmake --build . -jN # (where N is the number of available CPU threads/cores on your system)
+   cmake --build . -j$(nproc) # (where $(nproc) returns the number of available CPU threads/cores on your system)
    mkdir ../bin && cp vegastrike ../bin/ && cp setup/vssetup ../bin/ && cd ..
    ```
 

--- a/README.md
+++ b/README.md
@@ -266,10 +266,10 @@ sudo apt-get -y install git cmake python-dev build-essential automake autoconf l
 
    __TIPS__:
 
-   To enable verbose output for debugging purposes (will show compilation commands), supply the `-v` flag:
+   To enable verbose output for debugging purposes (will show compilation commands), pass the `-- VERBOSE=1` argument:
 
    ```bash
-   cmake --build . -v
+   cmake --build . -- VERBOSE=1
    ```
 
    To enable/disable compile-time options with cmake, use `cmake -D<option>=<value>`. Example:

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -580,6 +580,46 @@ IF(DATADIR)
 ENDIF(DATADIR)
 
 
+# On some Ubuntu versions and derivatives, a bug exists whereby enabling
+# PIE compilation (Position Independent Executables) results in the
+# `file` utility incorrectly recognising the compiled vegastrike binary
+# as a shared library instead of a position independent shared executable
+# object.
+#
+# The effect of the bug is that vegastrike can still be started from the
+# command line but that it will not be recognised as an executable by GUI
+# file managers such as Nautilus and Dolphin.
+#
+# To avoid this scenario, turn off this flag by default and let packagers
+# on other distributions turn this on if their OS is able to correctly deal
+# with Position Independent Executables.
+
+# For more info, see:
+# - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
+# - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
+#
+UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
+UNSET(ENV_CFLAGS)
+UNSET(ENV_CXXFLAGS)
+SET(ENV_CFLAGS "${CMAKE_C_FLAGS}")
+SET(ENV_CXXFLAGS "${CMAKE_CXX_FLAGS}")
+OPTION(COMPILE_WITH_FPIE
+  "Enable Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint)"
+  OFF)
+IF(COMPILE_WITH_FPIE)
+  message("!! Enabling Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint) !!")
+  #SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  SET(CMAKE_C_FLAGS "${ENV_CFLAGS} -fPIC -fPIE")
+  SET(CMAKE_CXX_FLAGS "${ENV_CXXFLAGS} -fPIC -fPIE")
+ELSE(COMPILE_WITH_FPIE)
+  message("++ Disabling Position Independent Executables/Shared Libraries (Recommended on Ubuntu/Mint)")
+  #add_compile_options(-fno-PIE)
+  #add_compile_options(-fno-PIC)
+  SET(CMAKE_C_FLAGS "${ENV_CFLAGS} -fno-PIC -fno-PIE")
+  SET(CMAKE_CXX_FLAGS "${ENV_CXXFLAGS} -fno-PIC -fno-PIE")
+ENDIF(COMPILE_WITH_FPIE)
+
+
 # Debug target block. 
 SET(CMAKE_CXX_FLAGS_DEBUG " ${BUILD_OPT} ${CPU_OPTS} ${DEFINES} -include config.h -pipe -g2 -std=c++11 -Wall -fvisibility=hidden" CACHE STRING
     "Flags used by the C++ compiler during debug builds."
@@ -648,42 +688,6 @@ ELSE("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
 	MARK_AS_ADVANCED( FORCE
 		 CMAKE_CXX_FLAGS_PROFILER )
 ENDIF("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
-
-
-# On some Ubuntu versions and derivatives, a bug exists whereby enabling
-# PIE compilation (Position Independent Executables) results in the
-# `file` utility incorrectly recognising the compiled vegastrike binary
-# as a shared library instead of a position independent shared executable
-# object.
-#
-# The effect of the bug is that vegastrike can still be started from the
-# command line but that it will not be recognised as an executable by GUI
-# file managers such as Nautilus and Dolphin.
-#
-# To avoid this scenario, turn off this flag by default and let packagers
-# on other distributions turn this on if their OS is able to correctly deal
-# with Position Independent Executables.
-
-# For more info, see:
-# - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
-# - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
-#
-UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
-OPTION(COMPILE_WITH_FPIE
-  "Enable Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint)"
-  OFF)
-IF(COMPILE_WITH_FPIE)
-  message("!! Enabling Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint) !!")
-  #SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  SET(CMAKE_C_FLAGS "-fPIC -fPIE" ${CMAKE_C_FLAGS})
-  SET(CMAKE_CXX_FLAGS "-fPIC -fPIE" ${CMAKE_CXX_FLAGS})
-ELSE(COMPILE_WITH_FPIE)
-  message("++ Disabling Position Independent Executables/Shared Libraries (Recommended on Ubuntu/Mint)")
-  #add_compile_options(-fno-PIE)
-  #add_compile_options(-fno-PIC)
-  SET(CMAKE_C_FLAGS "-fno-PIC -fno-PIE" ${CMAKE_C_FLAGS})
-  SET(CMAKE_CXX_FLAGS "-fno-PIC -fno-PIE" ${CMAKE_CXX_FLAGS})
-ENDIF(COMPILE_WITH_FPIE)
 
 
 # Turn off compiling vegastrike bin

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -668,18 +668,21 @@ ENDIF("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
 # - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
 # - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
 #
-UNSET(COMPILE_WITH_FPIE CACHE)
 UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
 OPTION(COMPILE_WITH_FPIE
   "Enable Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint)"
   OFF)
 IF(COMPILE_WITH_FPIE)
   message("!! Enabling Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint) !!")
-  SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  #SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  SET(CMAKE_C_FLAGS "-fPIC -fPIE" ${CMAKE_C_FLAGS})
+  SET(CMAKE_CXX_FLAGS "-fPIC -fPIE" ${CMAKE_CXX_FLAGS})
 ELSE(COMPILE_WITH_FPIE)
   message("++ Disabling Position Independent Executables/Shared Libraries (Recommended on Ubuntu/Mint)")
-  add_compile_options(-fno-PIE)
-  add_compile_options(-fno-PIC)
+  #add_compile_options(-fno-PIE)
+  #add_compile_options(-fno-PIC)
+  SET(CMAKE_C_FLAGS "-fno-PIC -fno-PIE" ${CMAKE_C_FLAGS})
+  SET(CMAKE_CXX_FLAGS "-fno-PIC -fno-PIE" ${CMAKE_CXX_FLAGS})
 ENDIF(COMPILE_WITH_FPIE)
 
 
@@ -1033,13 +1036,11 @@ add_subdirectory(setup)
 add_subdirectory(objconv)
 
 
-
-
 # show debug output 
 get_directory_property(TEMP_DIRECTORY INCLUDE_DIRECTORIES)
-message("Default build type is Release, no cpu opts enabled. ")
-message("Building with BUILD_OPT: ${BUILD_OPT}")
-#message("Building with CFLAGS: ${CMAKE_CXX_FLAGS}")
+message("-- Default build type is Release, no cpu opts enabled. ")
+message("++ Building with BUILD_OPT: ${BUILD_OPT}")
+#message("++ Building with CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 #message("Linking with : ${TST_LIBS}")
 #message("including : ${TEMP_DIRECTORY}")
 # end debug output 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -650,6 +650,36 @@ ELSE("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
 ENDIF("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
 
 
+# On some Ubuntu versions and derivatives, a bug exists whereby enabling
+# PIE compilation (Position Independent Executables) results in the
+# `file` utility incorrectly recognising the compiled vegastrike binary
+# as a shared library instead of a position independent shared executable
+# object.
+#
+# To avoid this scenario, turn off this flag by default and let packagers
+# on other distributions turn this on if their OS is able to correctly deal
+# with Position Independent Executables.
+#
+# For more info, see:
+#
+# - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
+#
+# - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
+#
+UNSET(COMPILE_WITH_FPIE CACHE)
+UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
+OPTION(COMPILE_WITH_FPIE
+  "Enable Position Independent Executables (NOT RECOMMENDED on Debian/Ubuntu/Mint)"
+  OFF)
+IF(COMPILE_WITH_FPIE)
+  message("!! Enabling Position Independent Executables (NOT RECOMMENDED on Debian/Ubuntu/Mint) !!")
+  SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ELSE(COMPILE_WITH_FPIE)
+  message("++ Disabling Position Independent Executables (Recommended on Debian/Ubuntu/Mint)")
+  add_compile_options(-fno-PIE)
+ENDIF(COMPILE_WITH_FPIE)
+
+
 # Turn off compiling vegastrike bin
 OPTION(DISABLE_CLIENT "Disable building the vegastrike bin"
 		OFF )

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -671,14 +671,15 @@ ENDIF("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
 UNSET(COMPILE_WITH_FPIE CACHE)
 UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
 OPTION(COMPILE_WITH_FPIE
-  "Enable Position Independent Executables (NOT RECOMMENDED on Debian/Ubuntu/Mint)"
+  "Enable Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint)"
   OFF)
 IF(COMPILE_WITH_FPIE)
-  message("!! Enabling Position Independent Executables (NOT RECOMMENDED on Debian/Ubuntu/Mint) !!")
+  message("!! Enabling Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint) !!")
   SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 ELSE(COMPILE_WITH_FPIE)
-  message("++ Disabling Position Independent Executables (Recommended on Debian/Ubuntu/Mint)")
+  message("++ Disabling Position Independent Executables/Shared Libraries (Recommended on Ubuntu/Mint)")
   add_compile_options(-fno-PIE)
+  add_compile_options(-fno-PIC)
 ENDIF(COMPILE_WITH_FPIE)
 
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -598,26 +598,20 @@ ENDIF(DATADIR)
 # - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
 # - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
 #
-UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
-UNSET(ENV_CFLAGS)
-UNSET(ENV_CXXFLAGS)
-SET(ENV_CFLAGS "${CMAKE_C_FLAGS}")
-SET(ENV_CXXFLAGS "${CMAKE_CXX_FLAGS}")
-OPTION(COMPILE_WITH_FPIE
+#UNSET(CMAKE_POSITION_INDEPENDENT_CODE)
+OPTION(ENABLE_PIE
   "Enable Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint)"
   OFF)
-IF(COMPILE_WITH_FPIE)
+IF(ENABLE_PIE)
   message("!! Enabling Position Independent Executables/Shared Libraries (NOT RECOMMENDED on Ubuntu/Mint) !!")
   #SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  SET(CMAKE_C_FLAGS "${ENV_CFLAGS} -fPIC -fPIE")
-  SET(CMAKE_CXX_FLAGS "${ENV_CXXFLAGS} -fPIC -fPIE")
-ELSE(COMPILE_WITH_FPIE)
+  add_compile_options("-pie")
+  link_libraries("-pie")
+ELSE(ENABLE_PIE)
   message("++ Disabling Position Independent Executables/Shared Libraries (Recommended on Ubuntu/Mint)")
-  #add_compile_options(-fno-PIE)
-  #add_compile_options(-fno-PIC)
-  SET(CMAKE_C_FLAGS "${ENV_CFLAGS} -fno-PIC -fno-PIE")
-  SET(CMAKE_CXX_FLAGS "${ENV_CXXFLAGS} -fno-PIC -fno-PIE")
-ENDIF(COMPILE_WITH_FPIE)
+  add_compile_options("-no-pie")
+  link_libraries("-no-pie")
+ENDIF(ENABLE_PIE)
 
 
 # Debug target block. 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -656,14 +656,16 @@ ENDIF("${CMAKE_BUILD_TYPE}" STREQUAL "Profiler")
 # as a shared library instead of a position independent shared executable
 # object.
 #
+# The effect of the bug is that vegastrike can still be started from the
+# command line but that it will not be recognised as an executable by GUI
+# file managers such as Nautilus and Dolphin.
+#
 # To avoid this scenario, turn off this flag by default and let packagers
 # on other distributions turn this on if their OS is able to correctly deal
 # with Position Independent Executables.
-#
+
 # For more info, see:
-#
 # - https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711
-#
 # - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/94
 #
 UNSET(COMPILE_WITH_FPIE CACHE)

--- a/sh/vsbuild.sh
+++ b/sh/vsbuild.sh
@@ -19,7 +19,7 @@
 
 
 echo "-------------------------------"
-echo "--- vsbuild.sh | 2020-02-09 ---"
+echo "--- vsbuild.sh | 2020-05-13 ---"
 echo "-------------------------------"
 
 #----------------------------------
@@ -38,15 +38,18 @@ fi
 
 cd $BUILD_DIR
 
-# configure libraries
-cmake -DCMAKE_BUILD_TYPE=Release $@ $SRC_DIR
+# configure libraries and prepare for the Debug build having -Werror set,
+# thus gating VS commits on being warning-free at some point in the near
+# future -- see https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/50
+cmake -DCMAKE_BUILD_TYPE=Debug $@ $SRC_DIR
 
 # for a clean build only
 # mut we can do it manually
 #make clean
 
-# compile now using all cpus
-make -j$(nproc)
+# compile now using all cpus and show the compiler command line for each
+# compilation unit for easier troubleshooting in case of failures.
+cmake --build -v -j$(nproc) .
 
 cd $ROOT_DIR
 

--- a/sh/vsbuild.sh
+++ b/sh/vsbuild.sh
@@ -49,7 +49,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug $@ $SRC_DIR
 
 # compile now using all cpus and show the compiler command line for each
 # compilation unit for easier troubleshooting in case of failures.
-cmake --build -v -j$(nproc) .
+cmake --build . -v -j$(nproc)
 
 cd $ROOT_DIR
 

--- a/sh/vsbuild.sh
+++ b/sh/vsbuild.sh
@@ -44,8 +44,8 @@ cmake -DCMAKE_BUILD_TYPE=Debug $@ $SRC_DIR
 # mut we can do it manually
 #make clean
 
-# compile now using all cpus. 
-cmake --build $BUILD_DIR -j $(nproc)  
+# compile now using all cpus and show compilation commands
+cmake --build . -j $(nproc) -- VERBOSE=1
 
 cd $ROOT_DIR
 

--- a/sh/vsbuild.sh
+++ b/sh/vsbuild.sh
@@ -44,9 +44,8 @@ cmake -DCMAKE_BUILD_TYPE=Debug $@ $SRC_DIR
 # mut we can do it manually
 #make clean
 
-# compile now using all cpus and show the compiler command line for each
-# compilation unit for easier troubleshooting in case of failures.
-cmake --build $BUILD_DIR -v -j $(nproc)
+# compile now using all cpus. 
+cmake --build $BUILD_DIR -j $(nproc)  
 
 cd $ROOT_DIR
 

--- a/sh/vsbuild.sh
+++ b/sh/vsbuild.sh
@@ -32,11 +32,8 @@ BIN_DIR=$ROOT_DIR/bin
 SRC_DIR=$ROOT_DIR/engine
 COMMAND=""
 
-if [ ! -d "$BUILD_DIR" ]; then
-    mkdir $BUILD_DIR
-fi
-
-cd $BUILD_DIR
+# -p creates if the target doesn't exist, noop otherwise
+mkdir -pv $BUILD_DIR && cd $BUILD_DIR
 
 # configure libraries and prepare for the Debug build having -Werror set,
 # thus gating VS commits on being warning-free at some point in the near
@@ -49,12 +46,10 @@ cmake -DCMAKE_BUILD_TYPE=Debug $@ $SRC_DIR
 
 # compile now using all cpus and show the compiler command line for each
 # compilation unit for easier troubleshooting in case of failures.
-cmake --build . -v -j$(nproc)
+cmake --build $BUILD_DIR -v -j$(nproc)
 
 cd $ROOT_DIR
 
-if [ ! -d "$BIN_DIR" ]; then
-    mkdir $BIN_DIR
-fi
+mkdir -pv $BIN_DIR
 
-cp $BUILD_DIR/{vegastrike,setup/vssetup,objconv/mesh_tool} $BIN_DIR
+cp -v $BUILD_DIR/{vegastrike,setup/vssetup,objconv/mesh_tool} $BIN_DIR

--- a/sh/vsbuild.sh
+++ b/sh/vsbuild.sh
@@ -46,7 +46,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug $@ $SRC_DIR
 
 # compile now using all cpus and show the compiler command line for each
 # compilation unit for easier troubleshooting in case of failures.
-cmake --build $BUILD_DIR -v -j$(nproc)
+cmake --build $BUILD_DIR -v -j $(nproc)
 
 cd $ROOT_DIR
 


### PR DESCRIPTION
Older versions of Ubuntu and its derivates have an issue where the
`file` utility will interpret Position Independent Executables as
shared libraries:

https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711

As a workaround, allow setting the option `ENABLE_PIE`
(defaults to `OFF`) and add a suitable message for maintainers in both
the CMake code, during configuration runs and in ccmake.

Update the build instructions in `README.md` to reflect this change.

Additionally, switch sh/vsbuild.sh to the Debug target (see #50) and enable verbose compilation by default to make it easier to spot errors in CI.

Closes #94