### PR TITLE
Removed config.h includes due to redundancy

### DIFF
--- a/engine/objconv/mesher/to_OgreMesh.cpp
+++ b/engine/objconv/mesher/to_OgreMesh.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 
 #ifdef HAVE_OGRE
 

--- a/engine/src/SharedPool.h
+++ b/engine/src/SharedPool.h
@@ -1,6 +1,5 @@
 #ifndef __STRINGPOOL_H__INCLUDED__
 #define __STRINGPOOL_H__INCLUDED__
-#include "config.h"
 #include <string>
 #include "gnuhash.h"
 

--- a/engine/src/VSFileXMLSerializer.cpp
+++ b/engine/src/VSFileXMLSerializer.cpp
@@ -1,5 +1,4 @@
 #include "VSFileXMLSerializer.h"
-#include "config.h"
 
 #include "vsfilesystem.h"
 #include "audio/Exceptions.h"

--- a/engine/src/audio/CodecRegistry.cpp
+++ b/engine/src/audio/CodecRegistry.cpp
@@ -4,7 +4,6 @@
 
 #include "CodecRegistry.h"
 #include "codecs/Codec.h"
-#include "config.h"
 
 #include <algorithm>
 #include <iostream>

--- a/engine/src/audio/Listener.cpp
+++ b/engine/src/audio/Listener.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Listener.h"
-#include "config.h"
 
 #include <math.h>
 

