### PR TITLE
Move reactToCollision code to its own class

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -214,6 +214,7 @@ SET(LIBCMD_SOURCES
     src/cmd/unit_xml.cpp
     src/cmd/weapon_xml.cpp
 
+    src/cmd/collision.cpp
     src/cmd/damageable.cpp
     src/cmd/drawable.cpp
     src/cmd/movable.cpp

--- a/engine/src/cmd/asteroid_generic.cpp
+++ b/engine/src/cmd/asteroid_generic.cpp
@@ -34,23 +34,6 @@ void Asteroid::Init(float difficulty)
 }
 
 
-void Asteroid::reactToCollision(Unit * smaller, const QVector& biglocation, const Vector& bignormal, const QVector& smalllocation, const Vector& smallnormal, float dist)
-{
-	switch (smaller->isUnit()) {
-		case ASTEROIDPTR:
-		case ENHANCEMENTPTR:
-			break;
-		case NEBULAPTR:
-			smaller->reactToCollision(this,smalllocation,smallnormal,biglocation,bignormal,dist);
-			break;
-		default:
-			/***** DOES THAT STILL WORK WITH UNIT:: ?????????? *******/
-			Unit::reactToCollision (smaller,biglocation,bignormal,smalllocation,smallnormal,dist);
-			break;
-	}
-}
-
-
 Asteroid::Asteroid(const char * filename, int faction, Flightgroup* fg, int fg_snumber, float difficulty):Unit (filename,false, faction,string(""),fg,fg_snumber)
 {
 	Init( difficulty);

--- a/engine/src/cmd/asteroid_generic.h
+++ b/engine/src/cmd/asteroid_generic.h
@@ -9,7 +9,6 @@ class Asteroid: public Unit
 	public:
 		void Init( float difficulty);
 		virtual enum clsptr isUnit() const { return(ASTEROIDPTR);}
-		virtual void reactToCollision(Unit * smaller, const QVector& biglocation, const Vector& bignormal, const QVector& smalllocation, const Vector& smallnormal, float dist);
 
 		protected:
 		/** Constructor that can only be called by the UnitFactory.

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -89,6 +89,17 @@ void Collision::shouldApplyForceAndDealDamage(Unit* other_unit)
         return;
     }
 
+    // Collision with a jump point does nothing
+    if(other_unit->isJumppoint())
+    {
+        other_unit->jumpReactToCollision(unit);
+        return;
+    }
+
+    if(unit->isJumppoint())
+    {
+        return;
+    }
 
     switch(unit_type)
     {

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -1,0 +1,405 @@
+#include "collision.h"
+
+#include "unit_generic.h"
+#include "universe.h"
+#include "universe_util.h"
+#include "game_config.h"
+#include "missile.h"
+#include "enhancement.h"
+#include <typeinfo>
+
+static const float kilojoules_per_damage = GameConfig::GetVariable( "physics", "kilojoules_per_unit_damage", 5400 );
+static const float collision_scale_factor =
+        GameConfig::GetVariable( "physics", "collision_damage_scale", 1.0f );
+static const float inelastic_scale = GameConfig::GetVariable( "physics", "inelastic_scale", 0.8f);
+static const float min_time =
+        GameConfig::GetVariable( "physics", "minimum_time_between_recorded_player_collisions", 0.1f);
+static const float minimum_mass = 1e-6f;
+
+//Collision force caps primarily for AI-AI collisions. Once the AIs get a real collision avoidance system, we can
+// turn damage for AI-AI collisions back on, and then we can remove these caps.
+//value, in seconds of desired maximum recovery time
+static const float max_torque_multiplier =
+        GameConfig::GetVariable( "physics", "maxCollisionTorqueMultiplier", 0.67f);
+//value, in seconds of desired maximum recovery time
+static const float max_force_multiplier  =
+        GameConfig::GetVariable( "physics", "maxCollisionForceMultiplier", 5);
+
+static const int upgrade_faction =
+        GameConfig::GetVariable( "physics", "cargo_deals_collide_damage",
+                                                        false) ? -1 : FactionUtil::GetUpgradeFaction();
+
+static const float collision_hack_distance =
+        GameConfig::GetVariable( "physics", "collision_avoidance_hack_distance", 10000);
+static const float front_collision_hack_distance =
+        GameConfig::GetVariable( "physics", "front_collision_avoidance_hack_distance", 200000);
+
+static float front_collision_hack_angle = cos( 3.1415926536f * GameConfig::GetVariable( "physics", "front_collision_avoidance_hack_angle", 40)/180.0f );
+
+static const bool collision_damage_to_ai = GameConfig::GetVariable( "physics", "collisionDamageToAI", false);
+
+static const bool crash_dock_unit = GameConfig::GetVariable( "physics", "unit_collision_docks", false);
+
+static const bool crash_dock_hangar = GameConfig::GetVariable( "physics", "only_hangar_collision_docks", false);
+
+// Disabled bouncing missile option. Missiles always explode when colliding with something.
+//static const bool does_missile_bounce = GameConfig::GetVariable( "physics", "missile_bounce", false);
+
+
+
+Collision::Collision(Unit* unit, const QVector& location, const Vector& normal):
+    unit(unit), location(location), normal(normal)
+{
+    cockpit = _Universe->isPlayerStarship( unit ); // smcp/thcp
+    unit_type = unit->isUnit();
+    is_player_ship = _Universe->isPlayerStarship(unit);
+    mass = std::max(unit->GetMass(), minimum_mass);
+    position = unit->Position();
+    velocity = unit->GetVelocity();
+    angular_velocity = unit->GetAngularVelocity();
+    linear_velocity = velocity - angular_velocity.Cross( location - position );
+}
+
+
+void Collision::Collision2(Matrix& from_new_reference, Matrix& to_new_reference,
+                           Vector inelastic_vf, Collision& other_data)
+{
+    aligned_velocity = Transform( to_new_reference, linear_velocity );
+
+    //compute along aligned dimension, then return to previous reference frame
+    aligned_velocity.k = (aligned_velocity.k*(mass-other_data.mass)/(mass+other_data.mass)+( 2.0f*other_data.mass/(mass+other_data.mass) )*other_data.aligned_velocity.k);
+
+    elastic_vf = Transform( from_new_reference, aligned_velocity );
+    final_velocity = inelastic_scale * inelastic_vf + (1.0f - inelastic_scale) * elastic_vf;
+    delta_e = (0.5f)*mass*(final_velocity-elastic_vf).MagnitudeSquared();
+}
+
+
+void Collision::Collision3(Collision& other_data)
+{
+    //Damage distribution (NOTE: currently arbitrary - no known good model for calculating how much energy object endures as a result of the collision)
+    damage = (0.25f*delta_e+0.75f*other_data.delta_e)/kilojoules_per_damage*collision_scale_factor;
+
+    //Vector ThisDesiredVelocity = ThisElastic_vf*(1-inelastic_scale/2)+Inelastic_vf*inelastic_scale/2;
+    //Vector SmallerDesiredVelocity = SmallerElastic_vf*(1-inelastic_scale)+Inelastic_vf*inelastic_scale;
+    //FIXME need to resolve 2 problems -
+    //1) simulation_atom_var for small != simulation_atom_var for large (below smforce line should mostly address this)
+    //2) Double counting due to collision occurring for each object in a different physics frame.
+    force = (final_velocity - velocity) * mass
+            / ( simulation_atom_var * ((float)unit->sim_atom_multiplier)
+                / ( (float) other_data.unit->sim_atom_multiplier ));
+
+    if (cockpit)
+    {
+        if ( (getNewTime()-cockpit->TimeOfLastCollision) > min_time )
+            cockpit->TimeOfLastCollision = getNewTime();
+        else
+            not_player_or_min_time_passed = false;
+    }
+
+    delta = ( _Universe->AccessCamera()->GetPosition()-position ).Cast();
+    magnitude = delta.Magnitude();
+}
+
+
+// This function handles the initial reaction of the unit to hitting the other unit
+// Note: I'm changing the expected behavior here
+// Return value indicates whether to continue processing
+/*UNITPTR,
+PLANETPTR,
+BUILDINGPTR,
+NEBULAPTR,
+ASTEROIDPTR,
+ENHANCEMENTPTR,
+MISSILEPTR*/
+Collision::ReactionResult Collision::reactionMatrix(Unit* other_unit)
+{
+    ReactionResult result = ReactionResult(false, false);
+    // Collision with a nebula does nothing
+    if(other_unit->isUnit() == NEBULAPTR)
+    {
+        return ReactionResult(false, false);
+    }
+
+    // Collision with a enhancement improves your shield apparently
+    if(other_unit->isUnit() == ENHANCEMENTPTR)
+    {
+        return ReactionResult(true, false);
+    }
+
+
+    switch(unit_type)
+    {
+    // Missiles and asteroids always explode on impact with anything except Nebula and Enhancement.
+    case MISSILEPTR:
+        // Missile should explode when killed
+        // If not, uncomment this
+        //((Missile*)unit)->Discharge();
+        unit->Kill();
+        return ReactionResult(false, false);
+
+    case ASTEROIDPTR:
+        unit->Kill();
+        return ReactionResult(false, false);
+
+    // Planets and Nebulas can't be killed right now
+    case PLANETPTR:
+    case NEBULAPTR:
+        return ReactionResult(false, false);
+
+    // Buildings should not calculate actual damage
+    case BUILDINGPTR:
+        return ReactionResult(false, false);
+
+    // Units (ships) should calculate actual damage
+    case UNITPTR:
+        return ReactionResult(true, true);
+
+    // Not sure what an enhancement is, but it looks like it's something that can increase the shields of the unit it collided with.
+    case ENHANCEMENTPTR:
+        if (other_unit->isUnit() == ASTEROIDPTR)
+        {
+            return ReactionResult(true, false);
+        }
+
+        Enhancement* enhancement = dynamic_cast<Enhancement*>(unit);
+
+        double percent;
+        char tempdata[sizeof (unit->shield)];
+        memcpy( tempdata, &unit->shield, sizeof (unit->shield) );
+        unit->shield.number = 0;     //don't want them getting our boosted shields!
+        unit->shield.shield2fb.front = unit->shield.shield2fb.back =
+                unit->shield.shield2fb.frontmax = unit->shield.shield2fb.backmax = 0;
+        other_unit->Upgrade( unit, 0, 0, true, true, percent );
+        memcpy( &unit->shield, tempdata, sizeof (unit->shield) );
+        string fn( unit->filename );
+        string fac( FactionUtil::GetFaction( unit->faction ) );
+        unit->Kill();
+        _Universe->AccessCockpit()->savegame->AddUnitToSave( fn.c_str(), ENHANCEMENTPTR, fac.c_str(), (long) unit );
+        return ReactionResult(true, false);
+    }
+}
+
+// This stops the unit from going through the other unit
+void Collision::applyForce()
+{
+    //for torque... location -- approximation hack of MR^2 for rotational inertia (moment of inertia currently just M)
+    Vector torque = force/(unit->radial_size*unit->radial_size);
+    Vector force  = this->force-torque; // Note the variable shadowing
+
+    float  max_force  = max_force_multiplier*(unit->limits.forward + unit->limits.retro + unit->limits.lateral + unit->limits.vertical);
+    float  max_torque = max_torque_multiplier*(unit->limits.yaw + unit->limits.pitch+unit->limits.roll);
+
+    //Convert from frames to seconds, so that the specified value is meaningful
+    max_force  = max_force / (unit->sim_atom_multiplier * simulation_atom_var);
+    max_torque = max_torque / (unit->sim_atom_multiplier * simulation_atom_var);
+    float torque_magnitude = torque.Magnitude();
+    float force_magnitude = force.Magnitude();
+    if (torque_magnitude > max_torque) {
+        torque *= (max_torque/torque_magnitude);
+    }
+    if (force_magnitude > max_force) {
+        force *= (max_force/force_magnitude);
+    }
+    unit->ApplyTorque( torque, location );
+    unit->ApplyForce( force-torque );
+}
+
+
+// This needs careful review
+// I have no idea what this does or why
+// TODO: review if doesn't work and review anyway at some point
+bool Collision::shouldDealDamage(float radial_size)
+{
+    // I think this is another way of checking if the ship is a player ship
+    if(cockpit != nullptr)
+    {
+        return true;
+    }
+
+    if (magnitude <= collision_hack_distance + radial_size)
+    {
+        return true;
+    }
+
+    if (magnitude <= front_collision_hack_distance + radial_size)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+void Collision::applyDamage(Collision other_collision)
+{
+    if(unit->faction == upgrade_faction) {
+        return;
+    }
+
+    unit->ApplyDamage(other_collision.location.Cast(),
+                      other_collision.normal,
+                      damage, unit, GFXColor( 1,1,1,2 ), other_collision.unit->owner
+                      != nullptr ? other_collision.unit->owner : this );
+}
+
+
+// This plays a docking sound
+extern void abletodock( int dock );
+
+// Some variants (e.g. privateer) automatically land when colliding with a planet/station
+// Return true if successfully docked
+// this->unit is the one attempting to land
+bool Collision::crashLand(Unit *base)
+{
+    if (!crash_dock_unit) {
+        return false;
+    }
+
+    if (UnitUtil::getFlightgroupName( base ) != "Base") {
+        return false;
+    }
+
+    // Set docking port
+    int docking_port = base->CanDockWithMe( unit, !crash_dock_hangar );
+    if(docking_port == -1)
+    {
+        return false;
+    }
+
+    if (unit->ForceDock( base, static_cast<unsigned int>(docking_port)) <= 0)
+    {
+        return false;
+    }
+
+    // Set docking position
+    QVector docking_position = UniverseUtil::SafeEntrancePoint( unit->Position(), unit->rSize()*1.5 );
+    unit->SetPosAndCumPos( docking_position );
+
+    // This plays a docking sound
+    // TODO: really doesn't belong here. Refactor somehow.
+    abletodock( 3 );
+
+    // Probably does not belong here
+    // Set the upgrade interface of a planet or base
+    unit->UpgradeInterface( base );
+}
+
+// Discussion - the original code ran this once for both units. This required a comprison of the units to find out which is smaller.
+void Collision::collide( Unit* unit1,
+                                   const QVector &location1,
+                                   const Vector &normal1,
+                                   Unit* unit2,
+                                   const QVector &location2,
+                                   const Vector &normal2,
+                                   float distance)
+{
+    std::cout << "Collision between " << typeid(unit1).name() << " and " << typeid(unit2).name() << "\n";
+
+    Collision collision1 = Collision(unit1, location1, normal1);
+    Collision collision2 = Collision(unit2, location2, normal2);
+
+    // Try crash landing both ways
+    if(collision1.crashLand(unit2)) {
+        return;
+    } else if(collision2.crashLand(unit1)) {
+        return;
+    }
+
+    // If either unit jumps as a result, we avoid a collision
+    // We don't check which unit is smaller
+    // But jumpReactToCollision does supposedly
+    if ( unit1->jumpReactToCollision( unit2 ) ||
+         unit2->jumpReactToCollision( unit1 ) )
+    {
+        return;
+    }
+
+    ReactionResult reaction1 = collision1.reactionMatrix(unit2);
+    ReactionResult reaction2 = collision2.reactionMatrix(unit1);
+
+    // Here we calculate a whole bunch of things but don't do anything with them yet.
+    // Compute reference frame conversions to align along force normals (newZ)(currently using bignormal
+    // - will experiment to see if both are needed for sufficient approximation)
+    Vector orthoz = ( (collision2.mass * normal2)-(collision1.mass * normal1) ).Normalize();
+    Vector orthox = MakeNonColinearVector( orthoz );
+    Vector orthoy( 0, 0, 0 );
+
+    // Need z and non-colinear x to compute new basis trio. destroys x,y, preserves z.
+    Orthogonize( orthox, orthoy, orthoz );
+
+    // Transform matrix from normal aligned space
+    Matrix from_new_reference( orthox, orthoy, orthoz );
+    Matrix to_new_reference = from_new_reference;
+
+    // Transform matrix to normal aligned space
+    from_new_reference.InvertRotationInto( to_new_reference );
+
+    //Compute elastic and inelastic terminal velocities (point object approximation)
+    //doesn't need aligning (I think)
+    Vector inelastic_vf = ( collision1.mass/(collision1.mass+collision2.mass) ) * collision1.linear_velocity + ( collision2.mass/(collision1.mass + collision2.mass) ) * collision2.linear_velocity;
+
+    collision1.Collision2(from_new_reference, to_new_reference, inelastic_vf, collision2);
+    collision2.Collision2(from_new_reference, to_new_reference, inelastic_vf, collision1);
+
+    collision1.Collision3(collision2);
+    collision2.Collision3(collision1);
+
+    bool is_not_player_or_has_been_min_time = collision1.not_player_or_min_time_passed & collision2.not_player_or_min_time_passed;
+
+    // Apply force applies the motion effect of a collision
+    if(reaction1.apply_force && is_not_player_or_has_been_min_time)
+    {
+        collision1.applyForce();
+    }
+
+    if(reaction2.apply_force && is_not_player_or_has_been_min_time)
+    {
+        collision2.applyForce();
+    }
+
+    // Begin damage
+    if(!collision1.shouldDealDamage(collision2.unit->rSize()) &&
+            !collision2.shouldDealDamage())
+    {
+            return;
+    }
+
+    // Disable damage to NPC ships because... stupid AI ships always crash into each other.
+    if ( !collision_damage_to_ai && !collision1.is_player_ship && !collision2.is_player_ship &&
+         collision1.unit_type != MISSILEPTR && collision2.unit_type != MISSILEPTR)
+    {
+        return;
+    }
+
+    // Now we start to act on the above calculations,
+    // but only if we need to
+    if(reaction1.deal_damage)
+    {
+        collision1.applyDamage(collision2);
+    }
+    if(reaction2.deal_damage)
+    {
+        collision2.applyDamage(collision1);
+    }
+}
+
+
+//HACK ALERT:
+//following code referencing minvel and time between collisions attempts
+//to alleviate ping-pong problems due to collisions being detected
+//after the player has penetrated the hull of another vessel because of discretization of time.
+//this should eventually be replaced by instead figuring out where
+//the point of collision should have occurred, and moving the vessels to the
+//actual collision location before applying forces
+
+//Need to incorporate normals of colliding polygons somehow, without overiding directions of travel.
+//We'll use the point object approximation for the magnitude of damage, and then apply the force along the appropriate normals
+//ThisElastic_vf=((ThisElastic_vf.Magnitude()>minvel||!thcp)?ThisElastic_vf.Magnitude():minvel)*smallnormal;
+//SmallerElastic_vf=((SmallerElastic_vf.Magnitude()>minvel||!smcp)?SmallerElastic_vf.Magnitude():minvel)*bignormal;
+
+
+//float LargeKE = (0.5)*m2*GetVelocity().MagnitudeSquared();
+//float SmallKE = (0.5)*m1*smalle->GetVelocity().MagnitudeSquared();
+//float FinalInelasticKE = Inelastic_vf.MagnitudeSquared()*(0.5)*(m1+m2);
+//float InelasticDeltaKE = LargeKE +SmallKE - FinalInelasticKE;
+//1/2Mass*deltavfromnoenergyloss^2

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -8,6 +8,8 @@
 #include "enhancement.h"
 #include <typeinfo>
 
+// TODO: convert all float to double and all Vector to QVector.
+
 static const float kilojoules_per_damage = GameConfig::GetVariable( "physics", "kilojoules_per_unit_damage", 5400 );
 static const float collision_scale_factor =
         GameConfig::GetVariable( "physics", "collision_damage_scale", 1.0f );
@@ -56,50 +58,9 @@ Collision::Collision(Unit* unit, const QVector& location, const Vector& normal):
     mass = std::max(unit->GetMass(), minimum_mass);
     position = unit->Position();
     velocity = unit->GetVelocity();
-    angular_velocity = unit->GetAngularVelocity();
-    linear_velocity = velocity - angular_velocity.Cross( location - position );
 }
 
 
-void Collision::Collision2(Matrix& from_new_reference, Matrix& to_new_reference,
-                           Vector inelastic_vf, Collision& other_data)
-{
-    aligned_velocity = Transform( to_new_reference, linear_velocity );
-
-    //compute along aligned dimension, then return to previous reference frame
-    aligned_velocity.k = (aligned_velocity.k*(mass-other_data.mass)/(mass+other_data.mass)+( 2.0f*other_data.mass/(mass+other_data.mass) )*other_data.aligned_velocity.k);
-
-    elastic_vf = Transform( from_new_reference, aligned_velocity );
-    final_velocity = inelastic_scale * inelastic_vf + (1.0f - inelastic_scale) * elastic_vf;
-    delta_e = (0.5f)*mass*(final_velocity-elastic_vf).MagnitudeSquared();
-}
-
-
-void Collision::Collision3(Collision& other_data)
-{
-    //Damage distribution (NOTE: currently arbitrary - no known good model for calculating how much energy object endures as a result of the collision)
-    damage = (0.25f*delta_e+0.75f*other_data.delta_e)/kilojoules_per_damage*collision_scale_factor;
-
-    //Vector ThisDesiredVelocity = ThisElastic_vf*(1-inelastic_scale/2)+Inelastic_vf*inelastic_scale/2;
-    //Vector SmallerDesiredVelocity = SmallerElastic_vf*(1-inelastic_scale)+Inelastic_vf*inelastic_scale;
-    //FIXME need to resolve 2 problems -
-    //1) simulation_atom_var for small != simulation_atom_var for large (below smforce line should mostly address this)
-    //2) Double counting due to collision occurring for each object in a different physics frame.
-    force = (final_velocity - velocity) * mass
-            / ( simulation_atom_var * ((float)unit->sim_atom_multiplier)
-                / ( (float) other_data.unit->sim_atom_multiplier ));
-
-    if (cockpit)
-    {
-        if ( (getNewTime()-cockpit->TimeOfLastCollision) > min_time )
-            cockpit->TimeOfLastCollision = getNewTime();
-        else
-            not_player_or_min_time_passed = false;
-    }
-
-    delta = ( _Universe->AccessCamera()->GetPosition()-position ).Cast();
-    magnitude = delta.Magnitude();
-}
 
 
 // This function handles the initial reaction of the unit to hitting the other unit
@@ -112,19 +73,19 @@ NEBULAPTR,
 ASTEROIDPTR,
 ENHANCEMENTPTR,
 MISSILEPTR*/
-Collision::ReactionResult Collision::reactionMatrix(Unit* other_unit)
+void Collision::shouldApplyForceAndDealDamage(Unit* other_unit)
 {
-    ReactionResult result = ReactionResult(false, false);
     // Collision with a nebula does nothing
     if(other_unit->isUnit() == NEBULAPTR)
     {
-        return ReactionResult(false, false);
+        return;
     }
 
     // Collision with a enhancement improves your shield apparently
     if(other_unit->isUnit() == ENHANCEMENTPTR)
     {
-        return ReactionResult(true, false);
+        apply_force = true;
+        return;
     }
 
 
@@ -136,33 +97,34 @@ Collision::ReactionResult Collision::reactionMatrix(Unit* other_unit)
         // If not, uncomment this
         //((Missile*)unit)->Discharge();
         unit->Kill();
-        return ReactionResult(false, false);
+        return;
 
     case ASTEROIDPTR:
         unit->Kill();
-        return ReactionResult(false, false);
+        return;
 
     // Planets and Nebulas can't be killed right now
     case PLANETPTR:
     case NEBULAPTR:
-        return ReactionResult(false, false);
+        return;
 
     // Buildings should not calculate actual damage
     case BUILDINGPTR:
-        return ReactionResult(false, false);
+        return;
 
     // Units (ships) should calculate actual damage
     case UNITPTR:
-        return ReactionResult(true, true);
+        apply_force = true;
+        deal_damage = true;
+        return;
 
     // Not sure what an enhancement is, but it looks like it's something that can increase the shields of the unit it collided with.
     case ENHANCEMENTPTR:
         if (other_unit->isUnit() == ASTEROIDPTR)
         {
-            return ReactionResult(true, false);
+            apply_force = true;
+            return;
         }
-
-        Enhancement* enhancement = dynamic_cast<Enhancement*>(unit);
 
         double percent;
         char tempdata[sizeof (unit->shield)];
@@ -175,13 +137,14 @@ Collision::ReactionResult Collision::reactionMatrix(Unit* other_unit)
         string fn( unit->filename );
         string fac( FactionUtil::GetFaction( unit->faction ) );
         unit->Kill();
-        _Universe->AccessCockpit()->savegame->AddUnitToSave( fn.c_str(), ENHANCEMENTPTR, fac.c_str(), (long) unit );
-        return ReactionResult(true, false);
+        _Universe->AccessCockpit()->savegame->AddUnitToSave( fn.c_str(), ENHANCEMENTPTR, fac.c_str(), reinterpret_cast<long>(unit));
+        apply_force = true;
+        return;
     }
 }
 
 // This stops the unit from going through the other unit
