### PR TITLE
peg boost to 1.77, 1.78 currently causes compilation issues

### DIFF
--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -3,16 +3,16 @@
     "name": "vega-strike",
     "version-string": "0.9.0",
     "dependencies": [
-        "boost-python",
-        "boost-log",
-        "boost-date-time",
-        "boost-iostreams",
-        "boost-system",
-        "boost-filesystem",
-        "boost-thread",
-        "boost-chrono",
-        "boost-atomic",
-        "boost-assign",
+        {"name": "boost-python", "version>=": "1.77.0"},
+         {"name": "boost-log","version>=": "1.77.0"},
+         {"name": "boost-date-time","version>=": "1.77.0"},
+         {"name": "boost-iostreams","version>=": "1.77.0"},
+         {"name": "boost-system","version>=": "1.77.0"},
+         {"name": "boost-filesystem","version>=": "1.77.0"},
+         {"name": "boost-thread","version>=": "1.77.0"},
+         {"name": "boost-chrono","version>=": "1.77.0"},
+         {"name": "boost-atomic","version>=": "1.77.0"},
+         {"name": "boost-assign","version>=": "1.77.0"},
         "expat",
         "freeglut",
         "libpng",
@@ -23,5 +23,6 @@
         "opengl-registry",
         "sdl1",
         "zlib"
-    ]
+    ],
+    "builtin-baseline":"cc471dc0f59b7b2066d6172c2893419412327a7a"
 }


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
  Only completed a build test.
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
The Windows build seems broken currently.  This pull request downgrades Boost as that seems to repair the build.  The problem with .78 may be related to https://github.com/microsoft/vcpkg/issues/22495 

Not sure if there is a better way to fix this while keeping 1.78 in use...
