### PR TITLE
Retire py2 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,105 +15,84 @@ jobs:
     include:
         - os: linux
           compiler: gcc
-          name: "Ubuntu 20.04 LTS - GCC"
+          name: "Ubuntu 20.04 LTS - Py3 GCC"
           env:
             - FROM='ubuntu:focal'
             - COMPILER='gcc'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
+            - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "Ubuntu 20.04 LTS - Clang"
-          env:
-            - FROM='ubuntu:focal'
-            - COMPILER='clang'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
-        - os: linux
-          compiler: clang
-          name: "Ubuntu 20.04 LTS - Py3"
+          name: "Ubuntu 20.04 LTS - Py3 Clang"
           env:
             - FROM='ubuntu:focal'
             - COMPILER='clang'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: gcc
-          name: "Ubuntu 18.04 LTS - GCC"
+          name: "Ubuntu 18.04 LTS - Py3 GCC"
           env:
             - FROM='ubuntu:bionic'
             - COMPILER='gcc'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
+            - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "Ubuntu 18.04 LTS - Clang"
-          env:
-            - FROM='ubuntu:bionic'
-            - COMPILER='clang'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
-        - os: linux
-          compiler: clang
-          name: "Ubuntu 18.04 LTS - Py3"
+          name: "Ubuntu 18.04 LTS - Py3 Clang"
           env:
             - FROM='ubuntu:bionic'
             - COMPILER='clang'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: gcc
-          name: "Ubuntu 16.04 LTS - GCC"
-          env:
-            - FROM='ubuntu:xenial'
-            - COMPILER='gcc'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
-        - os: linux
-          compiler: clang
-          name: "Ubuntu 16.04 LTS - Clang"
-          env:
-            - FROM='ubuntu:xenial'
-            - COMPILER='clang'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
-        - os: linux
-          compiler: gcc
-          name: "Ubuntu 16.04 LTS - Py3"
+          name: "Ubuntu 16.04 LTS - Py3 GCC"
           env:
             - FROM='ubuntu:xenial'
             - COMPILER='gcc'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "Debian 10 - Py3"
+          name: "Ubuntu 16.04 LTS - Py3 Clang"
+          env:
+            - FROM='ubuntu:xenial'
+            - COMPILER='clang'
+            - FLAGS='-DUSE_PYTHON_3=ON'
+        - os: linux
+          compiler: clang
+          name: "Debian 10 - Py3 Clang"
           env:
             - FROM='debian:buster'
             - COMPILER='clang'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: gcc
-          name: "Debian 9 - GCC"
+          name: "Debian 9 - Py3 GCC"
           env:
             - FROM='debian:stretch'
             - COMPILER='gcc'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
+            - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "openSUSE Leap 15.2 - Py3"
+          name: "openSUSE Leap 15.2 - Py3 Clang"
           env:
             - FROM='opensuse/leap'
             - COMPILER='clang'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "Fedora 33 - Py3"
+          name: "Fedora 33 - Py3 Clang"
           env:
             - FROM='fedora:33'
             - COMPILER='clang'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "Fedora 32 - Py3"
+          name: "Fedora 32 - Py3 Clang"
           env:
             - FROM='fedora:32'
             - COMPILER='clang'
             - FLAGS='-DUSE_PYTHON_3=ON'
         - os: linux
           compiler: clang
-          name: "CentOS 8 - Py3"
+          name: "CentOS 8 - Py3 Clang"
           env:
             - FROM='centos:8'
             - COMPILER='clang'
@@ -121,7 +100,7 @@ jobs:
         - os: osx
           osx_image: xcode11.3
           env:
-            - FLAGS='-DUSE_PYTHON_3=OFF -DBoost_NO_BOOST_CMAKE=ON'
+            - FLAGS='-DUSE_PYTHON_3=ON -DBoost_NO_BOOST_CMAKE=ON'
         - os: osx
           osx_image: xcode11.3
           env:
@@ -131,11 +110,11 @@ jobs:
         - os: linux
           # dist: xenial
           compiler: clang
-          name: "Ubuntu 16.04 LTS - Clang"
+          name: "Ubuntu 16.04 LTS - Py3 Clang"
           env:
             - FROM='ubuntu:xenial'
             - COMPILER='clang'
-            - FLAGS='-DUSE_PYTHON_3=OFF'
+            - FLAGS='-DUSE_PYTHON_3=ON'
     fast_finish: true
 
 addons:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /usr/src/Vega-Strike-Engine-Source
 COPY . .
 
 ENTRYPOINT ["script/docker-entrypoint.sh"]
-CMD ["-DUSE_PYTHON_3=OFF"]
+CMD ["-DUSE_PYTHON_3=ON"]

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -752,13 +752,14 @@ CHECK_TYPE_SIZE("void*" SIZEOF_VOID_P BUILTIN_TYPES_ONLY)
 # Let cmake find our in-tree modules
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${Vega_Strike_SOURCE_DIR})
 
-# Python 3 has a SASL compatibility issue which causes an error
-# on some installations that prefer Python 3
-# -- Python 2.7 is default for now
-OPTION(USE_PYTHON_3 "Use Python 3 instead of Python 2.7 (default is 2.7)" OFF)
+# Python 3 is now our default -- stephengtuggy 2020-12-18
+## Python 3 has a SASL compatibility issue which causes an error
+## on some installations that prefer Python 3
+## -- Python 2.7 is default for now
+OPTION(USE_PYTHON_3 "Use Python 3 or Python 2.7 (default is 3)" ON)
 IF (USE_PYTHON_3)
     # We want at least Python 3.4, but we prefer newer versions
-    SET(Python_ADDITIONAL_VERSIONS 3.8 3.7 3.6 3.5 3.4)
+    SET(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5 3.4)
 ELSE (USE_PYTHON_3)
     SET(Python_ADDITIONAL_VERSIONS 2.7)
 ENDIF (USE_PYTHON_3)
@@ -810,13 +811,13 @@ IF (USE_SYSTEM_BOOST)
         ELSEIF (USE_PYTHON_3)
             SET(BOOST_PYTHON_COMPONENT "python3")
 
-            # Xenial lacks libboost_python3.{so|a} but has libboost_python-py{major}{minor}.{so|a}
-            # (This is common to all Debian and Debian-based systems up to Boost 1.67,
-            #   it's just not needed for any other Debian-based system (at the moment).)
+            # Debian and Debian-based systems up to Boost 1.67 lack libboost_python3.{so|a}
+            # but have libboost_python-py{major}{minor}.{so|a}. E.g., Ubuntu xenial and 
+            # Debian stretch.
             IF (CMAKE_SYSTEM_NAME STREQUAL Linux)
-                IF (LINUX_CODENAME STREQUAL xenial)
+                IF (LINUX_CODENAME STREQUAL xenial OR LINUX_CODENAME STREQUAL stretch)
                     SET(BOOST_PYTHON_COMPONENT "python-py3${PYTHON_VERSION_MINOR}")
-                ENDIF (LINUX_CODENAME STREQUAL xenial)
+                ENDIF (LINUX_CODENAME STREQUAL xenial OR LINUX_CODENAME STREQUAL stretch)
             ENDIF (CMAKE_SYSTEM_NAME STREQUAL Linux)
 
         ELSE (Boost_1_67_Or_Later_Result)


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] This is a CI/CD/build system change only

Issues:
- Please list any related issues
**#362** 

Purpose:
- What is this pull request trying to do? **Retire the Python 2 builds, which we no longer officially support as of 0.8.x**
- What release is this for? **0.8.x**
- Is there a project or milestone we should apply this to? **0.8.x**
