### PR TITLE
Fix resume crash on 0.6.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ext/
 *.pyc
 build-engine-Desktop-Default/
 packages/
+*.log

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -572,9 +572,9 @@ IF (POLICY CMP0072)
   CMAKE_POLICY (SET CMP0072 NEW)
 ENDIF ()
 
-# Set the default build type to Release
+# Set the default build type to Debug
 IF (NOT CMAKE_BUILD_TYPE)
-    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Release, Debug, Profiler" FORCE )
+    SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Release, Debug, Profiler" FORCE )
 ENDIF (NOT CMAKE_BUILD_TYPE)
 
 IF (NOT BUILD_OPT)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -714,7 +714,7 @@ ENDIF ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
 
 
 # Profiler Target block
-SET(CMAKE_CXX_FLAGS_PROFILER " ${BUILD_OPT} ${CPU_OPTS} -pg -g2 -DNV_CUBE_MAP -DBOOST_PYTHON_NO_PY_SIGNATURES -include config.h -pipe -std=c++11 -Wall -Wno-unused-function -Wno-unused-variable" CACHE STRING
+SET(CMAKE_CXX_FLAGS_PROFILER " ${BUILD_OPT} ${CPU_OPTS} ${DEFINES} -pg -g2 -include config.h -pipe -std=c++11 -Wall -Wno-unused-function -Wno-unused-variable" CACHE STRING
     "Flags used by the C++ compiler during profiler builds."
     FORCE
 )

--- a/engine/src/cmd/ai/firekeyboard.cpp
+++ b/engine/src/cmd/ai/firekeyboard.cpp
@@ -529,9 +529,12 @@ void FireKeyboard::ECMKey( const KBData&, KBSTATE k )
 
 void FireKeyboard::FireKey( const KBData&, KBSTATE k )
 {
-    if (g().firekey == DOWN && k == UP)
+    if (g().firekey == DOWN && k == UP) {
         return;
-    if (k == UP && g().firekey == RELEASE) {} else {
+    }
+    if (k == UP && g().firekey == RELEASE) {
+        
+    } else {
         g().firekey = k;
     }
 }
@@ -732,8 +735,10 @@ void FireKeyboard::NearestJumpKey( const KBData&, KBSTATE k )
 
 void FireKeyboard::TogglePause( const KBData&, KBSTATE k )
 {
-    if (g().togglepausekey != PRESS)
+    if (k == PRESS) {
+        VSFileSystem::vs_dprintf(1, "FireKeyboard::TogglePause(): Pause key detected\n");
         g().togglepausekey = k;
+    }
 }
 
 
@@ -1873,15 +1878,18 @@ void FireKeyboard::Execute()
         refresh_target     = true;
     }
     if (f().togglepausekey == PRESS) {
+        VSFileSystem::vs_dprintf(1, "Pause key pressed\n");
         f().togglepausekey = DOWN;
         if (toggle_pause())
-	{
-	    _Universe->AccessCockpit()->OnPauseBegin();
-	}
-	else
-	{
-	    _Universe->AccessCockpit()->OnPauseEnd();
-	}
+        {
+            VSFileSystem::vs_dprintf(1, "Calling _Universe->AccessCockpit()->OnPauseBegin();\n");
+            _Universe->AccessCockpit()->OnPauseBegin();
+        }
+        else
+        {
+            VSFileSystem::vs_dprintf(1, "Calling _Universe->AccessCockpit()->OnPauseEnd();\n");
+            _Universe->AccessCockpit()->OnPauseEnd();
+        }
     }
     if (f().weapk == PRESS || f().rweapk == PRESS) {
         bool forward;

--- a/engine/src/lin_time.cpp
+++ b/engine/src/lin_time.cpp
@@ -123,6 +123,10 @@ bool toggle_pause()
     else
     {
         fprintf(stderr, "toggle_pause() in lin_time.cpp: Pausing\n");
+        
+        // If you make this value too small, then when the user presses the
+        // Pause key again to resume, the game will take too long to respond.
+        // It will effectively stay frozen.
         setTimeCompression(.00001);
         paused = true;
     }

--- a/engine/src/lin_time.cpp
+++ b/engine/src/lin_time.cpp
@@ -113,15 +113,18 @@ void setTimeCompression( float tc )
 bool toggle_pause()
 {
     static bool paused = false;
+    fprintf(stderr, "toggle_pause() called in lin_time.cpp\n");
     if (paused)
     {
+        fprintf(stderr, "toggle_pause() in lin_time.cpp: Resuming (unpausing)\n");
         setTimeCompression(1);
         paused = false;
     }
     else
     {
-        setTimeCompression(.0000001);
-	paused = true;
+        fprintf(stderr, "toggle_pause() in lin_time.cpp: Pausing\n");
+        setTimeCompression(.0001);
+        paused = true;
     }
     return paused;
 }

--- a/engine/src/lin_time.cpp
+++ b/engine/src/lin_time.cpp
@@ -123,7 +123,7 @@ bool toggle_pause()
     else
     {
         fprintf(stderr, "toggle_pause() in lin_time.cpp: Pausing\n");
-        setTimeCompression(.0001);
+        setTimeCompression(.00001);
         paused = true;
     }
     return paused;

--- a/engine/src/main_loop.cpp
+++ b/engine/src/main_loop.cpp
@@ -1024,6 +1024,7 @@ void main_loop()
 
 #ifndef NO_GFX
     //BOOST_LOG_TRIVIAL(trace) << boost::format("Drawn %1% vertices in %2% batches") % gl_vertices_this_frame % gl_batches_this_frame;
+    VSFileSystem::vs_dprintf(3, "Drawn X vertices in Y batches\n");
     gl_vertices_this_frame = 0;
     gl_batches_this_frame = 0;
 #endif


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
Closes #28 

Purpose:
- What is this pull request trying to do? **Make it so that users can pause and resume the game freely, without crashes.**
- What release is this for? **0.6.0**
- Is there a project or milestone we should apply this to? **0.6.x**
