### PR TITLE
Correct boost_python3 component on non-Debian systems

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -764,7 +764,21 @@ IF (USE_SYSTEM_BOOST)
         IF (Boost_1_67_Or_Later_Result)
             SET(BOOST_PYTHON_COMPONENT "python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
         ELSEIF (USE_PYTHON_3)
-            SET(BOOST_PYTHON_COMPONENT "python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")   # This may be specific to Ubuntu xenial
+            SET(BOOST_PYTHON_COMPONENT "python3")
+
+            # Xenial lacks libboost_python3.{so|a} but has libboost_python-py{major}{minor}.{so|a}
+            # (This is common to all Debian and Debian-based systems up to Boost 1.67,
+            #   it's just not needed for any other Debian-based system (at the moment).)
+            IF (CMAKE_SYSTEM_NAME STREQUAL Linux)
+                EXECUTE_PROCESS(
+                    COMMAND sh -c "cat /etc/os-release | grep ^VERSION_CODENAME= | sed 's/^VERSION_CODENAME=//' | tr -d '\n'"
+                    OUTPUT_VARIABLE LINUX_CODENAME)
+                IF (LINUX_CODENAME STREQUAL xenial)
+                    SET(BOOST_PYTHON_COMPONENT "python-py3${PYTHON_VERSION_MINOR}")
+                ENDIF (LINUX_CODENAME STREQUAL xenial)
+                UNSET(LINUX_CODENAME)
+            ENDIF (CMAKE_SYSTEM_NAME STREQUAL Linux)
+
         ELSE (Boost_1_67_Or_Later_Result)
             SET(BOOST_PYTHON_COMPONENT "python")
         ENDIF (Boost_1_67_Or_Later_Result)


### PR DESCRIPTION
### Purpose
In #202, the following change was made:

```diff
         ELSEIF (USE_PYTHON_3)
-            SET(BOOST_PYTHON_COMPONENT "python3")
+            SET(BOOST_PYTHON_COMPONENT "python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")   # This may be specific to Ubuntu xenial
```

Whilst this works fine for Debian and Debian-based distros (e.g. Ubuntu, Mint) - at least those that still use a version of `Boost` below `1.67` - this will have broken `python 3` builds for most, if not all, distros that are *not* based on Debian (and are *also* running a `Boost` version lower than `1.67`).

The attached changeset resolves this, putting in a specific conditional for the one distro (Xenial) that actually needs the `boost-python` specifying in such a manner for the `python 3` build to work, and restoring the old component specification for everyone else.

- **What release is this for?** Any
- **Is there a project or milestone we should apply this to?** master / 0.6.x


### Code Changes
- [x] Build System change only, no gameplay alteration
- [ ] Passes Travis CI
    - [x] [Fork](https://travis-ci.com/github/s0600204/Vega-Strike-Engine-Source/builds/178026856)
    - [ ] [PR](https://travis-ci.org/github/vegastrike/Vega-Strike-Engine-Source/builds/713908487)

### Related Issues
- #142
