### PR TITLE
Rename entire CMake project from 'vsUTCS' to 'Vega_Strike'

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -13,7 +13,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 SET(CMAKE_CXX_STANDARD 11)
 
-PROJECT(vsUTCS)
+PROJECT(Vega_Strike)
 
 UNSET(PYTHONLIBS_FOUND)
 UNSET(Boost_FOUND)
@@ -35,9 +35,9 @@ UNSET(OGRE_FOUND)
 UNSET(Boost_DIR)
 
 INCLUDE_DIRECTORIES(
-    ${vsUTCS_SOURCE_DIR}/src
-    ${vsUTCS_SOURCE_DIR}/src/cmd
-    ${vsUTCS_BINARY_DIR}
+    ${Vega_Strike_SOURCE_DIR}/src
+    ${Vega_Strike_SOURCE_DIR}/src/cmd
+    ${Vega_Strike_BINARY_DIR}
     /usr/include/harfbuzz/
 )
 
@@ -706,7 +706,7 @@ INCLUDE(CheckIncludeFileCXX)
 INCLUDE(CheckTypeSize)
 CHECK_TYPE_SIZE("void*" SIZEOF_VOID_P BUILTIN_TYPES_ONLY)
 # Let cmake find our in-tree modules
-SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${vsUTCS_SOURCE_DIR})
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${Vega_Strike_SOURCE_DIR})
 
 # Python 3 has a SASL compatibility issue which causes an error
 # on some installations that prefer Python 3
@@ -812,7 +812,7 @@ IF (NOT USE_SYSTEM_BOOST)
     UNSET(Boost_LIBRARY_DIRS)
     SET(Boost_DIR ../ext/)
     SET(BOOST_PYTHON_NO_PY_SIGNATURES 1)
-    SET(TST_INCLUDES ${TST_INCLUDES} ${vsUTCS_SOURCE_DIR}/${Boost_DIR})
+    SET(TST_INCLUDES ${TST_INCLUDES} ${Vega_Strike_SOURCE_DIR}/${Boost_DIR})
     IF (USE_PYTHON_3)
         MESSAGE("++ Using Internal Boost::python3")
         SET(TST_LIBS ${TST_LIBS} boost_python3)
@@ -1039,7 +1039,7 @@ ELSE (UNIX)
     SET(HOSTOS "APPLE")
 ENDIF (UNIX)
 
-CONFIGURE_FILE(${vsUTCS_SOURCE_DIR}/cmake-config.h.in ${vsUTCS_BINARY_DIR}/config.h)
+CONFIGURE_FILE(${Vega_Strike_SOURCE_DIR}/cmake-config.h.in ${Vega_Strike_BINARY_DIR}/config.h)
 
 #end config.h generation
 #SET(CMAKE_CXX_FLAGS "-include config.h;-pipe;"${CMAKE_CXX_FLAGS})

--- a/engine/objconv/CMakeLists.txt
+++ b/engine/objconv/CMakeLists.txt
@@ -43,8 +43,8 @@ SET(MESHER_SOURCES
     mesher/Modules/XMesh_to_BFXM.cpp
     mesher/Modules/XMesh_to_Ogre.cpp
     mesher/Modules/Wavefront_to_BFXM.cpp
-    ${vsUTCS_SOURCE_DIR}/src/hashtable.cpp
-    ${vsUTCS_SOURCE_DIR}/src/xml_support.cpp
+    ${Vega_Strike_SOURCE_DIR}/src/hashtable.cpp
+    ${Vega_Strike_SOURCE_DIR}/src/xml_support.cpp
 )
 
 INCLUDE_DIRECTORIES(${MSH_INCLUDES} mesher)

--- a/engine/objconv/mesher/CMakeLists.txt
+++ b/engine/objconv/mesher/CMakeLists.txt
@@ -17,8 +17,8 @@ IF (EXPAT_FOUND)
         Modules/XMesh_to_Ogre.cpp
         Modules/Wavefront_to_BFXM.cpp
         PrecompiledHeaders/Converter.cpp
-        ${vsUTCS_SOURCE_DIR}/src/hashtable.cpp
-        ${vsUTCS_SOURCE_DIR}/src/xml_support.cpp
+        ${Vega_Strike_SOURCE_DIR}/src/hashtable.cpp
+        ${Vega_Strike_SOURCE_DIR}/src/xml_support.cpp
     )
 
     # Still need to add CEGUI and OGRE find packages

--- a/engine/setup/CMakeLists.txt
+++ b/engine/setup/CMakeLists.txt
@@ -24,6 +24,11 @@ IF (NOT BEOS)
 	ENDIF(GTK3_FOUND)
 
 	ADD_DEFINITIONS(${GTK_CFLAGS})
-	INCLUDE_DIRECTORIES(${vsUTCS_SOURCE_DIR}/setup/src/include ${vsUTCS_SOURCE_DIR}/src/common ${vsUTCS_BINARY_DIR} ${GTK3_INCLUDE_DIRS})
+	INCLUDE_DIRECTORIES(
+        ${Vega_Strike_SOURCE_DIR}/setup/src/include
+        ${Vega_Strike_SOURCE_DIR}/src/common
+        ${Vega_Strike_BINARY_DIR}
+        ${GTK3_INCLUDE_DIRS}
+    )
 	TARGET_LINK_LIBRARIES(vegasettings ${GTK_LIBS})
 ENDIF (NOT BEOS)


### PR DESCRIPTION
and make associated changes to each CMakeLists.txt file

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] **This is a build system change only**

Issues:
- Please list any related issues
**Resolves #266** 

Purpose:
- What is this pull request trying to do? **Rename the CMake project to avoid confusion between "Vega Strike" (the game engine); VSU (the fictional Vega Strike Universe); and UtCS (Upon the Coldest Sea, a particular game built using the Vega Strike game engine, and set in the VSU).**
- What release is this for? **0.7.x**
- Is there a project or milestone we should apply this to? **0.7.x, and possibly 0.6.x as well, though that would be a separate pull request**