-void Collision::applyForce()
+/*void Collision::applyForce(double elasticity, float& m2, Vector& v2)
 {
     //for torque... location -- approximation hack of MR^2 for rotational inertia (moment of inertia currently just M)
     Vector torque = force/(unit->radial_size*unit->radial_size);
@@ -203,38 +166,27 @@ void Collision::applyForce()
     }
     unit->ApplyTorque( torque, location );
     unit->ApplyForce( force-torque );
-}
+}*/
 
 
-// This needs careful review
-// I have no idea what this does or why
-// TODO: review if doesn't work and review anyway at some point
-bool Collision::shouldDealDamage(float radial_size)
+
+
+void Collision::dealDamage(Collision other_collision, float factor)
 {
-    // I think this is another way of checking if the ship is a player ship
-    if(cockpit != nullptr)
+    if(!deal_damage)
     {
-        return true;
-    }
-
-    if (magnitude <= collision_hack_distance + radial_size)
-    {
-        return true;
-    }
-
-    if (magnitude <= front_collision_hack_distance + radial_size)
-    {
-        return true;
-    }
-
-    return false;
-}
-
-void Collision::applyDamage(Collision other_collision)
-{
-    if(unit->faction == upgrade_faction) {
         return;
     }
+
+    // Shorten variables for better visibility
+    float& m1 = mass;
+    float& m2 = other_collision.mass;
+    Vector& v1 = velocity;
+    Vector& v2 = other_collision.velocity;
+
+    float relative_velocity = (v1-v2).Magnitude();
+    float damage = relative_velocity * relative_velocity *
+            (m2)/(m1+m2) * factor;
 
     unit->ApplyDamage(other_collision.location.Cast(),
                       other_collision.normal,
@@ -242,47 +194,36 @@ void Collision::applyDamage(Collision other_collision)
                       != nullptr ? other_collision.unit->owner : this );
 }
 
