### PR TITLE
vcpkg.json, Windows-CI.yml: Port fix for Boost 1.78 issue on Windows …

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -33,17 +33,19 @@ jobs:
 
       - name: install-vcpkg
         # You may pin to the exact commit or the version.
+        # uses: lukka/run-vcpkg@9c0ae56bad291f4b185cc433a9b56084b2962259
         uses: lukka/run-vcpkg@v7
         with:
           vcpkgDirectory: '${{ github.workspace }}/v'
           setupOnly: true
-          vcpkgGitCommitId: 'b3cfaaf1bba70febd07c2f672ae590dc5d914180'
+          vcpkgGitCommitId: '49a30e9db17a8edf7c2809940ee2036746b1b982'
           vcpkgTriplet: 'x64-windows'
           appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}
           additionalCachedPaths: ${{ env.buildDir }}/vcpkg_installed
 
       - name: run-cmake
         # You may pin to the exact commit or the version.
+        # uses: lukka/run-cmake@7ba4481660f0f04c86cfa5f1f24b90effc97bde1
         uses: lukka/run-cmake@v3
         with:
           # Path to CMakeLists.txt. Used for both CMakeListsTxtBasic and CMakeListsTxtAdvanced modes.

--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -1,26 +1,28 @@
 {
-    "name": "vega-strike",
-    "version-string": "0.8.0",
-    "dependencies": [
-      "boost-python",
-      "boost-log",
-      "boost-date-time",
-      "boost-iostreams",
-      "boost-system",
-      "boost-filesystem",
-      "boost-thread",
-      "boost-chrono",
-      "boost-atomic",
-      "boost-assign",
-      "expat",
-      "freeglut",
-      "libpng",
-      "libjpeg-turbo",
-      "libvorbis",
-      "openal-soft",
-      "opengl",
-      "opengl-registry",
-      "sdl1",
-      "zlib"
-    ]
-  }
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "vega-strike",
+  "version-string": "0.8.0",
+  "builtin-baseline": "1085a57da0725c19e19586025438e8c16f34c890",
+  "dependencies": [
+    "boost-python",
+    "boost-log",
+    "boost-date-time",
+    "boost-iostreams",
+    "boost-system",
+    "boost-filesystem",
+    "boost-thread",
+    "boost-chrono",
+    "boost-atomic",
+    "boost-assign",
+    "expat",
+    "freeglut",
+    "libpng",
+    "libjpeg-turbo",
+    "libvorbis",
+    "openal-soft",
+    "opengl",
+    "opengl-registry",
+    "sdl1",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
…from `master` to 0.8.x

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Port the fix for the Boost 1.78 issue on Windows, from `master` to `0.8.x`
- What release is this for? 0.8.x
- Is there a project or milestone we should apply this to? 0.8.x
