### PR TITLE
Fixes the empty name in the dynamically generated universe xml that i…

### DIFF
--- a/engine/src/galaxy_gen.cpp
+++ b/engine/src/galaxy_gen.cpp
@@ -565,7 +565,7 @@ void WriteUnit( const string &tag,
                 float thisloy = 0 )
 {
     Tab();
-    f.Fprintf( "<%s name=\"%s\" file=\"%s\" ", tag.c_str(), name.c_str(), filename.c_str() );
+    f.Fprintf( "<%s name=\"%s\" file=\"%s\" ", tag.c_str(), getRandName( names ).c_str(), filename.c_str() );
     if (nebfile.length() > 0)
         f.Fprintf( "nebfile=\"%s\" ", nebfile.c_str() );
     f.Fprintf( "ri=\"%f\" rj=\"%f\" rk=\"%f\" si=\"%f\" sj=\"%f\" sk=\"%f\" ", r.i, r.j, r.k, s.i, s.j, s.k );


### PR DESCRIPTION
…s saved in the home directory


Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
The dynamically generated universe is saved in the home directory under sectors. 
In some solar systems, there is units with an empty name. This fix fills that empty variable with a random name. 

There is still Unit naming weirdness going on that is unrelated to this fix, as the Python scripts also add units to the universe, but they are not saved in the sectors sub directory. I am still on the hunt for those, but as they reside in Assets-Production, I'll make a PR on that repository when I have them sorted.

Purpose:
- What is this pull request trying to do?
Fix empty names for some installations in the universe.
- What release is this for?
Works on all of them. 
- Is there a project or milestone we should apply this to?
Nope.