-
-// This plays a docking sound
-extern void abletodock( int dock );
-
-// Some variants (e.g. privateer) automatically land when colliding with a planet/station
-// Return true if successfully docked
-// this->unit is the one attempting to land
-bool Collision::crashLand(Unit *base)
+void Collision::applyForce(double elasticity, float& m2, Vector& v2)
 {
-    if (!crash_dock_unit) {
-        return false;
-    }
+    /*
+    The current implementation is of an imperfectly elastic collision.
+    An elastic collision is an encounter between two bodies in which the total kinetic energy of the two bodies remains the same. In an ideal, perfectly elastic collision, there is no net conversion of kinetic energy into other forms such as heat, noise, or potential energy.
+    https://en.wikipedia.org/wiki/Elastic_collision
 
-    if (UnitUtil::getFlightgroupName( base ) != "Base") {
-        return false;
-    }
+    This function adds an elasticity ratio to reduce velocity, due to heat, damage, etc.
+    */
 
-    // Set docking port
-    int docking_port = base->CanDockWithMe( unit, !crash_dock_hangar );
-    if(docking_port == -1)
+    // Ratio must be between 0 and 1
+    assert(elasticity>=0);
+    assert(elasticity<=1);
+
+    if(!apply_force)
     {
-        return false;
+        return;
     }
 
-    if (unit->ForceDock( base, static_cast<unsigned int>(docking_port)) <= 0)
-    {
-        return false;
-    }
+    // Shorten variables for better visibility
+    float& m1 = mass;
+    Vector& v1 = velocity;
 
-    // Set docking position
-    QVector docking_position = UniverseUtil::SafeEntrancePoint( unit->Position(), unit->rSize()*1.5 );
-    unit->SetPosAndCumPos( docking_position );
+    // Perfectly elastic result
+    Vector new_velocity = v1*(m1-m2)/(m1+m2) + v2*2*m2/(m1+m2);
 
-    // This plays a docking sound
-    // TODO: really doesn't belong here. Refactor somehow.
-    abletodock( 3 );
-
-    // Probably does not belong here
-    // Set the upgrade interface of a planet or base
-    unit->UpgradeInterface( base );
+    // Apply ratio
+    new_velocity = new_velocity * elasticity;
 }
