### PR TITLE
CMakeLists.txt: Increment VEGASTRIKE_ASSETS_API_VERSION to 2

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -76,7 +76,7 @@ ENDIF ()
 # This is an incrementing number similar to the Google Android API Version
 # allowing us to differentiate our Assets API across multiple versions.
 # If a release is missing this value, then version `1` can be assumed.
-SET(VEGASTRIKE_ASSETS_API_VERSION "1")
+SET(VEGASTRIKE_ASSETS_API_VERSION "2")
 
 IF (COMMAND cmake_policy)
     CMAKE_POLICY(SET CMP0003 NEW)


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [Partly] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Simply increment the API version that the engine reports to the assets, for upcoming release series 0.9.x
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
