### PR TITLE
Fixes a compile error by removing an out of date ifdef

### DIFF
--- a/engine/src/gldrv/gl_texture.cpp
+++ b/engine/src/gldrv/gl_texture.cpp
@@ -353,11 +353,9 @@ GFXBOOL /*GFXDRVAPI*/ GFXCreateTexture( int width,
     case TEXTURE2D:
         textures[*handle].targets = GL_TEXTURE_2D;
         break;
-#ifdef GL_EXT_texture3D
     case TEXTURE3D:
         textures[*handle].targets = GL_TEXTURE_3D;
         break;
-#endif
     case CUBEMAP:
         textures[*handle].targets = GL_TEXTURE_CUBE_MAP_EXT;
         break;


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
Issue #256 

Purpose:
- What is this pull request trying to do?
This PR removes an pre-processor ifdef that is causing the compiler warning. One can safely assume that every OpenGL driver running today supports this. 

- What release is this for?
Any.
- Is there a project or milestone we should apply this to?
Nope.