### PR TITLE
cmake: Fix DATA_DIR quoting

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -599,7 +599,7 @@ IF (CPU_SMP GREATER 1)
 ENDIF (CPU_SMP GREATER 1)
 
 IF (DATADIR)
-    SET(DEFINES "${DEFINES} -DDATA_DIR=\"${DATADIR}\"")
+    SET(DEFINES "${DEFINES} -DDATA_DIR='\"${DATADIR}\"'")
 ENDIF (DATADIR)
 
 # Gather info about Linux distro and release (if applicable) for later use down below.


### PR DESCRIPTION
First level quoting is used for cmake,
second level is consumed by the shell executing the compiler,
so there needs to be a third level for the `DATA_DIR` macro to be recognized as a string inside the source files.

Without this patch currently it will get transformed like this:
```
cmake: "${DEFINES} -DDATA_DIR=\"${DATADIR}\""
calls gcc:
gcc ... -DDATA_DIR="/foo/bar"
defines:
#define DATA_DIR /foo/bar
```
So the DATA_DIR is no longer a string.