+
 
 // Discussion - the original code ran this once for both units. This required a comprison of the units to find out which is smaller.
 void Collision::collide( Unit* unit1,
@@ -293,113 +234,26 @@ void Collision::collide( Unit* unit1,
                                    const Vector &normal2,
                                    float distance)
 {
-    std::cout << "Collision between " << typeid(unit1).name() << " and " << typeid(unit2).name() << "\n";
-
     Collision collision1 = Collision(unit1, location1, normal1);
     Collision collision2 = Collision(unit2, location2, normal2);
 
-    // Try crash landing both ways
-    if(collision1.crashLand(unit2)) {
-        return;
-    } else if(collision2.crashLand(unit1)) {
-        return;
-    }
+    // TODO: Try "crash" landing both ways
+    // See commit a66bdcfa1e00bf039183603913567d48e52c7a8e method crashLand for an example
+    // If configured, the game should behave like privateer and land if close enough to a dock
 
-    // If either unit jumps as a result, we avoid a collision
-    // We don't check which unit is smaller
-    // But jumpReactToCollision does supposedly
-    if ( unit1->jumpReactToCollision( unit2 ) ||
-         unit2->jumpReactToCollision( unit1 ) )
-    {
-        return;
-    }
+    // TODO: Try "auto jump" both ways
+    // See commit a66bdcfa1e00bf039183603913567d48e52c7a8e method Unit->jumpReactToCollision for an example
+    // I assume this is for "always open" jump gates that you pass through
 
-    ReactionResult reaction1 = collision1.reactionMatrix(unit2);
-    ReactionResult reaction2 = collision2.reactionMatrix(unit1);
+    collision1.shouldApplyForceAndDealDamage(unit2);
+    collision2.shouldApplyForceAndDealDamage(unit1);
 
-    // Here we calculate a whole bunch of things but don't do anything with them yet.
-    // Compute reference frame conversions to align along force normals (newZ)(currently using bignormal
-    // - will experiment to see if both are needed for sufficient approximation)
-    Vector orthoz = ( (collision2.mass * normal2)-(collision1.mass * normal1) ).Normalize();
-    Vector orthox = MakeNonColinearVector( orthoz );
-    Vector orthoy( 0, 0, 0 );
+    float elasticity = 0.8f;
+    collision1.applyForce(elasticity, collision2.mass, collision2.velocity);
+    collision2.applyForce(elasticity, collision1.mass, collision1.velocity);
 
-    // Need z and non-colinear x to compute new basis trio. destroys x,y, preserves z.
-    Orthogonize( orthox, orthoy, orthoz );
+    collision1.dealDamage(collision2);
+    collision2.dealDamage(collision1);
 
-    // Transform matrix from normal aligned space
-    Matrix from_new_reference( orthox, orthoy, orthoz );
-    Matrix to_new_reference = from_new_reference;
-
-    // Transform matrix to normal aligned space
-    from_new_reference.InvertRotationInto( to_new_reference );
-
-    //Compute elastic and inelastic terminal velocities (point object approximation)
-    //doesn't need aligning (I think)
-    Vector inelastic_vf = ( collision1.mass/(collision1.mass+collision2.mass) ) * collision1.linear_velocity + ( collision2.mass/(collision1.mass + collision2.mass) ) * collision2.linear_velocity;
-
-    collision1.Collision2(from_new_reference, to_new_reference, inelastic_vf, collision2);
-    collision2.Collision2(from_new_reference, to_new_reference, inelastic_vf, collision1);
-
-    collision1.Collision3(collision2);
-    collision2.Collision3(collision1);
-
-    bool is_not_player_or_has_been_min_time = collision1.not_player_or_min_time_passed & collision2.not_player_or_min_time_passed;
-
-    // Apply force applies the motion effect of a collision
-    if(reaction1.apply_force && is_not_player_or_has_been_min_time)
-    {
-        collision1.applyForce();
-    }
-
-    if(reaction2.apply_force && is_not_player_or_has_been_min_time)
-    {
-        collision2.applyForce();
-    }
-
-    // Begin damage
-    if(!collision1.shouldDealDamage(collision2.unit->rSize()) &&
-            !collision2.shouldDealDamage())
-    {
-            return;
-    }
-
-    // Disable damage to NPC ships because... stupid AI ships always crash into each other.
-    if ( !collision_damage_to_ai && !collision1.is_player_ship && !collision2.is_player_ship &&
-         collision1.unit_type != MISSILEPTR && collision2.unit_type != MISSILEPTR)
-    {
-        return;
-    }
-
-    // Now we start to act on the above calculations,
-    // but only if we need to
-    if(reaction1.deal_damage)
-    {
-        collision1.applyDamage(collision2);
-    }
-    if(reaction2.deal_damage)
-    {
-        collision2.applyDamage(collision1);
-    }
+    // TODO: add torque
 }
-
-
-//HACK ALERT:
-//following code referencing minvel and time between collisions attempts
-//to alleviate ping-pong problems due to collisions being detected
-//after the player has penetrated the hull of another vessel because of discretization of time.
-//this should eventually be replaced by instead figuring out where
-//the point of collision should have occurred, and moving the vessels to the
-//actual collision location before applying forces
-
-//Need to incorporate normals of colliding polygons somehow, without overiding directions of travel.
-//We'll use the point object approximation for the magnitude of damage, and then apply the force along the appropriate normals
-//ThisElastic_vf=((ThisElastic_vf.Magnitude()>minvel||!thcp)?ThisElastic_vf.Magnitude():minvel)*smallnormal;
-//SmallerElastic_vf=((SmallerElastic_vf.Magnitude()>minvel||!smcp)?SmallerElastic_vf.Magnitude():minvel)*bignormal;
-
-
-//float LargeKE = (0.5)*m2*GetVelocity().MagnitudeSquared();
-//float SmallKE = (0.5)*m1*smalle->GetVelocity().MagnitudeSquared();
-//float FinalInelasticKE = Inelastic_vf.MagnitudeSquared()*(0.5)*(m1+m2);
-//float InelasticDeltaKE = LargeKE +SmallKE - FinalInelasticKE;
-//1/2Mass*deltavfromnoenergyloss^2

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -224,7 +224,8 @@ void Collision::applyForce(double elasticity, float& m2, Vector& v2)
     new_velocity = new_velocity * elasticity;
 
     // Apply force
-    unit->ApplyForce(new_velocity);
+    // Disabling - it messes with the thrusters
+    //unit->ApplyForce(new_velocity);
 }
 
 

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -222,6 +222,9 @@ void Collision::applyForce(double elasticity, float& m2, Vector& v2)
 
     // Apply ratio
     new_velocity = new_velocity * elasticity;
