### PR TITLE
Fix build issues with Boost 1.78 on windows by reverting to Boost 1.77 (alternate approach)

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           vcpkgDirectory: '${{ github.workspace }}/v'
           setupOnly: true
-          vcpkgGitCommitId: 'b3cfaaf1bba70febd07c2f672ae590dc5d914180'
+          vcpkgGitCommitId: '49a30e9db17a8edf7c2809940ee2036746b1b982'
           vcpkgTriplet: 'x64-windows'
           appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}
           additionalCachedPaths: ${{ env.buildDir }}/vcpkg_installed

--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -2,6 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "vega-strike",
     "version-string": "0.9.0",
+    "builtin-baseline": "1085a57da0725c19e19586025438e8c16f34c890",
     "dependencies": [
         "boost-python",
         "boost-log",


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [In Process] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Fix the build on Windows by reverting Boost to version 1.77 instead of 1.78
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
