### PR TITLE
MacOS CI Workflow File

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,0 +1,75 @@
+name: 'MacOS - CI'
+
+on:
+  # Activate on pull-requests...
+  #pull_request:
+
+  # ...pushes to certain branches...
+  push:
+    branches: [osx-gha]
+
+  # ...or manually
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - clang
+          - gcc
+        override:
+          - -
+          - opengl
+          - openal
+
+    steps:
+
+    # Dependencies provided in the macos-latest image:
+    # - jpeg
+    # - libpng
+    # - libvorbis
+    - name: Install general dependencies using homebrew
+      run: brew install boost-python3 gtk+3 gtkglext sdl
+
+    # The following Apple-provided libraries are deprecated:
+    # * OpenGL as of MacOS 10.14
+    # * GLUT as of MacOS 10.9
+    - name: Install homebrewed OpenGL and GLUT
+      if: ${{ matrix.override == 'opengl' }}
+      run: |
+        brew install mesa mesa-glu freeglut
+        ln -s /usr/local/include/GL /usr/local/include/OpenGL
+        ln -s /usr/local/include/GL /usr/local/include/GLUT
+        ln -s /usr/local/lib/libGL.dylib /usr/local/lib/libOpenGL.dylib
+
+    # The Apple-provided OpenAL is deprecated as of MacOS 10.15
+    - name: Install homebrewed OpenAL
+      if: ${{ matrix.override == 'openal' }}
+      run: brew install openal-soft
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+        submodules: false
+
+    # Ensure PRs are built against the PR Head
+    # As opposed to the merge commit
+    - name: Conditionally relocate to PR HEAD
+      if: github.event.pull_request
+      run: git checkout HEAD^2
+
+    - name: Build it
+      env:
+        MY_OS_NAME: macos
+        COMPILER:   ${{ matrix.compiler }}
+        FLAGS:      -DCMAKE_FIND_FRAMEWORK=LAST
+        OPENALDIR:  "/usr/local/opt/openal-soft"
+      run: script/cibuild $FLAGS

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,4 +1,4 @@
-name: 'MacOS - CI'
+name: 'MacOS-CI'
 
 on:
   # Activate manually
@@ -7,11 +7,13 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - macos-10.15
         compiler:
           - clang
           - gcc
@@ -22,17 +24,23 @@ jobs:
 
     steps:
 
-    # Dependencies provided in the macos-latest image:
+    # The following dependencies are already present within macos-* images:
+    # - clang (llvm 12)
+    # - cmake
+    # - expat
+    # - gcc (9, 10, 11)
+    # - git
     # - jpeg
     # - libpng
     # - libvorbis
-    - name: Install general dependencies using homebrew
+    # - python (3.8, 3.9)
+    - name: Install dependencies using homebrew
       run: brew install boost-python3 gtk+3 gtkglext sdl
 
     # The following Apple-provided libraries are deprecated:
     # * OpenGL as of MacOS 10.14
     # * GLUT as of MacOS 10.9
-    - name: Install homebrewed OpenGL and GLUT
+    - name: Optionally install homebrewed OpenGL and GLUT
       if: ${{ matrix.override == 'opengl' }}
       run: |
         brew install mesa mesa-glu freeglut
@@ -41,7 +49,7 @@ jobs:
         ln -s /usr/local/lib/libGL.dylib /usr/local/lib/libOpenGL.dylib
 
     # The Apple-provided OpenAL is deprecated as of MacOS 10.15
-    - name: Install homebrewed OpenAL
+    - name: Optionally install homebrewed OpenAL
       if: ${{ matrix.override == 'openal' }}
       run: brew install openal-soft
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,14 +1,7 @@
 name: 'MacOS - CI'
 
 on:
-  # Activate on pull-requests...
-  #pull_request:
-
-  # ...pushes to certain branches...
-  push:
-    branches: [osx-gha]
-
-  # ...or manually
+  # Activate manually
   workflow_dispatch:
 
 jobs:

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -916,6 +916,23 @@ ELSE (OPENGL_FOUND AND OPENGL_GLU_FOUND)
     MESSAGE("!! Why you no have GL?")
 ENDIF (OPENGL_FOUND AND OPENGL_GLU_FOUND)
 