+
+    // Apply force
+    unit->ApplyForce(new_velocity);
 }
 
 

--- a/engine/src/cmd/collision.h
+++ b/engine/src/cmd/collision.h
@@ -1,0 +1,83 @@
+#ifndef COLLISION_H
+#define COLLISION_H
+
+#include "gfx/vec.h"
+#include "unit_generic.h"
+
+class Unit;
+class Cockpit;
+
+/* Rather than implement collision as part of unit as Collidable,
+ * I chose to implement a class for the collision itself.
+ * The reactToCollision method creates two collision object instances,
+ * one for each unit.
+ * It is used to reduce duplication of code, as much of the code is simple duplication.
+ * Because some variables rely on previous calculations using both units,
+ * we do initialization in stages.
+*/
+
+class Collision
+{
+    struct ReactionResult
+    {
+        bool apply_force = false;
+        bool deal_damage = false;
+
+        ReactionResult(bool apply_force, bool deal_damage):
+            apply_force(apply_force), deal_damage(deal_damage) {}
+    };
+
+    // Stage 1
+    Cockpit* cockpit;
+    Unit* unit;
+    clsptr unit_type;
+    bool is_player_ship;
+    const QVector& location;
+    const Vector& normal;
+    float mass;
+    Vector position;
+    Vector velocity;
+    Vector angular_velocity;
+    Vector linear_velocity; //Compute linear velocity of points of impact by taking into account angular velocities
+
+    // Stage 2
+    Vector aligned_velocity;
+    Vector elastic_vf;
+    Vector final_velocity;
+    float delta_e;
+
+    // Stage 3
+    float damage;
+    Vector force;
+    bool not_player_or_min_time_passed = true;
+    Vector delta;
+    float  magnitude;
+
+    Collision(Unit* unit, const QVector &location, const Vector& normal);
+    void Collision2(Matrix& from_new_reference, Matrix& to_new_reference,
+                      Vector inelastic_vf, Collision& other_collision);
+    void Collision3(Collision& other_collision);
+    ReactionResult reactionMatrix(Unit* other_unit);
+    void applyForce();
+    bool shouldDealDamage(float radial_size = 0.0);
+    void applyDamage(Collision other_collision);
+    bool crashLand(Unit *base);
+public:
+    static void collide( Unit* unit1,
+                           const QVector &location1,
+                           const Vector &normal1,
+                           Unit* unit2,
+                           const QVector &location2,
+                           const Vector &normal2,
+                           float distance );
+
+
+    void dealDamageFromCollision(Unit* unit, Unit* other_unit,
+                                 const QVector &other_unit_location, // biglocation
+                                 const Vector &other_unit_normal, // bignormal
+                                 const QVector &unit_location, // smalllocation
+                                 const Vector &unit_normal, // smallernormal
+                                 float distance);
+};
+
+#endif // COLLISION_H