--- a/engine/src/audio/RenderableListener.cpp
+++ b/engine/src/audio/RenderableListener.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "RenderableListener.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/RenderableSource.cpp
+++ b/engine/src/audio/RenderableSource.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "RenderableSource.h"
-#include "config.h"
 #include <stdio.h>
 
 namespace Audio {

--- a/engine/src/audio/Renderer.cpp
+++ b/engine/src/audio/Renderer.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Renderer.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/Scene.cpp
+++ b/engine/src/audio/Scene.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Scene.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/SceneManager.cpp
+++ b/engine/src/audio/SceneManager.cpp
@@ -2,7 +2,6 @@
 // C++ Implementation: Audio::SceneManager
 //
 #include "SceneManager.h"
-#include "config.h"
 
 #include "Renderer.h"
 #include "RenderableSource.h"

--- a/engine/src/audio/SimpleScene.cpp
+++ b/engine/src/audio/SimpleScene.cpp
@@ -4,7 +4,6 @@
 
 #include "SimpleScene.h"
 #include "SimpleSource.h"
-#include "config.h"
 
 #include "SceneManager.h"
 

--- a/engine/src/audio/SimpleSound.cpp
+++ b/engine/src/audio/SimpleSound.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "SimpleSound.h"
-#include "config.h"
 
 #include "CodecRegistry.h"
 #include "Stream.h"

--- a/engine/src/audio/SimpleSource.cpp
+++ b/engine/src/audio/SimpleSource.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "SimpleSource.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/Sound.cpp
+++ b/engine/src/audio/Sound.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Sound.h"
-#include "config.h"
 
 #include "utils.h"
 

--- a/engine/src/audio/SoundBuffer.cpp
+++ b/engine/src/audio/SoundBuffer.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "SoundBuffer.h"
-#include "config.h"
 
 #include <stdlib.h>
 #include <memory.h>

--- a/engine/src/audio/Source.cpp
+++ b/engine/src/audio/Source.cpp
@@ -4,7 +4,6 @@
 
 #include "Source.h"
 #include "SourceListener.h"
-#include "config.h"
 #include "utils.h"
 
 #include <math.h>

--- a/engine/src/audio/SourceTemplate.cpp
+++ b/engine/src/audio/SourceTemplate.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "SourceTemplate.h"
-#include "config.h"
 
 #include <math.h>
 

--- a/engine/src/audio/Stream.cpp
+++ b/engine/src/audio/Stream.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Stream.h"
-#include "config.h"
 
 #include <utility>
 #include <cstring>

--- a/engine/src/audio/TemplateManager.cpp
+++ b/engine/src/audio/TemplateManager.cpp
@@ -2,7 +2,6 @@
 // C++ Implementation: Audio::TemplateManager
 //
 #include "TemplateManager.h"
-#include "config.h"
 
 #include <utility>
 #include <assert.h>

--- a/engine/src/audio/codecs/Codec.cpp
+++ b/engine/src/audio/codecs/Codec.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "Codec.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/codecs/FFCodec.cpp
+++ b/engine/src/audio/codecs/FFCodec.cpp
@@ -2,7 +2,6 @@
 // C++ Implementation: Audio::FFCodec
 //
 
-#include "config.h"
 
 #ifdef HAVE_FFMPEG
 
@@ -10,7 +9,6 @@
 
 #include "FFCodec.h"
 #include "FFStream.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/codecs/FFStream.cpp
+++ b/engine/src/audio/codecs/FFStream.cpp
@@ -2,7 +2,6 @@
 // C++ Implementation: Audio::OggStream
 //
 
-#include "config.h"
 
 #ifdef HAVE_FFMPEG
 

--- a/engine/src/audio/codecs/OggCodec.cpp
+++ b/engine/src/audio/codecs/OggCodec.cpp
@@ -2,7 +2,6 @@
 // C++ Implementation: Audio::OggCodec
 //
 
-#include "config.h"
 
 #ifdef HAVE_OGG
 
@@ -11,7 +10,6 @@
 #include "OggCodec.h"
 #include "OggStream.h"
 #include "OggData.h"
-#include "config.h"
 
 namespace Audio {
 

--- a/engine/src/audio/codecs/OggData.cpp
+++ b/engine/src/audio/codecs/OggData.cpp
@@ -2,7 +2,6 @@
 // C++ implementation: Audio::__impl::OggData
 //
 
-#include "config.h"
 
 #ifdef HAVE_OGG
 #include <sys/types.h>
@@ -10,7 +9,6 @@
 #include <stdint.h>
 #endif
 #include "OggData.h"
-#include "config.h"
 #include "../Format.h"
 #include "../Exceptions.h"
 

--- a/engine/src/audio/codecs/OggStream.cpp
+++ b/engine/src/audio/codecs/OggStream.cpp
@@ -2,13 +2,11 @@
 // C++ Implementation: Audio::OggStream
 //
 
-#include "config.h"
 
 #ifdef HAVE_OGG
 
 #include "OggStream.h"
 #include "OggData.h"
-#include "config.h"
 
 #include <utility>
 #include <limits>

--- a/engine/src/audio/renderers/OpenAL/OpenALHelpers.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALHelpers.cpp
@@ -7,7 +7,6 @@
 #include "../../Types.h"
 #include "../../Exceptions.h"
 
-#include "config.h"
 #include "al.h"
 
 #include <string>

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableListener.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableListener.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "OpenALRenderableListener.h"
-#include "config.h"
 
 #include "al.h"
 

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableSource.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableSource.cpp
@@ -4,7 +4,6 @@
 #include "OpenALRenderableSource.h"
 #include "OpenALSimpleSound.h"
 #include "OpenALHelpers.h"
-#include "config.h"
 
 #include "al.h"
 

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderableStreamingSource.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderableStreamingSource.cpp
@@ -4,7 +4,6 @@
 #include "OpenALRenderableStreamingSource.h"
 #include "OpenALStreamingSound.h"
 #include "OpenALHelpers.h"
-#include "config.h"
 
 #include "al.h"
 

--- a/engine/src/audio/renderers/OpenAL/OpenALRenderer.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderer.cpp
@@ -5,7 +5,6 @@
 #include "OpenALRenderer.h"
 #include "BorrowedOpenALRenderer.h"
 #include "OpenALHelpers.h"
-#include "config.h"
 
 #include "al.h"
 

--- a/engine/src/audio/renderers/OpenAL/OpenALSimpleSound.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALSimpleSound.cpp
@@ -4,7 +4,6 @@
 
 #include "OpenALSimpleSound.h"
 #include "OpenALHelpers.h"
-#include "config.h"
 
 #include "../../CodecRegistry.h"
 #include "../../Stream.h"

--- a/engine/src/audio/renderers/OpenAL/OpenALStreamingSound.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALStreamingSound.cpp
@@ -4,7 +4,6 @@
 
 #include "OpenALStreamingSound.h"
 #include "OpenALHelpers.h"
-#include "config.h"
 
 #include "../../CodecRegistry.h"
 #include "../../Stream.h"

--- a/engine/src/audio/renderers/OpenAL/al.h
+++ b/engine/src/audio/renderers/OpenAL/al.h
@@ -1,7 +1,6 @@
 #ifndef __AL_INCLUDES__INCLUDED__
 #define __AL_INCLUDES__INCLUDED__
 
-#include "config.h"
 
 #ifdef __APPLE__
     #include <al.h>

--- a/engine/src/audio/test.cpp
+++ b/engine/src/audio/test.cpp
@@ -1,7 +1,6 @@
 //
 // C++ Implementation: Audio::Test
 //
-#include "config.h"
 
 #include "Types.h"
 #include "Exceptions.h"

--- a/engine/src/audio/utils.cpp
+++ b/engine/src/audio/utils.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "utils.h"
-#include "config.h"
 
 #include "universe_util.h"
 #include "lin_time.h"

--- a/engine/src/cmd/ai/aggressive.cpp
+++ b/engine/src/cmd/ai/aggressive.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <list>
 #include <vector>
 #include "aggressive.h"

--- a/engine/src/cmd/ai/pythonai.cpp
+++ b/engine/src/cmd/ai/pythonai.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <boost/version.hpp>
 #include <boost/python/class.hpp>
 

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <algorithm>
 #include "cs_python.h"
 #include "base.h"

--- a/engine/src/cmd/base_util.h
+++ b/engine/src/cmd/base_util.h
@@ -2,7 +2,6 @@
 #ifndef _BASE_UTIL_H_
 #define _BASE_UTIL_H_
 
-#include "config.h"
 #include <string>
 #include <boost/version.hpp>
 #if BOOST_VERSION != 102800

--- a/engine/src/cmd/base_xml.cpp
+++ b/engine/src/cmd/base_xml.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <boost/version.hpp>
 #if BOOST_VERSION != 102800
 #include <boost/python/object.hpp>

--- a/engine/src/cmd/collide2/Ice/IcePreprocessor.h
+++ b/engine/src/cmd/collide2/Ice/IcePreprocessor.h
@@ -11,7 +11,6 @@
 // Include Guard
 #ifndef __ICEPREPROCESSOR_H__
 #define __ICEPREPROCESSOR_H__
-#include "config.h"
 
 	// Check platform
 	#if defined( _WIN32 ) || defined( WIN32 )

--- a/engine/src/cmd/collide2/csgeom2/opmath.h
+++ b/engine/src/cmd/collide2/csgeom2/opmath.h
@@ -23,7 +23,6 @@
 #define HAVE_ISNORMAL 1  
 
 
-#include "config.h"
 #include <math.h>
 #include <float.h>
 #include "cmd/collide2/opcodealgorithms.h"

--- a/engine/src/cmd/collide2/opcodetypes.h
+++ b/engine/src/cmd/collide2/opcodetypes.h
@@ -20,7 +20,6 @@
 #define __CS_CSTYPES_H__
 
 // config.h is the VS ./configure determined header.
-#include "config.h" 
 #include <float.h>
 #include <wchar.h>
 #if defined(_WIN32) && !defined(__CYGWIN__) // && defined(_MSC_VER)

--- a/engine/src/cmd/csv.h
+++ b/engine/src/cmd/csv.h
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <string>
 #include <vector>
 #include <gnuhash.h>

--- a/engine/src/cmd/pilot.h
+++ b/engine/src/cmd/pilot.h
@@ -1,4 +1,3 @@
-#include "config.h"
 #include "gnuhash.h"
 #include <vector>
 class Animation;

--- a/engine/src/cmd/script/c_alike/c_alike.h
+++ b/engine/src/cmd/script/c_alike/c_alike.h
@@ -23,7 +23,6 @@
   c_alike scripting written by Alexander Rawass <alexannika@users.sourceforge.net>
 */
 
-#include "config.h"
 
 #include <stdio.h>
 

--- a/engine/src/cmd/script/director.cpp
+++ b/engine/src/cmd/script/director.cpp
@@ -22,7 +22,6 @@
 /*
  *  xml Mission Scripting written by Alexander Rawass <alexannika@users.sourceforge.net>
  */
-#include "config.h"
 #include <boost/version.hpp>
 #include <boost/python/class.hpp>
 #include "python/python_class.h"

--- a/engine/src/cmd/script/director_generic.cpp
+++ b/engine/src/cmd/script/director_generic.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 
 #ifdef HAVE_PYTHON
 #include <boost/version.hpp>

--- a/engine/src/cmd/script/director_server.cpp
+++ b/engine/src/cmd/script/director_server.cpp
@@ -22,7 +22,6 @@
 /*
  *  xml Mission Scripting written by Alexander Rawass <alexannika@users.sourceforge.net>
  */
-#include "config.h"
 #include "python/python_class.h"
 #include <boost/version.hpp>
 #include <boost/python/class.hpp>

--- a/engine/src/cmd/script/flightgroup.h
+++ b/engine/src/cmd/script/flightgroup.h
@@ -1,6 +1,5 @@
 #ifndef _FLIGHTGROUP_H_
 #define _FLIGHTGROUP_H_
-#include "config.h"
 #include "cmd/container.h"
 #include "mission.h"
 #include <string>

--- a/engine/src/cmd/script/mission.cpp
+++ b/engine/src/cmd/script/mission.cpp
@@ -22,7 +22,6 @@
 /*
  *  xml Mission written by Alexander Rawass <alexannika@users.sourceforge.net>
  */
-#include "config.h"
 #include "cs_python.h"
 #include <math.h>
 #include <stdlib.h>

--- a/engine/src/cmd/script/mission.h
+++ b/engine/src/cmd/script/mission.h
@@ -27,7 +27,6 @@
 
 #ifndef _MISSION_H_
 #define _MISSION_H_
-#include "config.h"
 #include <gnuhash.h>
 
 #include <expat.h>

--- a/engine/src/cmd/script/pythonmission.cpp
+++ b/engine/src/cmd/script/pythonmission.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <boost/version.hpp>
 #include "cs_python.h"
 #include <math.h>

--- a/engine/src/cmd/unit_const_cache.h
+++ b/engine/src/cmd/unit_const_cache.h
@@ -1,6 +1,5 @@
 #ifndef __UNIT_CONST_CACHE_H
 #define __UNIT_CONST_CACHE_H
-#include "config.h"
 #include "hashtable.h"
 #include <string>
 #include <gnuhash.h>

--- a/engine/src/cmd/unit_factory.h
+++ b/engine/src/cmd/unit_factory.h
@@ -19,7 +19,6 @@
  */
 #ifndef _UNIT_FACTORY_H_
 #define _UNIT_FACTORY_H_
-#include "config.h"
 #include <string>
 
 #include "cmd/planet_generic.h"

--- a/engine/src/cmd/unit_generic.cpp
+++ b/engine/src/cmd/unit_generic.cpp
@@ -1,6 +1,5 @@
 // -*- mode: c++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
-#include "config.h"
 #include <set>
 #include "configxml.h"
 #include "audiolib.h"

--- a/engine/src/config_xml.h
+++ b/engine/src/config_xml.h
@@ -26,7 +26,6 @@
 #ifndef _VEGACONFIG_H_
 #define _VEGACONFIG_H_
 
-#include "config.h"
 #include <expat.h>
 #include <string>
 #include <gnuhash.h>

--- a/engine/src/easydom.h
+++ b/engine/src/easydom.h
@@ -25,7 +25,6 @@
 
 #ifndef _EASYDOM_H_
 #define _EASYDOM_H_
-#include "config.h"
 #include <expat.h>
 #include <string>
 #include <vector>

--- a/engine/src/endianness.h
+++ b/engine/src/endianness.h
@@ -2,7 +2,6 @@
 #define _ENDIANNESS_H
 double DONTUSE__NXSwapBigDoubleToLittleEndian( double x );
 
-#include "config.h"
 
 #if defined (__HAIKU__) //For unknow reasons, Haiku don't fit into any case below
     #include <endian.h>

--- a/engine/src/faction_generic.h
+++ b/engine/src/faction_generic.h
@@ -1,6 +1,5 @@
 #ifndef __FACTIONGENERIC_H
 #define __FACTIONGENERIC_H
-#include "config.h"
 #include <string>
 #include <boost/shared_ptr.hpp>
 //#include <gnuhash.h>

--- a/engine/src/ffmpeg_init.cpp
+++ b/engine/src/ffmpeg_init.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "vsfilesystem.h"
-#include "config.h"
 #include "ffmpeg_init.h"
 
 #include <string.h>

--- a/engine/src/gfx/cockpit_xml.cpp
+++ b/engine/src/gfx/cockpit_xml.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include "cockpit.h"
 #include "xml_support.h"
 #include "gauge.h"

--- a/engine/src/gfx/soundcontainer.cpp
+++ b/engine/src/gfx/soundcontainer.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 
 #include <string>
 

--- a/engine/src/gfx/soundcontainer_aldrv.cpp
+++ b/engine/src/gfx/soundcontainer_aldrv.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 
 #include "soundcontainer_aldrv.h"
 #include "audiolib.h"

--- a/engine/src/gfx/soundcontainer_generic.cpp
+++ b/engine/src/gfx/soundcontainer_generic.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 
 #include <string>
 

--- a/engine/src/gfx/technique.cpp
+++ b/engine/src/gfx/technique.cpp
@@ -1,7 +1,6 @@
 //
 //C++ Implementation: Technique
 //
-#include "config.h"
 
 #include <exception>
 #include <map>

--- a/engine/src/gfx/vid_file.cpp
+++ b/engine/src/gfx/vid_file.cpp
@@ -4,7 +4,6 @@
 
 #include "vid_file.h"
 #include "vsfilesystem.h"
-#include "config.h"
 #include "ffmpeg_init.h"
 
 #include <string.h>

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -19,7 +19,6 @@
 #include <assert.h>
 #include <sstream>
 
-#include "config.h"
 #include "gl_globals.h"
 #include "winsys.h"
 #include "vs_globals.h"

--- a/engine/src/gldrv/winsys.h
+++ b/engine/src/gldrv/winsys.h
@@ -18,7 +18,6 @@
  */
 #ifndef WINSYS_H
 #define WINSYS_H 1
-#include "config.h"
 #ifndef UCHAR_MAX
 #define UCHAR_MAX 255
 #endif

--- a/engine/src/gnuhash.h
+++ b/engine/src/gnuhash.h
@@ -1,6 +1,5 @@
 #ifndef _GNUHASH_H_
 #define _GNUHASH_H_
-#include "config.h"
 #include <unordered_map>
 
 #define vsUMap     std::unordered_map

--- a/engine/src/hashtable.h
+++ b/engine/src/hashtable.h
@@ -21,7 +21,6 @@
 
 #ifndef _HASHTABLE_H_
 #define _HASHTABLE_H_
-#include "config.h"
 #include "gnuhash.h"
 #include <math.h>
 #include <string>

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -22,7 +22,6 @@
 /*
  *  Joystick support written by Alexander Rawass <alexannika@users.sourceforge.net>
  */
-#include "config.h"
 #include "in_kb_data.h"
 #ifndef _JOYSTICK_H_
 #define _JOYSTICK_H_

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -16,7 +16,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
-#include "config.h"
 #include "cs_python.h"
 #include "audio/test.h"
 #if defined (HAVE_SDL)

--- a/engine/src/python/init.cpp
+++ b/engine/src/python/init.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #ifdef HAVE_PYTHON
 #include <boost/version.hpp>
 #if defined (_MSC_VER) && _MSC_VER <= 1200

--- a/engine/src/python/init.h
+++ b/engine/src/python/init.h
@@ -1,5 +1,4 @@
 //#define HAVE_PYTHON
-#include "config.h"
 
 #ifdef HAVE_PYTHON
 #ifndef PY_INIT_H_

--- a/engine/src/python/python_class.h
+++ b/engine/src/python/python_class.h
@@ -1,6 +1,5 @@
 #ifndef __PYTHON_CLASS_H__
 #define __PYTHON_CLASS_H__
-#include "config.h"
 //This takes care of the fact that several systems use the _POSIX_C_SOURCES
 //variable and don't set them to the same thing.
 //Python.h sets and uses it

--- a/engine/src/python/unit_exports.cpp
+++ b/engine/src/python/unit_exports.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <boost/version.hpp>
 #if BOOST_VERSION != 102800
 #include <boost/python.hpp>

--- a/engine/src/python/unit_method_defs.cpp
+++ b/engine/src/python/unit_method_defs.cpp
@@ -1,5 +1,4 @@
 #if _MSC_VER <= 1200
-#include "config.h"
 #include <boost/version.hpp>
 #include <boost/python.hpp>
 typedef boost::python::dict       BoostPythonDictionary;

--- a/engine/src/python/unit_wrapper.cpp
+++ b/engine/src/python/unit_wrapper.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <boost/version.hpp>
 #include <boost/python.hpp>
 typedef boost::python::dict       BoostPythonDictionary;

--- a/engine/src/python/universe_util_export.cpp
+++ b/engine/src/python/universe_util_export.cpp
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <boost/version.hpp>
 #include <boost/python.hpp>
 #include "python_class.h"

--- a/engine/src/rendertext.cpp
+++ b/engine/src/rendertext.cpp
@@ -1,6 +1,5 @@
 //rendertext.cpp: based on Don's gl_text.cpp
 //Based on Aardarples rendertext
-#include "config.h"
 #include "command.h"
 
 #include "vegastrike.h"

--- a/engine/src/star_system_generic.h
+++ b/engine/src/star_system_generic.h
@@ -1,6 +1,5 @@
 #ifndef _GENERICSYSTEM_H_
 #define _GENERICSYSTEM_H_
-#include "config.h"
 #include <expat.h>
 #include <string>
 #include <vector>

--- a/engine/src/vs_globals.h
+++ b/engine/src/vs_globals.h
@@ -1,6 +1,5 @@
 #ifndef __VS_GLOBALS_H_
 #define __VS_GLOBALS_H_
-#include "config.h"
 #include <vector>
 
 #include "universe_generic.h"

--- a/engine/src/vsfilesystem.cpp
+++ b/engine/src/vsfilesystem.cpp
@@ -22,7 +22,6 @@ struct dirent
 #include <dirent.h>
 #endif
 #include <sys/stat.h>
-#include "config.h"
 #include "configxml.h"
 #include "vsfilesystem.h"
 #include "vs_globals.h"

--- a/engine/src/vsfilesystem.h
+++ b/engine/src/vsfilesystem.h
@@ -1,6 +1,5 @@
 #ifndef __VSFILESYS_H
 #define __VSFILESYS_H
-#include "config.h"
 #include <stdio.h>
 #include <string>
 #include <vector>

--- a/engine/src/xml_support.h
+++ b/engine/src/xml_support.h
@@ -1,7 +1,6 @@
 #ifndef _XML_SUPPORT_H_
 #define _XML_SUPPORT_H_
 
-#include "config.h"
 #include <stdio.h>
 #include <string>
 #ifndef WIN32


### PR DESCRIPTION
Since we have -include config.h as a compiler parameter, the compiler adds automatically the header into each file it compiles.
The presence of this includes breaks windows compilation.