### PR TITLE
Change the `Fortify on Demand Scan` to run only when manually triggered

### DIFF
--- a/.github/workflows/fortify-on-demand-scan.yml
+++ b/.github/workflows/fortify-on-demand-scan.yml
@@ -1,11 +1,9 @@
 name: Fortify on Demand Scan
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
-  push:
-    # branches: ['master', '[0-9]?.[0-9]?.x']
-  pull_request:
-    # branches: ['master', '[0-9]?.[0-9]?.x']
+#   push:
+#   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [X] This is a CI system change only

Issues:
- Please list any related issues
- N/A

Purpose:
- What is this pull request trying to do? Change the `Fortify on Demand Scan` GitHub Action to run only when manually triggered
- What release is this for? Any
- Is there a project or milestone we should apply this to? Upcoming