--- a/engine/src/cmd/collision.h
+++ b/engine/src/cmd/collision.h
@@ -18,15 +18,6 @@ class Cockpit;
 
 class Collision
 {
-    struct ReactionResult
-    {
-        bool apply_force = false;
-        bool deal_damage = false;
-
-        ReactionResult(bool apply_force, bool deal_damage):
-            apply_force(apply_force), deal_damage(deal_damage) {}
-    };
-
     // Stage 1
     Cockpit* cockpit;
     Unit* unit;
@@ -37,30 +28,13 @@ class Collision
     float mass;
     Vector position;
     Vector velocity;
-    Vector angular_velocity;
-    Vector linear_velocity; //Compute linear velocity of points of impact by taking into account angular velocities
-
-    // Stage 2
-    Vector aligned_velocity;
-    Vector elastic_vf;
-    Vector final_velocity;
-    float delta_e;
-
-    // Stage 3
-    float damage;
-    Vector force;
-    bool not_player_or_min_time_passed = true;
-    Vector delta;
-    float  magnitude;
+    bool apply_force = false;
+    bool deal_damage = false;
 
     Collision(Unit* unit, const QVector &location, const Vector& normal);
-    void Collision2(Matrix& from_new_reference, Matrix& to_new_reference,
-                      Vector inelastic_vf, Collision& other_collision);
-    void Collision3(Collision& other_collision);
-    ReactionResult reactionMatrix(Unit* other_unit);
-    void applyForce();
-    bool shouldDealDamage(float radial_size = 0.0);
-    void applyDamage(Collision other_collision);
+    void shouldApplyForceAndDealDamage(Unit* other_unit);
+    void applyForce(double elasticity, float& m2, Vector& v2);
+    void dealDamage(Collision other_collision, float factor=0.01);
     bool crashLand(Unit *base);
 public:
     static void collide( Unit* unit1,
@@ -70,14 +44,6 @@ public:
                            const QVector &location2,
                            const Vector &normal2,
                            float distance );
-
-
-    void dealDamageFromCollision(Unit* unit, Unit* other_unit,
-                                 const QVector &other_unit_location, // biglocation
-                                 const Vector &other_unit_normal, // bignormal
-                                 const QVector &unit_location, // smalllocation
-                                 const Vector &unit_normal, // smallernormal
-                                 float distance);
 };
 
 #endif // COLLISION_H

--- a/engine/src/cmd/enhancement_generic.h
+++ b/engine/src/cmd/enhancement_generic.h
@@ -21,28 +21,6 @@ protected:
                  int fg_subnumber = 0 ) :
         Unit( filename, false, faction, modifications, flightgrp, fg_subnumber )
         , filename( filename ) {}
