### PR TITLE
Backport 470 0.8.x

### DIFF
--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -5979,7 +5979,7 @@ bool BaseComputer::actionConfirmedLoadGame()
     if (desc) {
         std::string tmp = desc->text();
         if (tmp.length() > 0) {
-           if ((tmp != "New_Game") && (!isUtf8SaveGame(tmp))) {
+            if ((string( "New_Game" ) != tmp) && (!isUtf8SaveGame(tmp))) {
                 showAlert( tmp + " is not UTF-8, convert it before loading" );
                 return true;
             }

--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -5979,7 +5979,7 @@ bool BaseComputer::actionConfirmedLoadGame()
     if (desc) {
         std::string tmp = desc->text();
         if (tmp.length() > 0) {
-            if (!isUtf8SaveGame(tmp)) {
+           if ((tmp != "New_Game") && (!isUtf8SaveGame(tmp))) {
                 showAlert( tmp + " is not UTF-8, convert it before loading" );
                 return true;
             }


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- #149, #470

Purpose:
Backport #470 to 0.8.x - a slight tweak of #463 to prevent overlaps with the in-game constant saved game name of `New Game`
Thanks @P-D-E for the work!

Test Details:
- Test 1: Start game; select Load, select an invalid UTF-8 saved game; click load.
- Test 2: Start game; start a new campaign; go to the concourse; click save/load; select an invalid UTF-8 saved game; click load

In both cases it should fail to load the game and present a message to the user.