### PR TITLE
Remove old unit csv code and fully replace with modern json/csv support

### DIFF
--- a/engine/src/cmd/ai/aggressive.cpp
+++ b/engine/src/cmd/ai/aggressive.cpp
@@ -109,31 +109,6 @@ static void TurretFAW(Unit *parent) {
     }
 }
 
-static vsUMap<string, string> getAITypes() {
-    vsUMap<string, string> ret;
-    VSFileSystem::VSFile f;
-    VSFileSystem::VSError err = f.OpenReadOnly("VegaPersonalities.csv", VSFileSystem::AiFile);
-    if (err <= VSFileSystem::Ok) {
-        CSVTable table(f, f.GetRoot());
-        vsUMap<std::string, int>::iterator browser = table.rows.begin();
-        for (; browser != table.rows.end(); ++browser) {
-            string rowname = (*browser).first;
-            CSVRow row(&table, rowname);
-            for (unsigned int i = 1; i < table.key.size(); ++i) {
-                string hasher = rowname;
-                if (i != 1) {
-                    hasher = rowname + "%" + table.key[i];
-                }
-                string rawrow = row[i];
-                if (rawrow.length() > 0) {
-                    ret[hasher] = rawrow;
-                }
-            }
-        }
-        f.Close();
-    }
-    return ret;
-}
 
 static string select_from_space_list(string inp, unsigned int seed) {
     if (inp.length() == 0) {
@@ -173,7 +148,7 @@ static AIEvents::ElemAttrMap *getLogicOrInterrupt(string name,
         vsUMap<string, AIEvents::ElemAttrMap *> &mymap,
         int personalityseed) {
     string append = "agg";
-    static vsUMap<string, string> myappend = getAITypes();
+    static vsUMap<string, string> myappend;
     vsUMap<string, string>::iterator iter;
     string factionname = FactionUtil::GetFaction(faction);
     if ((iter = myappend.find(factionname + "%" + unittype)) != myappend.end()) {

--- a/engine/src/cmd/ai/aggressive.cpp
+++ b/engine/src/cmd/ai/aggressive.cpp
@@ -109,6 +109,31 @@ static void TurretFAW(Unit *parent) {
     }
 }
 
+static vsUMap<string, string> getAITypes() {
+    vsUMap<string, string> ret;
+    VSFileSystem::VSFile f;
+    VSFileSystem::VSError err = f.OpenReadOnly("VegaPersonalities.csv", VSFileSystem::AiFile);
+    if (err <= VSFileSystem::Ok) {
+        CSVTable table(f, f.GetRoot());
+        vsUMap<std::string, int>::iterator browser = table.rows.begin();
+        for (; browser != table.rows.end(); ++browser) {
+            string rowname = (*browser).first;
+            CSVRow row(&table, rowname);
+            for (unsigned int i = 1; i < table.key.size(); ++i) {
+                string hasher = rowname;
+                if (i != 1) {
+                    hasher = rowname + "%" + table.key[i];
+                }
+                string rawrow = row[i];
+                if (rawrow.length() > 0) {
+                    ret[hasher] = rawrow;
+                }
+            }
+        }
+        f.Close();
+    }
+    return ret;
+}
 
 static string select_from_space_list(string inp, unsigned int seed) {
     if (inp.length() == 0) {
@@ -148,7 +173,7 @@ static AIEvents::ElemAttrMap *getLogicOrInterrupt(string name,
         vsUMap<string, AIEvents::ElemAttrMap *> &mymap,
         int personalityseed) {
     string append = "agg";
-    static vsUMap<string, string> myappend;
+    static vsUMap<string, string> myappend = getAITypes();
     vsUMap<string, string>::iterator iter;
     string factionname = FactionUtil::GetFaction(faction);
     if ((iter = myappend.find(factionname + "%" + unittype)) != myappend.end()) {

--- a/engine/src/cmd/csv.cpp
+++ b/engine/src/cmd/csv.cpp
@@ -187,17 +187,30 @@ CSVTable::CSVTable(const string &data, const string &root) {
 }
 
 CSVTable::CSVTable(VSFileSystem::VSFile &f, const string &root) {
-    std::string data = f.ReadFull();
-
-    UnitCSVFactory factory;
-    if (f.GetFilename() == "units_description.csv" ||
+    /*if (f.GetFilename() == "units_description.csv" ||
             f.GetFilename() == "master_part_list.csv") {
     } else if (f.GetFilename() == "units.csv") {
-        UnitJSONFactory::ParseJSON(f.GetFullPath());
-    } else {
-        factory.ProcessCSV(data, true);
-    }
+        VSFileSystem::VSFile jsonFile;
+        VSFileSystem::VSError err = jsonFile.OpenReadOnly("units.json", VSFileSystem::UnitFile);
+        if (err <= VSFileSystem::Ok) {
+            UnitJSONFactory::ParseJSON(jsonFile);
+        }
+        jsonFile.Close();
+    }*/
 
+    if (f.GetFilename() == "units_description.csv" ||
+        f.GetFilename() == "master_part_list.csv") {
+        // Not the CSV file we expect. Will crash unit_csv_factory
+    } /*else if (f.GetFilename() != "units.csv") {
+        // Open a saved game.
+        std::cerr << "Parsing " << f.GetFilename() << std::endl;
+        //abort();
+        UnitCSVFactory factory;
+        factory.ParseCSV(f, true);
+        f.Begin();
+    }*/
+
+    std::string data = f.ReadFull();
     this->rootdir = root;
     Init(data);
 }

--- a/engine/src/cmd/drawable.cpp
+++ b/engine/src/cmd/drawable.cpp
@@ -39,12 +39,14 @@
 #include "options.h"
 #include "weapon_info.h"
 #include "beam.h"
-#include "csv.h"
 #include "unit_csv.h"
 #include "universe_util.h"
 
 #include <boost/algorithm/string.hpp>
 #include "vega_cast_utils.hpp"
+
+// Required definition of static variable
+std::string Drawable::root;
 
 // Dupe to same function in unit.cpp
 // TODO: remove duplication
@@ -859,8 +861,6 @@ void Drawable::Split(int level) {
     int nm = this->nummesh();
     string fac = FactionUtil::GetFaction(unit->faction);
 
-    CSVRow unit_stats(LookupUnitRow(unit->name, fac));
-    unsigned int num_chunks = unit_stats.success() ? atoi(unit_stats["Num_Chunks"].c_str()) : 0;
     if (nm <= 0 && num_chunks == 0) {
         return;
     }
@@ -869,13 +869,13 @@ void Drawable::Split(int level) {
     old.pop_back();
 
     vector<unsigned int> meshsizes;
-    if (num_chunks && unit_stats.success()) {
+    if (num_chunks) {
         size_t i;
         vector<Mesh *> nw;
         unsigned int which_chunk = rand() % num_chunks;
         string chunkname = UniverseUtil::LookupUnitStat(unit->name, fac, "Chunk_" + XMLSupport::tostring(which_chunk));
         string dir = UniverseUtil::LookupUnitStat(unit->name, fac, "Directory");
-        VSFileSystem::current_path.push_back(unit_stats.getRoot());
+        VSFileSystem::current_path.push_back(root);
         VSFileSystem::current_subdirectory.push_back("/" + dir);
         VSFileSystem::current_type.push_back(VSFileSystem::UnitFile);
         float randomstartframe = 0;

--- a/engine/src/cmd/drawable.h
+++ b/engine/src/cmd/drawable.h
@@ -65,7 +65,10 @@ protected:
 
     string uniqueUnitName;
 
+    unsigned int num_chunks;
 public:
+    static std::string root;
+
     double curtime;
 
     static unsigned int unitCount;

--- a/engine/src/cmd/tests/csv_tests.cpp
+++ b/engine/src/cmd/tests/csv_tests.cpp
@@ -33,13 +33,13 @@
 TEST(CSV, Sanity) {
     // This may not work for all deployments.
     // Consider standardizing this.
-    std::ifstream ifs("../../data/units/units.csv", std::ifstream::in);
+    /*std::ifstream ifs("../../data/units/units.csv", std::ifstream::in);
     std::stringstream buffer;
     buffer << ifs.rdbuf();
 
     UnitCSVFactory factory;
     std::string csv_contents{buffer.str()};
-    factory.ProcessCSV(csv_contents, false);
+    factory.ProcessCSV(csv_contents, false);*/
 
     /*for (auto const& x : UnitCSVFactory::units)
     {

--- a/engine/src/cmd/tests/json_tests.cpp
+++ b/engine/src/cmd/tests/json_tests.cpp
@@ -42,7 +42,7 @@ TEST(JSON, Sanity) {
     // Much of this is comparing csv to json and this code doesn't work anymore as
     // I changed much of the game code for the game, rather to figure out why it isn't working.
 
-    std::map<std::string, std::map<std::string, std::string>> json_units;
+    //std::map<std::string, std::map<std::string, std::string>> json_units;
 
-    UnitJSONFactory::ParseJSON("test_assets/units.csv");
+    //UnitJSONFactory::ParseJSON("test_assets/units.csv");
 }

--- a/engine/src/cmd/unit_csv.h
+++ b/engine/src/cmd/unit_csv.h
@@ -28,8 +28,6 @@
 #ifndef __UNIT_CSV_H__
 #define __UNIT_CSV_H__
 
-CSVRow LookupUnitRow(const std::string &name, const std::string &faction);
-
 extern void AddMeshes(std::vector<Mesh *> &xmeshes,
         float &randomstartframe,
         float &randomstartseconds,

--- a/engine/src/cmd/unit_csv_factory.cpp
+++ b/engine/src/cmd/unit_csv_factory.cpp
@@ -93,9 +93,9 @@ std::vector<std::string> ProcessLine(std::string &line) {
     return cells;
 }
 
-void UnitCSVFactory::ProcessCSV(const std::string &d, bool saved_game) {
+void UnitCSVFactory::ParseCSV(VSFileSystem::VSFile &file, bool saved_game) {
     std::vector<std::string> columns;
-    std::string data(d);
+    std::string data = file.ReadFull();
     std::string delimiter = "\n";
     size_t pos = 0;
     std::string token;
@@ -123,6 +123,9 @@ void UnitCSVFactory::ProcessCSV(const std::string &d, bool saved_game) {
                 unit_attributes[columns[i]] = line[i];
             }
 
+            // Add root
+            unit_attributes["root"] = file.GetRoot();
+
             std::string key = (saved_game ? "player_ship" : line[0]);
 
             if(!key.empty()) {
@@ -131,4 +134,20 @@ void UnitCSVFactory::ProcessCSV(const std::string &d, bool saved_game) {
         }
         data.erase(0, pos + delimiter.length());
     }
+}
+
+
+// TODO: place this somewhere else with similar code from unit_csv
+std::string GetUnitKeyFromNameAndFaction(const std::string unit_name, const std::string unit_faction) {
+    std::string hash_name = unit_name + "__" + unit_faction;
+
+    if(UnitCSVFactory::HasUnit(hash_name)) {
+        return hash_name;
+    }
+
+    if(UnitCSVFactory::HasUnit(unit_name)) {
+        return unit_name;
+    }
+
+    return std::string();
 }

--- a/engine/src/cmd/unit_csv_factory.h
+++ b/engine/src/cmd/unit_csv_factory.h
@@ -30,8 +30,41 @@
 #include <string>
 #include <utility>
 #include <boost/algorithm/string.hpp>
-
 #include <iostream>
+
+#include "vsfilesystem.h"
+
+const std::string keys[] = {"Key", "Directory",	"Name",	"STATUS",	"Object_Type",
+                            "Combat_Role",	"Textual_Description",	"Hud_image",	"Unit_Scale",	"Cockpit",
+                            "CockpitX", "CockpitY",	"CockpitZ",	"Mesh",	"Shield_Mesh",	"Rapid_Mesh",	"BSP_Mesh",
+                            "Use_BSP", "Use_Rapid",	"NoDamageParticles", "Mass",	"Moment_Of_Inertia",
+                            "Fuel_Capacity",	"Hull", "Armor_Front_Top_Right",	"Armor_Front_Top_Left",
+                            "Armor_Front_Bottom_Right", "Armor_Front_Bottom_Left",	"Armor_Back_Top_Right",
+                            "Armor_Back_Top_Left", "Armor_Back_Bottom_Right",	"Armor_Back_Bottom_Left",	"Shield_Front_Top_Right",
+                            "Shield_Back_Top_Left",	"Shield_Front_Bottom_Right",	"Shield_Front_Bottom_Left",
+                            "Shield_Back_Top_Right",	"Shield_Front_Top_Left",	"Shield_Back_Bottom_Right",
+                            "Shield_Back_Bottom_Left",	"Shield_Recharge",	"Shield_Leak",	"Warp_Capacitor",
+                            "Primary_Capacitor",	"Reactor_Recharge",	"Jump_Drive_Present",	"Jump_Drive_Delay",
+                            "Wormhole",	"Outsystem_Jump_Cost",	"Warp_Usage_Cost",	"Afterburner_Type",
+                            "Afterburner_Usage_Cost",	"Maneuver_Yaw",	"Maneuver_Pitch",	"Maneuver_Roll",
+                            "Yaw_Governor",	"Pitch_Governor",	"Roll_Governor",	"Afterburner_Accel",
+                            "Forward_Accel",	"Retro_Accel",	"Left_Accel",	"Right_Accel",	"Top_Accel",
+                            "Bottom_Accel",	"Afterburner_Speed_Governor",	"Default_Speed_Governor",	"ITTS",
+                            "Radar_Color",	"Radar_Range",	"Tracking_Cone",	"Max_Cone", "Lock_Cone",	"Hold_Volume",
+                            "Can_Cloak",	"Cloak_Min",	"Cloak_Rate",	"Cloak_Energy",	"Cloak_Glass",	"Repair_Droid",
+                            "ECM_Rating",	"ECM_Resist",	"Ecm_Drain",	"Hud_Functionality",	"Max_Hud_Functionality",
+                            "Lifesupport_Functionality",	"Max_Lifesupport_Functionality",	"Comm_Functionality",
+                            "Max_Comm_Functionality",	"FireControl_Functionality",	"Max_FireControl_Functionality",
+                            "SPECDrive_Functionality",	"Max_SPECDrive_Functionality",	"Slide_Start",	"Slide_End",
+                            "Activation_Accel",	"Activation_Speed",	"Upgrades",	"Prohibited_Upgrades",
+                            "Sub_Units",	"Sound",	"Light",	"Mounts",	"Net_Comm",	"Dock",	"Cargo_Import",	"Cargo",
+                            "Explosion",	"Num_Animation_Stages",	"Upgrade_Storage_Volume",	"Heat_Sink_Rating",
+                            "Shield_Efficiency",	"Num_Chunks",	"Chunk_0",	"Collide_Subunits",	"Spec_Interdiction",
+                            "Tractorability",
+                            // These values are not in units.csv! There are probably more but I stopped mapping.
+                            // TODO: map all missing values using the commented out code below!
+                            "FaceCamera", "Unit_Role", "Attack_Preference", "Hidden_Hold_Volume", "Equipment_Space"};
+
 
 class UnitCSVFactory {
     static std::string DEFAULT_ERROR_VALUE;
@@ -44,6 +77,23 @@ class UnitCSVFactory {
 
         std::map<std::string, std::string> unit_attributes = UnitCSVFactory::units[unit_key];
 
+        // TODO: Use this code to find more missing key as shown above.
+        // Note: The following code can probably be cleaner with find...
+        /*bool attribute_found = false;
+
+        for(const std::string& key : keys) {
+            if(key == attribute_key) {
+                attribute_found = true;
+                break;
+            }
+        }
+
+        if (!attribute_found)
+        {
+            std::cout << attribute_key << " attribute not found.\n";
+            assert(0);
+        }*/
+
         if (unit_attributes.count(attribute_key) == 0) {
             return DEFAULT_ERROR_VALUE;
         }
@@ -53,10 +103,23 @@ class UnitCSVFactory {
 
     friend class UnitJSONFactory;
 public:
-    static void ProcessCSV(const std::string &d, bool saved_game);
+    static void ParseCSV(VSFileSystem::VSFile &file, bool saved_game);
 
     template<class T>
     static inline T GetVariable(std::string unit_key, std::string const &attribute_key, T default_value) = delete;
+    static bool HasVariable(std::string unit_key, std::string const &attribute_key) {
+        if (units.count(unit_key) == 0) {
+            return false;
+        }
+
+        std::map<std::string, std::string> unit_attributes = UnitCSVFactory::units[unit_key];
+
+        return (unit_attributes.count(attribute_key) > 0);
+    }
+
+    static bool HasUnit(std::string unit_key) {
+        return (units.count(unit_key) > 0);
+    }
 };
 
 // Template Specialization
@@ -136,5 +199,7 @@ inline int UnitCSVFactory::GetVariable(std::string unit_key, std::string const &
         return default_value;
     }
 }
+
+std::string GetUnitKeyFromNameAndFaction(const std::string unit_name, const std::string unit_faction);
 
 #endif // UNITCSVFACTORY_H

--- a/engine/src/cmd/unit_generic.cpp
+++ b/engine/src/cmd/unit_generic.cpp
@@ -72,6 +72,7 @@
 #include "configuration/game_config.h"
 #include "resource/resource.h"
 #include "base_util.h"
+#include "unit_csv_factory.h"
 
 #include <math.h>
 #include <list>
@@ -406,7 +407,6 @@ void Unit::Init() {
 
 using namespace VSFileSystem;
 extern std::string GetReadPlayerSaveGame(int);
-CSVRow GetUnitRow(string filename, bool subu, int faction, bool readLast, bool &read);
 
 void Unit::Init(const char *filename,
         bool SubU,
@@ -414,8 +414,11 @@ void Unit::Init(const char *filename,
         std::string unitModifications,
         Flightgroup *flightgrp,
         int fg_subnumber) {
-    const bool UNITTAB = configuration()->physics_config.unit_table;
-    CSVRow unitRow;
+    // Deprecated UNITTAB and configuration()->physics_config.unit_table options.
+    // Game will always load units from the JSON or CSV files.
+    // The other option was not implemented wholly. It simply opened the file
+    // but didn't do anything with it. See VSFile f variable.
+
     // TODO: something with the following line
     this->Unit::Init();
     graphicOptions.SubUnit = SubU ? 1 : 0;
@@ -423,17 +426,11 @@ void Unit::Init(const char *filename,
     graphicOptions.RecurseIntoSubUnitsOnCollision = !isSubUnit();
     this->faction = faction;
     SetFg(flightgrp, fg_subnumber);
-    VSFile f;
-    VSFile f2;
-    VSError err = Unspecified;
-    VSFile unitTab;
-    VSError taberr = Unspecified;
-    bool foundFile = false;
     bool saved_game = false;
-    if (unitModifications.length() != 0) {
+    bool modified = (unitModifications.length() != 0);
+    if (modified) {
         string nonautosave = GetReadPlayerSaveGame(_Universe->CurrentCockpit());
         string filepath("");
-        //In network mode we only look in the save subdir in HOME
 
         if (nonautosave.empty()) {
             VSFileSystem::CreateDirectoryHome(VSFileSystem::savedunitpath + "/" + unitModifications);
@@ -445,91 +442,40 @@ void Unit::Init(const char *filename,
 
         //Try to open save
         if (filename[0]) {
-            taberr = unitTab.OpenReadOnly(filepath + ".csv", UnitSaveFile);
+            VSFile unitTab;
+            VSError taberr = unitTab.OpenReadOnly(filepath + ".csv", UnitSaveFile);
             if (taberr <= Ok) {
-                unitTables.push_back(new CSVTable(unitTab, unitTables.back()->rootdir));
+                UnitCSVFactory::ParseCSV(unitTab, true);
                 unitTab.Close();
                 saved_game = true;
             }
-            if (!UNITTAB) {
-                err = f.OpenReadOnly(filepath, UnitSaveFile);
-            }
         }
     }
 
-
-    //If save was not succesfull we try to open the unit file itself
-    if (filename[0]) {
-        string subdir = "factions/" + FactionUtil::GetFactionName(faction);
-        //begin deprecated code (5/11)
-        if (UNITTAB) {
-        } else {
-            if (err > Ok) {
-                f.SetSubDirectory(subdir);
-                //No save found loading default unit
-                err = f.OpenReadOnly(filename, UnitFile);
-                if (err > Ok) {
-                    f.SetSubDirectory("");
-                    err = f.OpenReadOnly(filename, UnitFile);
-                }
-            } else {
-                f2.SetSubDirectory(subdir);
-                //Save found so just opening default unit to get its directory for further loading
-                err = f2.OpenReadOnly(filename, UnitFile);
-                if (err > Ok) {
-                    f2.SetSubDirectory("");
-                    err = f2.OpenReadOnly(filename, UnitFile);
-                }
-            }
-        }
-        //end deprecated code
-    }
-
-    if (UNITTAB) {
-        unitRow = GetUnitRow(filename, SubU, faction, true, foundFile);
-    } else {
-        foundFile = (err <= Ok);
-    }
     this->filename = filename;
-    if (!foundFile) {
-        bool istemplate = (string::npos != (string(filename).find(".template")));
-        if (!istemplate || (istemplate && configuration()->data_config.using_templates)) {
-            VS_LOG(trace, (boost::format("Unit file %1% not found") % filename));
-        }
-        meshdata.clear();
-        meshdata.push_back(NULL);
-        this->fullname = filename;
-        this->name = string("LOAD_FAILED");
-        calculate_extent(false);
-        radial_size = 1;
-        if ((taberr <= Ok && taberr != Unspecified)) {
-            delete unitTables.back();
-            unitTables.pop_back();
-        }
-        pilot->SetComm(this);
-        return;
-    }
-    this->name = this->filename;
-    bool tmpbool;
-    if (UNITTAB) {
-        //load from table?
+    this->name = filename;
 
-        //we have to set the root directory to where the saved unit would have come from.
-        //saved only exists if taberr<=Ok && taberr!=Unspecified...that's why we pass in said boolean
-        VSFileSystem::current_path.push_back(taberr <= Ok && taberr
-                != Unspecified ? GetUnitRow(filename, SubU, faction, false,
-                tmpbool).getRoot() : unitRow.getRoot());
-        VSFileSystem::current_subdirectory.push_back("/" + unitRow["Directory"]);
-        VSFileSystem::current_type.push_back(UnitFile);
-        LoadRow(unitRow, unitModifications, saved_game);
-        VSFileSystem::current_type.pop_back();
-        VSFileSystem::current_subdirectory.pop_back();
-        VSFileSystem::current_path.pop_back();
-        if ((taberr <= Ok && taberr != Unspecified)) {
-            delete unitTables.back();
-            unitTables.pop_back();
-        }
-    }
+    const std::string faction_name = FactionUtil::GetFactionName(faction);
+    const std::string unit_key = GetUnitKeyFromNameAndFaction(filename, faction_name);
+
+    //load from table?
+    //we have to set the root directory to where the saved unit would have come from.
+    //saved only exists if taberr<=Ok && taberr!=Unspecified...that's why we pass in said boolean
+    // Despite the check, has always taken the data folder, simplifying
+    //VSFileSystem::current_path.push_back(taberr <= Ok && taberr
+    //        != Unspecified ? GetUnitRow(filename, SubU, faction, false,
+    //        tmpbool).getRoot() : unitRow.getRoot());
+    std::string root = UnitCSVFactory::GetVariable(unit_key, "root", std::string());
+    VSFileSystem::current_path.push_back(root);
+
+    std::string directory = UnitCSVFactory::GetVariable(unit_key, "Directory", std::string());
+    VSFileSystem::current_subdirectory.push_back("/" + directory);
+    VSFileSystem::current_type.push_back(UnitFile);
+    LoadRow(unit_key, unitModifications, saved_game);
+    VSFileSystem::current_type.pop_back();
+    VSFileSystem::current_subdirectory.pop_back();
+    VSFileSystem::current_path.pop_back();
+
     calculate_extent(false);
     pilot->SetComm(this);
 

--- a/engine/src/cmd/unit_generic.cpp
+++ b/engine/src/cmd/unit_generic.cpp
@@ -458,6 +458,25 @@ void Unit::Init(const char *filename,
     const std::string faction_name = FactionUtil::GetFactionName(faction);
     const std::string unit_key = GetUnitKeyFromNameAndFaction(filename, faction_name);
 
+    if (unit_key == "") {
+        // This is actually used for upgrade checks.
+        bool istemplate = (string::npos != (string(filename).find(".template")));
+        if (!istemplate || (istemplate && configuration()->data_config.using_templates)) {
+            VS_LOG(trace, (boost::format("Unit file %1% not found") % filename));
+        }
+        meshdata.clear();
+        meshdata.push_back(NULL);
+        this->fullname = filename;
+        this->name = string("LOAD_FAILED");
+        calculate_extent(false);
+        radial_size = 1;
+
+        pilot->SetComm(this);
+        return;
+    }
+
+    bool tmpbool;
+
     //load from table?
     //we have to set the root directory to where the saved unit would have come from.
     //saved only exists if taberr<=Ok && taberr!=Unspecified...that's why we pass in said boolean

--- a/engine/src/cmd/unit_generic.h
+++ b/engine/src/cmd/unit_generic.h
@@ -219,7 +219,7 @@ public:
     void Init(const char *filename, bool SubUnit, int faction, std::string customizedUnit = std::string(
             ""), Flightgroup *flightgroup = NULL, int fg_subnumber = 0);
 //table can be NULL, but setting it appropriately may increase performance
-    void LoadRow(class CSVRow &row, std::string unitMod, bool saved_game);
+    void LoadRow(std::string unit_identifier, std::string unitMod, bool saved_game);
 
     // TODO: implement enum class as type safe bitmask...
     // http://blog.bitwigglers.org/using-enum-classes-as-type-safe-bitmasks/

--- a/engine/src/cmd/unit_json_factory.cpp
+++ b/engine/src/cmd/unit_json_factory.cpp
@@ -35,42 +35,8 @@
 #include "json.h"
 
 
-const std::string keys[] = {"Key", "Directory",	"Name",	"STATUS",	"Object_Type",
-                            "Combat_Role",	"Textual_Description",	"Hud_image",	"Unit_Scale",	"Cockpit",
-                            "CockpitX", "CockpitY",	"CockpitZ",	"Mesh",	"Shield_Mesh",	"Rapid_Mesh",	"BSP_Mesh",
-                            "Use_BSP", "Use_Rapid",	"NoDamageParticles", "Mass",	"Moment_Of_Inertia",
-                            "Fuel_Capacity",	"Hull", "Armor_Front_Top_Right",	"Armor_Front_Top_Left",
-                            "Armor_Front_Bottom_Right", "Armor_Front_Bottom_Left",	"Armor_Back_Top_Right",
-                            "Armor_Back_Top_Left", "Armor_Back_Bottom_Right",	"Armor_Back_Bottom_Left",	"Shield_Front_Top_Right",
-                            "Shield_Back_Top_Left",	"Shield_Front_Bottom_Right",	"Shield_Front_Bottom_Left",
-                            "Shield_Back_Top_Right",	"Shield_Front_Top_Left",	"Shield_Back_Bottom_Right",
-                            "Shield_Back_Bottom_Left",	"Shield_Recharge",	"Shield_Leak",	"Warp_Capacitor",
-                            "Primary_Capacitor",	"Reactor_Recharge",	"Jump_Drive_Present",	"Jump_Drive_Delay",
-                            "Wormhole",	"Outsystem_Jump_Cost",	"Warp_Usage_Cost",	"Afterburner_Type",
-                            "Afterburner_Usage_Cost",	"Maneuver_Yaw",	"Maneuver_Pitch",	"Maneuver_Roll",
-                            "Yaw_Governor",	"Pitch_Governor",	"Roll_Governor",	"Afterburner_Accel",
-                            "Forward_Accel",	"Retro_Accel",	"Left_Accel",	"Right_Accel",	"Top_Accel",
-                            "Bottom_Accel",	"Afterburner_Speed_Governor",	"Default_Speed_Governor",	"ITTS",
-                            "Radar_Color",	"Radar_Range",	"Tracking_Cone",	"Max_Cone", "Lock_Cone",	"Hold_Volume",
-                            "Can_Cloak",	"Cloak_Min",	"Cloak_Rate",	"Cloak_Energy",	"Cloak_Glass",	"Repair_Droid",
-                            "ECM_Rating",	"ECM_Resist",	"Ecm_Drain",	"Hud_Functionality",	"Max_Hud_Functionality",
-                            "Lifesupport_Functionality",	"Max_Lifesupport_Functionality",	"Comm_Functionality",
-                            "Max_Comm_Functionality",	"FireControl_Functionality",	"Max_FireControl_Functionality",
-                            "SPECDrive_Functionality",	"Max_SPECDrive_Functionality",	"Slide_Start",	"Slide_End",
-                            "Activation_Accel",	"Activation_Speed",	"Upgrades",	"Prohibited_Upgrades",
-                            "Sub_Units",	"Sound",	"Light",	"Mounts",	"Net_Comm",	"Dock",	"Cargo_Import",	"Cargo",
-                            "Explosion",	"Num_Animation_Stages",	"Upgrade_Storage_Volume",	"Heat_Sink_Rating",
-                            "Shield_Efficiency",	"Num_Chunks",	"Chunk_0",	"Collide_Subunits",	"Spec_Interdiction",
-                            "Tractorability"};
-
-void UnitJSONFactory::ParseJSON(const std::string &filename) {
-    const std::string json_filename = filename.substr(0, filename.size()-3) + "json";
-
-    std::ifstream ifs(json_filename, std::ifstream::in);
-    std::stringstream buffer;
-    buffer << ifs.rdbuf();
-
-    const std::string json_text = buffer.str();
+void UnitJSONFactory::ParseJSON(VSFileSystem::VSFile &file) {
+    const std::string json_text = file.ReadFull();
 
     std::vector<std::string> units = json::parsing::parse_array(json_text.c_str());
     // Iterate over root
@@ -88,6 +54,9 @@ void UnitJSONFactory::ParseJSON(const std::string &filename) {
                 unit_attributes[key] = "";
             }
         }
+
+        // Add root
+        unit_attributes["root"] = file.GetRoot();
 
         std::string unit_key = unit.get("Key");
         std::string stripped_unit_key = unit_key.substr(1, unit_key.size() - 2);

--- a/engine/src/cmd/unit_json_factory.h
+++ b/engine/src/cmd/unit_json_factory.h
@@ -27,10 +27,12 @@
 
 #include <string>
 
+#include "vsfilesystem.h"
+
 class UnitJSONFactory {
     static std::string DEFAULT_ERROR_VALUE;
 
 public:
-    static void ParseJSON(const std::string &filename);
+    static void ParseJSON(VSFileSystem::VSFile &file);
 };
 #endif // UNITJSONFACTORY_H

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -54,6 +54,8 @@
 #include "vs_logging.h"
 
 #include "weapon_factory.h"
+#include "unit_csv_factory.h"
+#include "unit_json_factory.h"
 
 #include <algorithm>
 #include <string>
@@ -269,8 +271,38 @@ static void AppendUnitTables(const string &csvfiles) {
 }
 
 void InitUnitTables() {
+    // Old Init
     AppendUnitTables(game_options()->modUnitCSV);
-    AppendUnitTables(game_options()->unitCSV);
+
+    // New Init
+    // Try to open units.json
+    VSFileSystem::VSFile jsonFile;
+    VSFileSystem::VSError err = jsonFile.OpenReadOnly("units.json", VSFileSystem::UnitFile);
+    if (err <= VSFileSystem::Ok) {
+        UnitJSONFactory::ParseJSON(jsonFile);
+
+    } else {
+        // Try units.csv
+        VSFileSystem::VSFile csvFile;
+        VSFileSystem::VSError err = csvFile.OpenReadOnly("units.csv", VSFileSystem::UnitFile);
+        if (err <= VSFileSystem::Ok) {
+            UnitCSVFactory::ParseCSV(csvFile, true);
+        } else {
+            std::cerr << "Unable to open units file. Aborting.\n";
+            abort();
+        }
+        csvFile.Close();
+    }
+
+    jsonFile.Close();
+
+    // TODO: where did this code snippet come from???
+    /*if (f.GetFilename() == "units_description.csv" ||
+        f.GetFilename() == "master_part_list.csv") {
+        // TODO: handle master_part_list
+    */
+
+
 }
 
 void CleanupUnitTables() {

--- a/engine/src/universe_util_generic.cpp
+++ b/engine/src/universe_util_generic.cpp
@@ -46,6 +46,7 @@
 #include "linecollide.h"
 #include "cmd/unit_collide.h"
 #include "cmd/unit_find.h"
+#include "unit_csv_factory.h"
 
 #include "python/init.h"
 #include <Python.h>
@@ -759,12 +760,14 @@ Unit *launch(string name_string,
 }
 
 string LookupUnitStat(const string &unitname, const string &faction, const string &statname) {
-    CSVRow tmp(LookupUnitRow(unitname, faction));
-    if (tmp.success()) {
-        return tmp[statname];
-    } else {
-        return string();
+    const std::string unit_key = GetUnitKeyFromNameAndFaction(unitname, faction);
+
+    // No Unit Key Found
+    if(unit_key.size() == 0) {
+        return unit_key;
     }
+
+    return UnitCSVFactory::GetVariable(unit_key, statname, std::string());
 }
 
 static std::vector<Unit *> cachedUnits;


### PR DESCRIPTION
This PR introduces full support for both JSON and CSV unit files. 
At present, save games will use CSV.
Unless a release is planned soon, the coming one. 

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation


Issues:
- When died and respawned, ship was missing all modules and texture. Radar range was either random or max int. Non-reproducible.
- When landing on a planet, ship was incorrectly drawn. Non-reproducible.
- Multiple issues related to legacy code and correctness of assets (to be fixed there).

