### PR TITLE
`Drawable::DrawSubunits`: Fix crash/segfault on pressing `a` in PWCU

### DIFF
--- a/engine/src/cmd/drawable.cpp
+++ b/engine/src/cmd/drawable.cpp
@@ -422,82 +422,82 @@ void Drawable::DrawSubunits(bool on_screen, Matrix wmat, int cloak, float averag
     Unit *unit = static_cast<Unit*>(this);
     Transformation *ct = &unit->cumulative_transformation;
 
-   for (int i = 0; (int) i < unit->getNumMounts(); i++) {
-       Mount *mount = &unit->mounts[i];
-       Mesh *gun = mount->type->gun;
+    for (int i = 0; (int) i < unit->getNumMounts(); i++) {
+        Mount *mount = &unit->mounts[i];
+        Mesh *gun = mount->type->gun;
 
-       // Don't try to draw a nonexistent object -- stephengtuggy 2021-10-10
-       if (gun == nullptr)
-       {
-           continue;
-       }
-
-       // Has to come before check for on screen, as a fired beam can still be seen
-       // even if the subunit firing it isn't on screen.
-       if (unit->mounts[i].type->type == WEAPON_TYPE::BEAM) {
-           // If gun is null (?)
-           if (unit->mounts[i].ref.gun) {
-               unit->mounts[i].ref.gun->Draw( *ct, wmat,
-                                              ( isAutoTrackingMount(unit->mounts[i].size)
+        // Has to come before check for on screen, as a fired beam can still be seen
+        // even if the subunit firing it isn't on screen.
+        if (unit->mounts[i].type->type == WEAPON_TYPE::BEAM) {
+            // If gun is null (?)
+            if (unit->mounts[i].ref.gun) {
+                unit->mounts[i].ref.gun->Draw( *ct, wmat,
+                                                ( isAutoTrackingMount(unit->mounts[i].size)
                                                 && (unit->mounts[i].time_to_lock <= 0)
                                                 && unit->TargetTracked() ) ? unit->Target() : NULL,
-                                              unit->computer.radar.trackingcone );
-           }
-       }
+                                                unit->computer.radar.trackingcone );
+            }
+        }
 
-       // Units not shown don't draw subunits
-       if(!on_screen) {
-           continue;
-       }
+        // Don't try to draw a nonexistent object -- stephengtuggy 2021-10-10
+        if (gun == nullptr)
+        {
+            continue;
+        }
 
-       // Don't draw mounts if game is set not to...
-      if(!game_options.draw_weapons) {
-           continue;
-      }
+        // Units not shown don't draw subunits
+        if (!on_screen) {
+            continue;
+        }
+
+        // Don't draw mounts if game is set not to...
+        if(!game_options.draw_weapons) {
+            continue;
+        }
 
 
-       // Don't bother drawing small mounts ?!
-       if (mount->xyscale == 0 || mount->zscale == 0) {
-           continue;
-       }
+        // Don't bother drawing small mounts ?!
+        if (mount->xyscale == 0 || mount->zscale == 0) {
+            continue;
+        }
 
-       // Don't draw unchosen GUN mounts, whatever that means
-       // Does not cover beams for some reason.
-       if (mount->status == Mount::UNCHOSEN) {
-           continue;
-       }
+        // Don't draw unchosen GUN mounts, whatever that means
+        // Does not cover beams for some reason.
+        if (mount->status == Mount::UNCHOSEN) {
+            continue;
+        }
 
-       Transformation mountLocation( mount->GetMountOrientation(), mount->GetMountLocation().Cast() );
-       mountLocation.Compose( *ct, wmat );
-       Matrix mat;
-       mountLocation.to_matrix( mat );
-       if (GFXSphereInFrustum( mountLocation.position, gun->rSize()*average_scale ) > 0) {
-           float d   = ( mountLocation.position-_Universe->AccessCamera()->GetPosition() ).Magnitude();
-           float pixradius = gun->rSize()*perspectiveFactor(
-                       (d-gun->rSize() < g_game.znear) ? g_game.znear : d-gun->rSize() );
-           float lod = pixradius * g_game.detaillevel;
-           if (lod > 0.5 && pixradius > 2.5) {
-               ScaleMatrix( mat, Vector( mount->xyscale, mount->xyscale, mount->zscale ) );
-               gun->setCurrentFrame( unit->mounts[i].ComputeAnimatedFrame( gun ) );
-               gun->Draw( lod, mat, d, cloak,
-                          (_Universe->AccessCamera()->GetNebula() == unit->nebula && unit->nebula != NULL) ? -1 : 0,
-                          char_damage,
-                          true );                                                                                                                                      //cloakign and nebula
-           }
-           if (mount->type->gun1) {
-               pixradius = gun->rSize()*perspectiveFactor(
-                           (d-gun->rSize() < g_game.znear) ? g_game.znear : d-gun->rSize() );
-               lod = pixradius * g_game.detaillevel;
-               if (lod > 0.5 && pixradius > 2.5) {
-                   gun = mount->type->gun1;
-                   gun->setCurrentFrame( unit->mounts[i].ComputeAnimatedFrame( gun ) );
-                   gun->Draw( lod, mat, d, cloak,
-                              (_Universe->AccessCamera()->GetNebula() == unit->nebula && unit->nebula
-                               != NULL) ? -1 : 0,
-                              char_damage, true );                                                                                                                              //cloakign and nebula
-               }
-           }
-       }
-   }
+        Transformation mountLocation( mount->GetMountOrientation(), mount->GetMountLocation().Cast() );
+        mountLocation.Compose( *ct, wmat );
+        Matrix mat;
+        mountLocation.to_matrix( mat );
+        if (GFXSphereInFrustum( mountLocation.position, gun->rSize()*average_scale ) > 0) {
+            float d   = ( mountLocation.position-_Universe->AccessCamera()->GetPosition() ).Magnitude();
+            float pixradius = gun->rSize()*perspectiveFactor(
+                        (d-gun->rSize() < g_game.znear) ? g_game.znear : d-gun->rSize() );
+            float lod = pixradius * g_game.detaillevel;
+            if (lod > 0.5 && pixradius > 2.5) {
+                ScaleMatrix( mat, Vector( mount->xyscale, mount->xyscale, mount->zscale ) );
+                gun->setCurrentFrame( unit->mounts[i].ComputeAnimatedFrame( gun ) );
+                gun->Draw( lod, mat, d, cloak,
+                            (_Universe->AccessCamera()->GetNebula() == unit->nebula && unit->nebula != NULL) ? -1 : 0,
+                            char_damage,
+                            true );                                                                                                                                      //cloakign and nebula
+            }
+            if (mount->type->gun1) {
+                pixradius = gun->rSize()*perspectiveFactor(
+                            (d-gun->rSize() < g_game.znear) ? g_game.znear : d-gun->rSize() );
+                lod = pixradius * g_game.detaillevel;
+                if (lod > 0.5 && pixradius > 2.5) {
+                    gun = mount->type->gun1;
+                    gun->setCurrentFrame( unit->mounts[i].ComputeAnimatedFrame( gun ) );
+                    gun->Draw( lod, mat, d, cloak,
+                                (_Universe->AccessCamera()->GetNebula() == unit->nebula && unit->nebula
+                                != NULL) ? -1 : 0,
+                                char_damage, true );                                                                                                                              //cloakign and nebula
+                }
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- Fixes #587 

Purpose:
- What is this pull request trying to do? Fix a bug that was introduced a month or two ago, where the code will try to draw guns even if they are NULL / nullptr. This was leading to a crash in PWCU when pressing `a` for Autopilot.
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