+# Workaround two oversights in FindGLUT (when trying to use freeglut on MacOS):
+#
+# 1. Use of OPENGL_LIBRARY_DIR
+#    This was added to FindOpenGL in June 2002, then removed 3 months later. In that time it had
+#    made its way into use within FindGLUT, where (oddly) it was used as a possible
+#    location of GLUT's headers but not its libraries. From here, it was never removed.
+#
+# 2. Missing path component
+#    FindGLUT looks for glut.h in various locations when (on MacOS) it should be looking for
+#    GLUT/glut.h. We use the latter in our headers when building on MacOS, so the include path
+#    FindGLUT returns isn't actually of any use, but if FindGLUT can't find glut.h the build
+#    ends up using Apple's deprecated Framework (which defeats the purpose of using freeglut).
+#
+# If we're not on MacOS and using freeglut this line is not required, but as OPENGL_LIBRARY_DIR
+# is not used by anything else the following does no harm either.
+SET(OPENGL_LIBRARY_DIR "${OPENGL_INCLUDE_DIR}/GLUT")
+
 #Find GLUT
 FIND_PACKAGE(GLUT REQUIRED)
 IF (GLUT_FOUND)

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,21 +9,22 @@
 
 set -e
 
+if [ "$COMPILER" == "gcc" ]
+then
+    export CC=gcc
+    export CXX=g++
+elif [ "$COMPILER" == "clang" ]
+then
+    export CC=clang
+    export CXX=clang++
+fi
+
 if [ "$MY_OS_NAME" == "linux" ]
 then
     SRC_DOCKER_IMG_NAME="vegastrike/vega-strike-build-env:$(echo $FROM | sed 's/:/_/' | sed 's/\//_/')"
     DST_DOCKER_IMG_NAME="building-vega-strike:$(echo $FROM | sed 's/:/_/' | sed 's/\//_/')"
     DOCKER_CONTAINER_NAME="building-vega-strike_$(echo $FROM | sed 's/:/_/' | sed 's/\//_/')"
     docker build --build-arg from=$SRC_DOCKER_IMG_NAME -t $DST_DOCKER_IMG_NAME .
-    if [ "$COMPILER" == "gcc" ]
-    then
-        export CC=gcc
-        export CXX=g++
-    elif [ "$COMPILER" == "clang" ]
-    then
-        export CC=clang
-        export CXX=clang++
-    fi
     docker run --env CC=$CC --env CXX=$CXX --env IS_RELEASE=$IS_RELEASE --env TAG_NAME=$TAG_NAME --env FLAGS=$FLAGS --name $DOCKER_CONTAINER_NAME $DST_DOCKER_IMG_NAME $FLAGS
     docker cp $DOCKER_CONTAINER_NAME:/usr/src/Vega-Strike-Engine-Source/bin .
     if [ $IS_RELEASE -eq 1 ]
@@ -31,6 +32,10 @@ then
         docker cp $DOCKER_CONTAINER_NAME:/usr/src/Vega-Strike-Engine-Source/packages .
     fi
     docker rm $DOCKER_CONTAINER_NAME
+elif [ "$MY_OS_NAME" == "macos" ]
+then
+    script/build.sh -DCMAKE_BUILD_TYPE=RelWithDebInfo $@
+    # Not building successfully yet, so shouldn't try to package it
 else
     script/docker-entrypoint.sh $@
 fi


### PR DESCRIPTION
This PR provides a workflow for a MacOS CI. For now it must be manually activated, however [here is a recent run](https://github.com/s0600204/Vega-Strike-Engine-Source/actions/runs/929734201) to give some idea of what the end result is.

As mentioned in the related issue (#78), both `OpenAL` and `OpenGL` (or at least the Apple-provided implementations of them) are now considered deprecated on MacOS. Thus the workflow file, along with testing building with both `clang` and `gcc`, also provide jobs that attempt to use alternate `OpenAL` and `OpenGL` implementations (`OpenAL-soft` and `Mesa3D`/`freeGLUT` respectively).

The PR does not contain any attempted fixes for building on MacOS, other than that needed to facilitate using `OpenAL-soft`, `Mesa3D`, and `freeGLUT`. (For those, see the below "related branch".)

----

Code Changes:
- [x] This is a CI-Change, no gameplay modifications made

Related Issues:
- #78
- #170 (Discussion of moving away from OpenGL)

Related branch:
- [WIP MacOS Build Fixes](https://github.com/s0600204/Vega-Strike-Engine-Source/tree/macosx)
    - (Feel free to adopt this branch upstream as proceeding any further is somewhat beyond my capabilities at this time.)