-public:
-    virtual void reactToCollision( Unit *smaller,
-                                   const QVector &biglocation,
-                                   const Vector &bignormal,
-                                   const QVector &smalllocation,
-                                   const Vector &smallnormal,
-                                   float dist )
-    {
-        if (smaller->isUnit() != ASTEROIDPTR) {
-            double percent;
-            char tempdata[sizeof (this->shield)];
-            memcpy( tempdata, &this->shield, sizeof (this->shield) );
-            shield.number = 0;     //don't want them getting our boosted shields!
-            shield.shield2fb.front = shield.shield2fb.back = shield.shield2fb.frontmax = shield.shield2fb.backmax = 0;
-            smaller->Upgrade( this, 0, 0, true, true, percent );
-            memcpy( &this->shield, tempdata, sizeof (this->shield) );
-            string fn( filename );
-            string fac( FactionUtil::GetFaction( faction ) );
-            Kill();
-            _Universe->AccessCockpit()->savegame->AddUnitToSave( fn.c_str(), ENHANCEMENTPTR, fac.c_str(), (long) this );
-        }
-    }
 protected:
 /// default constructor forbidden
     Enhancement() {}

--- a/engine/src/cmd/missile.h
+++ b/engine/src/cmd/missile.h
@@ -35,20 +35,7 @@ public:
         Missile::Discharge();
         GameUnit< Missile >::Kill( erase );
     }
