### PR TITLE
Add macports include path to FindGTK3.cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,23 @@ Assuming all the above steps succeed, you are now ready to run Vega Strike. Note
 Compiling On MacOS
 ------------------
 
-Currently VegaStrike is not compiling on MacOS. Any help will be appreciated to get it fixed. For more information go [here](https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/78)
+VegaStrike is now compiling on MacOS. However, it's currently experiencing segfaults. Any help will be appreciated to get it fixed. For more information go [here](https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/533)
+
+To install the required build dependencies:
+
+If you have Homebrew, follow the steps in the GitHub action:
+
+```
+.github/workflows/macos-ci.yml
+```
+
+If you have MacPorts, install the following:
+
+```
+sudo port install cmake expat jpeg libpng libvorbis boost gtk3 gtkglext libsdl mesa libGLU freeglut
+```
+
+Also set the environment variables to match those in the GitHub action.
 
 3. Packaging Vega Strike:
 

--- a/engine/FindGTK3.cmake
+++ b/engine/FindGTK3.cmake
@@ -179,6 +179,7 @@ FUNCTION(_GTK3_FIND_INCLUDE_DIR _var _hdr)
         /usr/openwin
         /sw
         /opt/local
+        /opt/local/include
         $ENV{GTKMM_BASEPATH}
         [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
         [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- #78
- #533 

Purpose:
Update `FindGTK3.cmake` so it can find GTK when installed with MacPorts.
