### PR TITLE
posh.h add Aarch64 support

### DIFF
--- a/engine/src/posh.h
+++ b/engine/src/posh.h
@@ -561,6 +561,17 @@
 #  endif
 #endif
 
+/* ------------------------------------------------------------------
+** AArch64
+** ------------------------------------------------------------------
+*/
+#if defined __aarch64__ || defined __arm64__ || defined FORCE_DOXYGEN
+#  define POSH_CPU_AARCH64 /**<if defined, target CPU is AArch64 */
+#  if !defined FORCE_DOXYGEN
+#     define POSH_CPU_STRING "AArch64"
+#  endif
+#endif
+
 /** @} */
 
 #if !defined POSH_CPU_STRING


### PR DESCRIPTION
This is a patch from the openSUSE games repository to enable Aarch64 support.