### PR TITLE
Further refactoring of bolt.cpp

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -968,6 +968,7 @@ SET(LIBCMDSERVER_SOURCES
 )
 
 SET(LIBGFXGENERIC_SOURCES
+    src/gfx/texture_manager.cpp
     src/gfx/boltdrawmanager.cpp
     src/gfx/cockpit_generic.cpp
     src/gfx/lerp.cpp

--- a/engine/src/cmd/bolt.h
+++ b/engine/src/cmd/bolt.h
@@ -31,12 +31,14 @@
 #include "gfx/matrix.h"
 #include "gfx/quaternion.h"
 #include "collide_map.h"
+#include "gfx/animation.h"
 
 
 class Unit;
 class StarSystem;
 class BoltDrawManager;
 class Animation;
+class Texture;
 
 class Bolt {
 private:
@@ -48,6 +50,16 @@ private:
   void *owner;
   float curdist;
   int decal;//which image it uses
+  float bolt_size; // actually squared
+  std::string bolt_name;
+
+  float ball_size;
+  std::string ball_name;
+
+  Texture *bolt_texture;
+  Animation animation;
+
+
  public:
   CollideMap::iterator location;
   static int AddTexture(BoltDrawManager *q, std::string filename);
@@ -68,7 +80,7 @@ private:
   //static void Draw();
   static void DrawAllBolts();
   static void DrawAllBalls();
-  void DrawBolt(float& bolt_size, GFXVertexList *qmesh);
+  void DrawBolt(GFXVertexList *qmesh);
   void DrawBall(float& bolt_size, Animation *cur);
   bool Update(Collidable::CollideRef index);
   bool Collide(Collidable::CollideRef index);

--- a/engine/src/cmd/mount.cpp
+++ b/engine/src/cmd/mount.cpp
@@ -44,6 +44,7 @@
 #include "universe.h"
 #include "weapon_info.h"
 #include "resource/resource.h"
+#include "gfx/boltdrawmanager.h"
 
 extern char SERVER;
 Mount::Mount()
@@ -271,11 +272,15 @@ bool Mount::PhysicsAlignedFire( Unit *caller,
                 ref.gun->Reinitialize();
             break;
         case WEAPON_TYPE::BOLT:
-        case WEAPON_TYPE::BALL:
             caller->energy -= type->energy_rate;
             hint[Unit::UNIT_BOLT] = Bolt( type, mat, velocity, owner, hint[Unit::UNIT_BOLT] ).location;             //FIXME turrets won't work! Velocity
-
             break;
+
+        case WEAPON_TYPE::BALL: {
+            caller->energy -= type->energy_rate;
+            hint[Unit::UNIT_BOLT] = BoltDrawManager::GetInstance().AddBall(type, mat, velocity, owner, hint[Unit::UNIT_BOLT]);
+            break;
+        }
         case WEAPON_TYPE::PROJECTILE:
             static bool match_speed_with_target =
                 XMLSupport::parse_float( vs_config->getVariable( "physics", "match_speed_with_target", "true" ) );

--- a/engine/src/gfx/boltdrawmanager.cpp
+++ b/engine/src/gfx/boltdrawmanager.cpp
@@ -118,3 +118,14 @@ void BoltDrawManager::Draw()
     GFXEnable( TEXTURE0 );
     GFXColor4f( 1, 1, 1, 1 );
 }
+
+
+CollideMap::iterator BoltDrawManager::AddBall( const WeaponInfo *typ,
+                                               const Matrix &orientationpos,
+                                               const Vector &shipspeed,
+                                               void *owner,
+                                               CollideMap::iterator hint ) {
+    Bolt ball = Bolt( typ, orientationpos, shipspeed, owner, hint );             //FIXME turrets won't work! Velocity
+    _balls.push_back(ball);
+    return _balls[_balls.size()-1].location;
+}

--- a/engine/src/gfx/boltdrawmanager.h
+++ b/engine/src/gfx/boltdrawmanager.h
@@ -48,10 +48,17 @@ public:
     vector <vector <Bolt> > bolts; // The inner vector is all of the same type.
     vector <vector <Bolt> > balls;
 
+    vector<Bolt> _balls;
+
     BoltDrawManager();
     ~BoltDrawManager();
 
     static BoltDrawManager& GetInstance();
+    CollideMap::iterator AddBall( const WeaponInfo *typ,
+                                       const Matrix &orientationpos,
+                                       const Vector &shipspeed,
+                                       void *owner,
+                                       CollideMap::iterator hint );
 
     static void Draw();
 };

--- a/engine/src/gfx/texture_manager.cpp
+++ b/engine/src/gfx/texture_manager.cpp
@@ -1,0 +1,28 @@
+#include "texture_manager.h"
+
+TextureManager::TextureManager()
+{
+
+}
+
+
+TextureManager& TextureManager::GetInstance() {
+    static TextureManager instance;     // Guaranteed to be destroyed.
+    return instance;                    // Instantiated on first use.
+}
+
+
+Texture* TextureManager::GetTexture( std::string const &name, enum FILTER mipmap ) {
+    // This is weird. We already store textures in a hashmap but can't rely on it.
+    // TODO: figure out how to rely on it.
+    Texture *texture = Texture::Exists( name );
+
+    // Texture already exists
+    if (!texture) {
+        // Need to create texture
+        texture = new Texture( name.c_str(), 0, mipmap, TEXTURE2D, TEXTURE_2D, GFXTRUE );
+        textures.push_back(texture);
+    }
+
+    return texture;
+}

--- a/engine/src/gfx/texture_manager.h
+++ b/engine/src/gfx/texture_manager.h
@@ -1,0 +1,18 @@
+#ifndef TEXTUREMANAGER_H
+#define TEXTUREMANAGER_H
+
+#include <vector>
+
+#include "gfx/aux_texture.h"
+
+class TextureManager
+{
+    std::vector<Texture*> textures;
+public:
+    TextureManager();
+
+    static TextureManager& GetInstance();
+    Texture* GetTexture( std::string const &name, enum FILTER mipmap );
+};
+
+#endif // TEXTUREMANAGER_H


### PR DESCRIPTION
Move away from the concept of decals to a simpler model where texture manager holds a master of every texture and copies it per shot.
Can't do the same for balls and animations because of weird life cycle issue of animations. They're destroyed before they should.

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [Yes] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- Shooting within the shield bubble of a base cause it to attack you. 
- Balls animation only use the first animation displayed. This is most likely a regression in the previous refactoring of bolt.cpp.
- Can't die in a collision. 
I'll open issues to the above as they are probably unrelated to this PR.
