### PR TITLE
Bug Fix: run cmake before packaging

### DIFF
--- a/script/package
+++ b/script/package
@@ -154,6 +154,9 @@ function copyFiles()
 
 function buildPackages()
 {
+	# before running make package regen the Cmake data so that
+	# it picks up the dependencies just generated
+	cmake "${SRC_DIR}"
 	make package
 	make package_source
 }


### PR DESCRIPTION
There's a circular relationship between CMake and the dependency.list
file such that CMake has to be run first to build the binaries,
then script/package to build the dependencies, but then CMake has
to be run again for CPack to pick up the dependency list for the
packages to be correct as intended.

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] CI only

Issues:
- #391

Purpose:
- Make the build system re-run cmake after building the dependencies so it picks up the right ones
- Synchronizes and additional change from #424 to 0.7.x

NOTE: This alleviates the issues external to the CMake configuration itself.