-    virtual void reactToCollision( Unit *smaller,
-                                   const QVector &biglocation,
-                                   const Vector &bignormal,
-                                   const QVector &smalllocation,
-                                   const Vector &smallnormal,
-                                   float dist )
-    {
-        static bool doesmissilebounce = XMLSupport::parse_bool( vs_config->getVariable( "physics", "missile_bounce", "false" ) );
-        if (doesmissilebounce)
-            GameUnit< Missile >::reactToCollision( smaller, biglocation, bignormal, smalllocation, smallnormal, dist );
-        Discharge();
-        if (!killed)
-            DealDamageToHull( smalllocation.Cast(), hull+1 );      //should kill, applying addmissile effect
-    }
+
     virtual void UpdatePhysics2( const Transformation &trans,
                                  const Transformation &old_physical_state,
                                  const Vector &accel,

--- a/engine/src/cmd/missile_generic.cpp
+++ b/engine/src/cmd/missile_generic.cpp
@@ -128,25 +128,7 @@ void Missile::Kill( bool erase ) {
     Unit::Kill( erase );
 }
 
-void Missile::reactToCollision( Unit *smaller,
-                                const QVector &biglocation,
-                                const Vector &bignormal,
-                                const QVector &smalllocation,
-                                const Vector &smallnormal,
-                                float dist ) {
-    static bool doesmissilebounce = XMLSupport::parse_bool( vs_config->getVariable( "physics", "missile_bounce", "false" ) );
-    if (doesmissilebounce)
-        Unit::reactToCollision( smaller, biglocation, bignormal, smalllocation, smallnormal, dist );
-    BOOST_LOG_TRIVIAL(info) << boost::format("Missile collided with %1%") % smaller->name.get();
-    if (smaller->isUnit() != MISSILEPTR) {
-        //2 missiles in a row can't hit each other
-        this->Velocity = smaller->Velocity;
-        Velocity = smaller->Velocity;
-        Discharge();
-        if (!killed)
-            DealDamageToHull( smalllocation.Cast(), hull+1 );              //should kill, applying addmissile effect
-    }
-}
+
 
 Unit * getNearestTarget( Unit *me )
 {

--- a/engine/src/cmd/missile_generic.h
+++ b/engine/src/cmd/missile_generic.h
@@ -98,12 +98,6 @@ protected:
 
 public:
     virtual void Kill( bool eraseFromSave = true );
-    virtual void reactToCollision( Unit *smaller,
-                                   const QVector &biglocation,
-                                   const Vector &bignormal,
-                                   const QVector &smalllocation,
-                                   const Vector &smallnormal,
-                                   float dist );
     virtual void UpdatePhysics2( const Transformation &trans,
                                  const Transformation &old_physical_state,
                                  const Vector &accel,

--- a/engine/src/cmd/nebula_generic.cpp
+++ b/engine/src/cmd/nebula_generic.cpp
@@ -135,7 +135,9 @@ Nebula::Nebula( const char *unitfile, bool SubU, int faction, Flightgroup *fg, i
     this->InitNebula( unitfile, SubU, faction, fg, fg_snumber );
 }
 
-void Nebula::reactToCollision( Unit *smaller,
+// Not sure what this does but disabled it for now
+// TODO: find out and do something with this code
+/*void Nebula::reactToCollision( Unit *smaller,
                                const QVector &biglocation,
                                const Vector &bignormal,
                                const QVector &smalllocation,
@@ -145,7 +147,7 @@ void Nebula::reactToCollision( Unit *smaller,
     if (fogme)
         SetNebula( this );
     smaller->SetNebula( this );
-}
+}*/
 
 void Nebula::UpdatePhysics2( const Transformation &trans,
                              const Transformation &old_physical_state,

--- a/engine/src/cmd/nebula_generic.h
+++ b/engine/src/cmd/nebula_generic.h
@@ -30,12 +30,6 @@ public:
     {
         return NEBULAPTR;
     }
-    virtual void reactToCollision( Unit *smaller,
-                                   const QVector &biglocation,
-                                   const Vector &bignormal,
-                                   const QVector &smalllocation,
-                                   const Vector &smallnormal,
-                                   float dist );
 
 protected:
 /// constructor only to be called by UnitFactory

--- a/engine/src/cmd/planet.cpp
+++ b/engine/src/cmd/planet.cpp
@@ -443,7 +443,10 @@ void GamePlanet::DrawTerrain()
 
 extern bool CrashForceDock( Unit *thus, Unit *dockingUn, bool force );
 extern void abletodock( int dock );
-void GamePlanet::reactToCollision( Unit *un,
+
+// Disabled this code.
+// Most of it does nothing at this point.
+/*void GamePlanet::reactToCollision( Unit *un,
                                    const QVector &biglocation,
                                    const Vector &bignormal,
                                    const QVector &smalllocation,
@@ -459,12 +462,12 @@ void GamePlanet::reactToCollision( Unit *un,
         un->SetPlanetOrbitData( terraintrans );
         Matrix top;
         Identity( top );
-        /*
-         *  Vector posRelToTerrain = terraintrans->InvTransform(un->LocalPosition());
-         *  top[12]=un->Position().i- posRelToTerrain.i;
-         *  top[13]=un->Position().j- posRelToTerrain.j;
-         *  top[14]=un->Position().k- posRelToTerrain.k;
-         */
+
+         //  Vector posRelToTerrain = terraintrans->InvTransform(un->LocalPosition());
+         // top[12]=un->Position().i- posRelToTerrain.i;
+         // top[13]=un->Position().j- posRelToTerrain.j;
+         // top[14]=un->Position().k- posRelToTerrain.k;
+
         Vector P, Q, R;
         un->GetOrientation( P, Q, R );
         terraintrans->InvTransformBasis( top, P, Q, R, un->Position() );
@@ -492,7 +495,8 @@ void GamePlanet::reactToCollision( Unit *un,
     }
     //nothing happens...you fail to do anythign :-)
     //maybe air reisstance here? or swithc dynamics to atmos mode
-}
+}*/
+
 void GamePlanet::EnableLights()
 {
     for (unsigned int i = 0; i < lights.size(); i++)

--- a/engine/src/cmd/planet.h
+++ b/engine/src/cmd/planet.h
@@ -96,12 +96,7 @@ public:
     {
         return atmosphere;
     }
-    void reactToCollision( Unit *smaller,
-                           const QVector &biglocation,
-                           const Vector &bignormal,
-                           const QVector &smalllocation,
-                           const Vector &smallnormal,
-                           float dist );
+
 
     friend class Planet::PlanetIterator;
     friend class PlanetaryOrbit;

--- a/engine/src/cmd/planet_generic.h
+++ b/engine/src/cmd/planet_generic.h
@@ -149,15 +149,7 @@ public:
     {
         return NULL;
     }
-    virtual void reactToCollision( Unit *smaller,
-                                   const QVector &biglocation,
-                                   const Vector &bignormal,
-                                   const QVector &smalllocation,
-                                   const Vector &smallnormal,
-                                   float dist )
-    {
-        this->Unit::reactToCollision( smaller, biglocation, bignormal, smalllocation, smallnormal, dist );
-    }
+
 
     class PlanetIterator
     {

--- a/engine/src/cmd/unit_collide.cpp
+++ b/engine/src/cmd/unit_collide.cpp
@@ -21,6 +21,7 @@
 #include "collide.h"
 #include "vsfilesystem.h"
 
+#include "collision.h"
 #include "universe.h"
 
 static bool operator==( const Collidable &a, const Collidable &b )
@@ -289,17 +290,20 @@ bool Unit::Collide( Unit *target )
         QVector bigpos, smallpos;
         Vector  bigNormal, smallNormal;
         if ( bigger->InsideCollideTree( smaller, bigpos, bigNormal, smallpos, smallNormal ) ) {
-            if ( !bigger->isDocked( smaller ) && !smaller->isDocked( bigger ) )
-                bigger->reactToCollision( smaller, bigpos, bigNormal, smallpos, smallNormal, 10 );
-            else return false;
+            if ( !bigger->isDocked( smaller ) && !smaller->isDocked( bigger ) ) {
+                //bigger->reactToCollision( smaller, bigpos, bigNormal, smallpos, smallNormal, 10 );
+                Collision::collide(bigger, bigpos, bigNormal, smaller, smallpos, smallNormal, 10);
+            } else return false;
         } else {return false; }
     } else {
         Vector normal( -1, -1, -1 );
         float  dist = 0.0;
         if ( bigger->Inside( smaller->Position(), smaller->rSize(), normal, dist ) ) {
-            if ( !bigger->isDocked( smaller ) && !smaller->isDocked( bigger ) )
-                bigger->reactToCollision( smaller, bigger->Position(), normal, smaller->Position(), -normal, dist );
-            else return false;
+            if ( !bigger->isDocked( smaller ) && !smaller->isDocked( bigger ) ) {
+                //bigger->reactToCollision( smaller, bigger->Position(), normal, smaller->Position(), -normal, dist );
+                Collision::collide(bigger, bigger->Position(), normal, smaller,
+                                            smaller->Position(), -normal, dist);
+            } else return false;
         } else {
             return(false);
         }

--- a/engine/src/cmd/unit_generic.cpp
+++ b/engine/src/cmd/unit_generic.cpp
@@ -319,7 +319,7 @@ bool CrashForceDock( Unit *thus, Unit *dockingUn, bool force )
     return false;
 }
 
-void Unit::reactToCollision( Unit *smalle,
+/*void Unit::reactToCollision( Unit *smalle,
                              const QVector &biglocation,
                              const Vector &bignormal,
                              const QVector &smalllocation,
@@ -544,7 +544,7 @@ void Unit::reactToCollision( Unit *smalle,
             }
         }
     }
-}
+}*/
 
 void Unit::ActivateJumpDrive( int destination )
 {

--- a/engine/src/cmd/unit_generic.h
+++ b/engine/src/cmd/unit_generic.h
@@ -1119,12 +1119,13 @@ public:
                             Vector &smallNormal,
                             bool bigasteroid = false,
                             bool smallasteroid = false );
-    virtual void reactToCollision( Unit *smaller,
-                                   const QVector &biglocation,
-                                   const Vector &bignormal,
-                                   const QVector &smalllocation,
-                                   const Vector &smallnormal,
-                                   float dist );
+//    virtual void reactToCollision( Unit *smaller,
+//                                   const QVector &biglocation,
+//                                   const Vector &bignormal,
+//                                   const QVector &smalllocation,
+//                                   const Vector &smallnormal,
+//                                   float dist );
+
 //returns true if jump possible even if not taken
 //Uses Universe thing
     bool jumpReactToCollision( Unit *smaller );

--- a/engine/src/cmd/unit_type.h
+++ b/engine/src/cmd/unit_type.h
@@ -1,0 +1,16 @@
+#ifndef UNIT_TYPE_H
+#define UNIT_TYPE_H
+
+// UnitType is already taken
+// TODO: rename to expected
+enum class UnitTypeEnum {
+    asteroid,
+    building,
+    enhancement,
+    missile,
+    nebula,
+    planet,
+    unit
+};
+
+#endif // UNIT_TYPE_H

--- a/engine/src/game_config.h
+++ b/engine/src/game_config.h
@@ -5,6 +5,8 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/foreach.hpp>
+#include <boost/algorithm/string.hpp>
+
 #include <string>
 #include <set>
 #include <map>
@@ -38,6 +40,14 @@ public:
 
 
 
+template <>
+inline bool GameConfig::GetVariable(string const &section, string const &name, bool default_value)
+{
+    string result = _GetVariable(section, name);
+    if(result == DEFAULT_ERROR_VALUE) return default_value;
+    boost::algorithm::to_lower(result);
+    return result == "true";
+}
 
 template <>
 inline float GameConfig::GetVariable(string const &section, string const &name, float default_value)

--- a/engine/src/gfx/tvector.h
+++ b/engine/src/gfx/tvector.h
@@ -63,8 +63,6 @@ public:
     TVector& operator-=( const TVector &obj );
     TVector& operator*=( const T &obj );
 
-
-private:
     const TVector<T,S>& operator=( const TVector<T,S> &a );
 
 // Methods


### PR DESCRIPTION
Purpose:
- What is this pull request trying to do? This is the refactoring of the reactToCollision functions throughout the unit class hierarchy. I've extracted the code and centralized it in a separate class. While it is still impossible to write unit tests for it, a second refactor will enable that too.  
- What release is this for? 0.7
- Is there a project or milestone we should apply this to? 0.7

Issues:
- Collision between units still isn't good, though better than before IMO. Units typically explode on impact.

Code Changes:
- [No ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation



