### PR TITLE
Enable Release CD on 0.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,19 +68,20 @@ deploy:
 #    # GitHub Releases
     provider: releases
     api_key:
-#        secure: "Encrypted GitHub Auth Key" <-- put this in the secrets
+        secure: m79xOkFq1yArD2c2rBVmbDTEly8jaKgmPy8CsncavCgD1d4pAq+FPdTKFgAhUrGBqOB3f/DP/J2W6VIvYiOs+x9bhCLS07OGE/euylm7UFjWX1dQenPMlTNaTb15YOthWsM8zYPSeb4sOl5aURedenV8sYK9kOU6OQ4ALBsCjNmVHo/3KMPxVoC+jIqsihl4Gc6Lkz2JW/Q/fQYg7gwDEKErq1L7UiiUfo9z5qs9z3ru6ZNkXmtedZpKyf0RsaUX769+POwF+CE2FDpK1t2gm+ga6dLu3au8NhS+FZZvQPk7ns9fbmNE/qb8c+DtGzZkIPDoDRtpZEHGcK3JZFdRatNnx4I1LleSNaTYOi/U+BmEtaEp7jL5MhVbYszodzAKeNaw9ZKnsmVFiOBsa/Rt5YLgHFtJ4g5UwAOPuPvEpgJhgE1lLxyjPyZ0P2LDrmIRIyKbMd7Ox1QAMFSd1RDvf7IubF+/Kt4nO8xmG3J1M/vUJBxKu+oJcbjR4fNo2GVbQfJ+uIU0z7vHm0b7mX/k7NVrnw22A4iy5Omu8XFDtVWRSQZvRlcsua4w1egEBfW0F/txh+7gUOhlo6O4hXVawBqZlUt04EiVUNKOtpGRpCNItk5TixN08gWbRIMzDNg6ZeWLuA0aMs5GhYImurE6dBu7NZ+Z7xakAy72SUxq09g=
     file:
        # Upload files in the `packages` directory
        - packages/*
 #    # Ensure the build doesn't get cleaned up so the files are avialable
 #    # for the release build
-    skip_clean: true
+    skip_cleanup: true
 #    # release is a draft so it can be edited, updated, etc.
     draft: true
     prerelease: true
 #    # GitHub Releases requires a tag; this guarnatees a tag is set
     on:
         tags: true
+        repo: vegastrike/Vega-Strike-Engine-Source
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,7 @@ before_deploy:
 deploy:
 #    # GitHub Releases
     provider: releases
-    api_key:
-        secure: $GITHUB_TOKEN
+    api_key: $GITHUB_TOKEN
     file:
        # Upload files in the `packages` directory
        - packages/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,27 +59,28 @@ script:
 # CI/CD hookups
 # See https://docs.travis-ci.com/user/deployment/releases/
 # for what to do for `before_deploy` and `deploy` sections
-#before_deploy:
+before_deploy:
 #  - pull the submodule here
-#  - ./sh/vspackage.sh
+  - ./sh/vspackage.sh
 #  - export TRAVIS_TAG="composite tag name here"
 #  - git tag ${TRAVIS_TAG}
-#deploy:
+deploy:
 #    # GitHub Releases
-#    provider: releases
-#    api_key:
+    provider: releases
+    api_key:
 #        secure: "Encrypted GitHub Auth Key" <-- put this in the secrets
-#    file:
-#       # Upload files in the `packages` directory
-#       - packages/*
+    file:
+       # Upload files in the `packages` directory
+       - packages/*
 #    # Ensure the build doesn't get cleaned up so the files are avialable
 #    # for the release build
-#    skip_clean: true
+    skip_clean: true
 #    # release is a draft so it can be edited, updated, etc.
-#    draft: true
+    draft: true
+    prerelease: true
 #    # GitHub Releases requires a tag; this guarnatees a tag is set
-#    on:
-#        tags: true
+    on:
+        tags: true
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ deploy:
 #    # GitHub Releases
     provider: releases
     api_key:
-        secure: m79xOkFq1yArD2c2rBVmbDTEly8jaKgmPy8CsncavCgD1d4pAq+FPdTKFgAhUrGBqOB3f/DP/J2W6VIvYiOs+x9bhCLS07OGE/euylm7UFjWX1dQenPMlTNaTb15YOthWsM8zYPSeb4sOl5aURedenV8sYK9kOU6OQ4ALBsCjNmVHo/3KMPxVoC+jIqsihl4Gc6Lkz2JW/Q/fQYg7gwDEKErq1L7UiiUfo9z5qs9z3ru6ZNkXmtedZpKyf0RsaUX769+POwF+CE2FDpK1t2gm+ga6dLu3au8NhS+FZZvQPk7ns9fbmNE/qb8c+DtGzZkIPDoDRtpZEHGcK3JZFdRatNnx4I1LleSNaTYOi/U+BmEtaEp7jL5MhVbYszodzAKeNaw9ZKnsmVFiOBsa/Rt5YLgHFtJ4g5UwAOPuPvEpgJhgE1lLxyjPyZ0P2LDrmIRIyKbMd7Ox1QAMFSd1RDvf7IubF+/Kt4nO8xmG3J1M/vUJBxKu+oJcbjR4fNo2GVbQfJ+uIU0z7vHm0b7mX/k7NVrnw22A4iy5Omu8XFDtVWRSQZvRlcsua4w1egEBfW0F/txh+7gUOhlo6O4hXVawBqZlUt04EiVUNKOtpGRpCNItk5TixN08gWbRIMzDNg6ZeWLuA0aMs5GhYImurE6dBu7NZ+Z7xakAy72SUxq09g=
+        secure: $GITHUB_TOKEN
     file:
        # Upload files in the `packages` directory
        - packages/*


### PR DESCRIPTION
As I understand from the documentation the workflow is as follows (after merging this PR):
1. Through Github we create a new release
2. Github creates a tag on the branch
3. Travis CI picks up the tag and creates a new build
4. Upon success, Travis CI pushes the packages into the release created in step 1

TODO:
- [x] @BenjamenMeyer, as the owner of Travis CI for this repo, you need to setup the OAuth key in here. Feel free to push to this branch.
- [ ] Create a release :)