### PR TITLE
Add Ubuntu 20.04 Focal support to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ addons:
   apt:
     packages:
       - python-dev
-      - python2-dev
+#      - python2-dev
       - libgl1-mesa-glx
       - freeglut3-dev
       - libopenal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ addons:
   apt:
     packages:
       - python-dev
+      - python2-dev
       - libgl1-mesa-glx
       - freeglut3-dev
       - libopenal-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
-os:
- - linux
+os: linux
+distro: focal
 
 # When updating be sure to add a section
 # to the matrix to cover the distro
@@ -15,7 +15,20 @@ env:
     - FLAGS='-DUSE_PYTHON_3=ON'
 
 jobs:
-    include:
+    include: 
+        - os: linux
+          dist: bionic
+          compiler: gcc
+          name: "Ubuntu 18.04 LTS - GCC"
+        - os: linux
+          dist: bionic
+          compiler: clang
+          name: "Ubuntu 18.04 LTS - Clang"
+        - os: linux
+          dist: bionic
+          compiler: clang
+          name: "Ubuntu 18.04 LTS - Py3"
+          env: FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           dist: xenial
           compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ compiler:
     - clang
 
 env:
-    - {}
+# Seems like Python2 doesn't work well on Focal.
+# Should be uncommented if someone fixes that
+#    - {}
     - FLAGS='-DUSE_PYTHON_3=ON'
 
 jobs:


### PR DESCRIPTION
CI changes only, to increase coverage. Shouldn't affect functionality in any way.