### PR TITLE
Fix tautological comparizon warning

### DIFF
--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -1230,7 +1230,7 @@ void BaseInterface::Room::Launch::Click( BaseInterface *base, float x, float y, 
                 playa->getAIState()->Communicate( c );
             abletodock( 5 );
             if (playa->name == "return_to_cockpit")
-                if (playa->faction == playa->faction)
+                if (playa->faction == bas->faction)
                     playa->owner = bas;
         }
         base->Terminate();


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
Looks like a copy/paste bug.
The intended comaprizon was probably against the `bas' variable.

Purpose:
- What is this pull request trying to do?
Fix a warning
- What release is this for?
Next one
- Is there a project or milestone we should apply this to?
Next one