### PR TITLE
Clarify first run README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ If you encounter any issues while playing, please create an issue with the Vega 
    ./bin/vegasettings --target ../Assets-Production
    ```
 
+   Absolute path may need to be supplied when running vegasettings for the first time.
+
    Do the same with vegastrike-engine using `-d` and no space. E.g.:
 
    ```bash


### PR DESCRIPTION
When running for the first time, Version.txt may not be present. Relative path may not work:
`Set data directory to ../Assets-Production
Error: Failed to find Version.txt anywhere.`

Instructions update per request at https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/526#issuecomment-907832444