### PR TITLE
Don't utf8-check New_Game

### DIFF
--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -5979,7 +5979,7 @@ bool BaseComputer::actionConfirmedLoadGame()
     if (desc) {
         std::string tmp = desc->text();
         if (tmp.length() > 0) {
-           if ((tmp != "New_Game") && (!isUtf8SaveGame(tmp))) {
+            if ((string( "New_Game" ) != tmp) && (!isUtf8SaveGame(tmp))) {
                 showAlert( tmp + " is not UTF-8, convert it before loading" );
                 return true;
             }

--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -5979,7 +5979,7 @@ bool BaseComputer::actionConfirmedLoadGame()
     if (desc) {
         std::string tmp = desc->text();
         if (tmp.length() > 0) {
-            if (!isUtf8SaveGame(tmp)) {
+           if ((tmp != "New_Game") && (!isUtf8SaveGame(tmp))) {
                 showAlert( tmp + " is not UTF-8, convert it before loading" );
                 return true;
             }


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- #149 

Purpose:
- What is this pull request trying to do?  **Skipping the utf-check for the New_Game special case as it's not a real file; it makes the Campaign (main menu) and New (while docked in game) buttons work properly**
- What release is this for?  **0.8.x**
- Is there a project or milestone we should apply this to?  **0.8.x**
