### PR TITLE
Bug Fix: script/package - binary locations (0.7.x)

### DIFF
--- a/script/package
+++ b/script/package
@@ -17,8 +17,8 @@ BIN_DIR=$ROOT_DIR/bin
 SRC_DIR=$ROOT_DIR/engine
 PACKAGE_DIR=$ROOT_DIR/packages
 VS_EXECUTABLE=${BUILD_DIR}/vegastrike
-VS_CONFIG_EXECUTABLE=${BUILD_DIR}/vegasettings
-VS_MESH_EXECUTABLE=${BUILD_DIR}/vega-meshtool
+VS_CONFIG_EXECUTABLE=${BUILD_DIR}/setup/vegasettings
+VS_MESH_EXECUTABLE=${BUILD_DIR}/objconv/vega-meshtool
 DEPS_LOOKUP_FILE=${BUILD_DIR}/dependency.lookup
 DEPS_FINALIZED=${BUILD_DIR}/dependency.list
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] CI system change

Issues:
- #391 

Purpose:
Fixes the `script/package` for the new location of the mesh and settings tools