### PR TITLE
engine/src/cmd/movable.cpp: Apply ermo's suggested patch for arithmetic exception during PWCU game load

### DIFF
--- a/engine/src/cmd/movable.cpp
+++ b/engine/src/cmd/movable.cpp
@@ -71,8 +71,8 @@ Movable::Movable() : cumulative_transformation_matrix( identity_matrix ) {
         maxnonplayerrotationrate = GameConfig::GetVariable( "physics", "maxNPCrot", 360);
         warpstretchcutoff = GameConfig::GetVariable( "graphics", "warp_stretch_cutoff", 500000) * GameConfig::GetVariable( "physics", "game_speed", 1);
         warpstretchoutcutoff = GameConfig::GetVariable( "graphics", "warp_stretch_decel_cutoff", 500000) * GameConfig::GetVariable( "physics", "game_speed", 1);
-        sec = GameConfig::GetVariable( "graphics", "insys_jump_ani_second_ahead", 4) / (GameConfig::GetVariable( "physics", "game_speed", 1) * GameConfig::GetVariable( "physics", "game_accel", 1));
-        endsec = GameConfig::GetVariable( "graphics", "insys_jump_ani_second_ahead_end",0.03f) /( GameConfig::GetVariable( "physics", "game_speed",1.0f) *GameConfig::GetVariable( "physics", "game_accel", 1.0f) );
+        sec = GameConfig::GetVariable( "graphics", "insys_jump_ani_second_ahead", 4.0f) / (GameConfig::GetVariable( "physics", "game_speed", 1.0f) * GameConfig::GetVariable( "physics", "game_accel", 1.0f));
+        endsec = GameConfig::GetVariable( "graphics", "insys_jump_ani_second_ahead_end", 0.03f) /( GameConfig::GetVariable( "physics", "game_speed", 1.0f) *GameConfig::GetVariable( "physics", "game_accel", 1.0f) );
         //Pi^2
         warpMultiplierMin = GameConfig::GetVariable( "physics", "warpMultiplierMin", 9.86960440109f);
         //C


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- #474 

Purpose:
- What is this pull request trying to do? Fix arithmetic exception that occurs while loading PWCU
- What release is this for? 0.8.x
- Is there a project or milestone we should apply this to? 0.8.x

PR Validation Tests have been run. This PR has been tested with both the PWCU and VS:UtCS datasets. Note, however, that Jenek's second mission caused an error in the Python assets:

```
TypeError: 'type' object is not subscriptable
```

apparently on [this line](https://github.com/vegastrike/Assets-Production/blob/e1242f004a84708548906c2c8c87cbaa180ffe4d/modules/campaign_lib.py#L361)