### PR TITLE
Treat ppc64le as little endian architecture. Fix #160

### DIFF
--- a/engine/src/posh.h
+++ b/engine/src/posh.h
@@ -797,7 +797,7 @@
 #  define POSH_LITTLE_ENDIAN
 #  define POSH_BIG_ENDIAN
 #elif defined POSH_CPU_X86 || defined POSH_CPU_AXP || defined POSH_CPU_STRONGARM || defined POSH_OS_WIN32 \
-    || defined POSH_OS_WINCE || defined __MIPSEL__
+    || defined POSH_OS_WINCE || defined __MIPSEL__ || (defined POSH_CPU_PPC && defined __LITTLE_ENDIAN__)
 #  define POSH_LITTLE_ENDIAN 1
 #  define POSH_ENDIAN_STRING "little"
 #else


### PR DESCRIPTION
Previously, almost all non-x86 architectures were treated as big endian by the `posh` abstraction layer. This is incorrect for ppc64le, which is a little endian architecture. This PR causes vegastrike to correctly treat ppc64le as little endian, avoiding incorrect byte swaps to correct endianness.
I think other architectures such as aarch64 might be affected as well, but I'm not an expert on those.
(This posh layer seems very arcane.. we should consider switching to a more modern abstraction layer in the long term, some of the things it does are covered by recent versions of the C++ standard such as data types of guaranteed length)

Code Changes:
- [ ] Have the PR Validation Tests been run? No, but I would argue that this change is minimal and only affects ppc64 users, of which there probably are none besides me at the moment ;)
- [ ] This is a documentation change only

Issues:
- Resolves #160

Purpose:
- What is this pull request trying to do? See above
- What release is this for? I would consider this a hotfix, so merge at earliest convenience please :) 
- Is there a project or milestone we should apply this to? Don't think so
