### PR TITLE
cmd/collision.cpp: Make it so that Nav 8 cannot be crashed into

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages/
 *.kdev4
 .vs/
 .vscode/
+.editorconfig

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -292,10 +292,7 @@ void Collision::collide( Unit* unit1,
     // See commit a66bdcfa1e00bf039183603913567d48e52c7a8e method Unit->jumpReactToCollision for an example
     // I assume this is for "always open" jump gates that you pass through
 
-    collision1.apply_force = false;
-    collision1.deal_damage = false;
-    collision2.apply_force = false;
-    collision2.deal_damage = false;
+    // apply_force and deal_damage are both initialized to false when the Collision object is constructed. (See collision.h.)
 
     collision1.shouldApplyForceAndDealDamage(unit2);
     collision2.shouldApplyForceAndDealDamage(unit1);

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -112,7 +112,7 @@ void Collision::shouldApplyForceAndDealDamage(Unit* other_unit)
             return;
         case _UnitType::planet:
             // Handle the "Nav 8" case
-            if (other_unit->getFilename().find("invisible")) {
+            if (other_unit->getFilename().find("invisible") != std::string::npos) {
                 BOOST_LOG_TRIVIAL(debug) << "Found a Nav_8-type object";
                 return;
             } else {

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -101,17 +101,25 @@ _UnitType::enhancement,
 _UnitType::missile*/
 void Collision::shouldApplyForceAndDealDamage(Unit* other_unit)
 {
-    // Collision with a nebula does nothing
-    if(other_unit->isUnit() == _UnitType::nebula)
+    switch (other_unit->isUnit())
     {
-        return;
-    }
-
-    // Collision with a enhancement improves your shield apparently
-    if(other_unit->isUnit() == _UnitType::enhancement)
-    {
-        apply_force = true;
-        return;
+        case _UnitType::nebula:
+            // Collision with a nebula does nothing
+            return;
+        case _UnitType::enhancement:
+            // Collision with a enhancement improves your shield apparently
+            apply_force = true;
+            return;
+        case _UnitType::planet:
+            // Handle the "Nav 8" case
+            if (other_unit->getFilename().find("invisible")) {
+                BOOST_LOG_TRIVIAL(debug) << "Found a Nav_8-type object";
+                return;
+            } else {
+                break;
+            }
+        default:
+            break;
     }
 
     // Collision with a jump point does nothing
@@ -298,15 +306,15 @@ void Collision::collide( Unit* unit1,
     collision2.shouldApplyForceAndDealDamage(unit1);
 
     float elasticity = 0.8f;
-    if (collision1.apply_force && collision2.apply_force) {
+    // if (collision1.apply_force && collision2.apply_force) {
         collision1.applyForce(elasticity, collision2.mass, collision2.velocity);
         collision2.applyForce(elasticity, collision1.mass, collision1.velocity);
-    }
+    // }
 
-    if (collision1.deal_damage && collision2.deal_damage) {
+    // if (collision1.deal_damage && collision2.deal_damage) {
         collision1.dealDamage(collision2);
         collision2.dealDamage(collision1);
-    }
+    // }
 
     // Is this still a TODO? -- add torque
 }

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -1,7 +1,7 @@
 /**
  * collision.cpp
  *
- * Copyright (C) 2020 Roy Falk, Stephen G. Tuggy and other Vega Strike
+ * Copyright (C) 2020-2021 Roy Falk, Stephen G. Tuggy and other Vega Strike
  * contributors
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
@@ -292,15 +292,24 @@ void Collision::collide( Unit* unit1,
     // See commit a66bdcfa1e00bf039183603913567d48e52c7a8e method Unit->jumpReactToCollision for an example
     // I assume this is for "always open" jump gates that you pass through
 
+    collision1.apply_force = false;
+    collision1.deal_damage = false;
+    collision2.apply_force = false;
+    collision2.deal_damage = false;
+
     collision1.shouldApplyForceAndDealDamage(unit2);
     collision2.shouldApplyForceAndDealDamage(unit1);
 
     float elasticity = 0.8f;
-    collision1.applyForce(elasticity, collision2.mass, collision2.velocity);
-    collision2.applyForce(elasticity, collision1.mass, collision1.velocity);
+    if (collision1.apply_force && collision2.apply_force) {
+        collision1.applyForce(elasticity, collision2.mass, collision2.velocity);
+        collision2.applyForce(elasticity, collision1.mass, collision1.velocity);
+    }
 
-    collision1.dealDamage(collision2);
-    collision2.dealDamage(collision1);
+    if (collision1.deal_damage && collision2.deal_damage) {
+        collision1.dealDamage(collision2);
+        collision2.dealDamage(collision1);
+    }
 
-    // TODO: add torque
+    // Is this still a TODO? -- add torque
 }

--- a/engine/src/cmd/collision.cpp
+++ b/engine/src/cmd/collision.cpp
@@ -112,8 +112,9 @@ void Collision::shouldApplyForceAndDealDamage(Unit* other_unit)
             return;
         case _UnitType::planet:
             // Handle the "Nav 8" case
-            if (other_unit->getFilename().find("invisible") != std::string::npos) {
-                BOOST_LOG_TRIVIAL(debug) << "Found a Nav_8-type object";
+            // BOOST_LOG_TRIVIAL(debug) << "shouldApplyForceAndDealDamage(): other_unit is a planet, with full name " << other_unit->getFullname();
+            if (other_unit->getFullname().find("invisible") != std::string::npos) {
+                // BOOST_LOG_TRIVIAL(debug) << "Found a Nav_8-type object";
                 return;
             } else {
                 break;
@@ -152,6 +153,7 @@ void Collision::shouldApplyForceAndDealDamage(Unit* other_unit)
     // Planets and Nebulas can't be killed right now
     case _UnitType::planet:
     case _UnitType::nebula:
+        // BOOST_LOG_TRIVIAL(debug) << "shouldApplyForceAndDealDamage(): this unit is a planet or nebula, with full name " << unit->getFullname();
         return;
 
     // Buildings should not calculate actual damage

--- a/engine/src/savegame.cpp
+++ b/engine/src/savegame.cpp
@@ -4,6 +4,7 @@
  * Copyright (C) Daniel Horn
  * Copyright (C) 2020 pyramid3d, Stephen G. Tuggy, and other Vega Strike
  * contributors
+ * Copyright (C) 2021 Stephen G. Tuggy
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *
@@ -340,7 +341,14 @@ QVector SaveGame::GetPlayerLocation()
     return PlayerLocation;
 }
 
-void SaveGame::RemoveUnitFromSave( long address ) // DELETE ? unused function?
+// DELETE ? unused function?
+// No, it's used all right. In AddUnitToSave() -- stephengtuggy 2021-09-11
+void SaveGame::RemoveUnitFromSave( long address )
+{
+}
+
+// stephengtuggy 2021-09-11: So I add another entire overload of this method, only to find out it does nothing. Argh.
+void SaveGame::RemoveUnitFromSave(void *address)
 {
 }
 
@@ -497,8 +505,18 @@ void SaveGame::ReadNewsData( char* &buf, bool just_skip )
 
 void SaveGame::AddUnitToSave( const char *filename, int type, const char *faction, long address )
 {
-    if ( game_options.Drone.compare( filename ) )
+    if ( game_options.Drone.compare( filename ) ) {
+        // So AddUnitToSave removes the unit from the save. Um... what? -- stephengtuggy 2021-09-11
         RemoveUnitFromSave( address );
+    }
+}
+
+void SaveGame::AddUnitToSave(const std::string filename, const int type, const std::string faction, void *address)
+{
+    if (game_options.Drone.compare(filename)) {
+        // Just copying what the above method does -- stephengtuggy 2021-09-11
+        RemoveUnitFromSave(address);
+    }
 }
 
 std::vector< float >& SaveGame::getMissionData( const std::string &magic_number )

--- a/engine/src/savegame.h
+++ b/engine/src/savegame.h
@@ -4,6 +4,7 @@
  * Copyright (C) Daniel Horn
  * Copyright (C) 2020 pyramid3d, Stephen G. Tuggy, and other Vega Strike
  * contributors
+ * Copyright (C) 2021 Stephen G. Tuggy
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *
@@ -137,9 +138,12 @@ public: ~SaveGame();
     std::string WriteDynamicUniverse();
     void ReadSavedPackets( char* &buf, bool commitfaction, bool skip_news = false, bool select_data = false,
                           const std::set< std::string > &select_data_filter = std::set< std::string > () );
-///cast address to long (for 64 bits compatibility)
     void AddUnitToSave( const char *unitname, int type, const char *faction, long address );
-    void RemoveUnitFromSave( long address ); //cast it to a long
+    // New method overload added by stephengtuggy 2021-09-11
+    void AddUnitToSave(const std::string unitname, const int type, const std::string faction, void *address);
+    void RemoveUnitFromSave( long address );
+    // New method overload added by stephengtuggy 2021-09-11
+    void RemoveUnitFromSave(void *address);
     void SetOutputFileName( const std::string &filename );
     void ParseSaveGame( const std::string &filename, std::string &ForceStarSystem, const std::string &originalstarsystem,
                        QVector &pos, bool &shouldupdatedfighter0pos, float &credits, std::vector< std::string > &originalunit,


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- Fixes #516 for 0.8.x branch

Purpose:
- What is this pull request trying to do? Fix a bug where, with PWCU, Nav 8 is unexpectedly an object that you can crash into
- What release is this for? 0.8.x; 0.9.x pending
- Is there a project or milestone we should apply this to? 0.8.x
