### PR TITLE
Read galaxy XML file name from vegastrike.config

### DIFF
--- a/engine/src/vsfilesystem.cpp
+++ b/engine/src/vsfilesystem.cpp
@@ -710,7 +710,10 @@ void LoadConfig( string subdir )
         BOOST_LOG_TRIVIAL(info) << boost::format("DATADIR - No datadir specified in config file, using : %1%") % datadir;
     }
 
-    string universe_file = datadir + "/universe/milky_way.xml";
+    string universe_file = datadir + "/" \
+        + vs_config->getVariable( "data", "universe_path", "universe" ) + "/" \
+        + vs_config->getVariable( "general", "galaxy", "milky_way.xml" );
+    BOOST_LOG_TRIVIAL(debug) << "Force galaxy to " << universe_file;
     Galaxy galaxy = Galaxy(universe_file);
 }
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? **The game loads and a new campaign can be started.**
- [ ] This is a documentation change only

Issues:
#389

Purpose:
This PR allows the hard-coded galaxy name (`universe/milky_way.xml`) to be overridden by settings in `vegastrike.config`.
