### PR TITLE
Add ability to parse from ships.json, a hierarchical unit structure

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -838,6 +838,7 @@ SET(LIBCMD_SOURCES
     src/cmd/unit_csv.cpp
     src/cmd/unit_csv_factory.cpp
     src/cmd/unit_json_factory.cpp
+    src/cmd/unit_optimize_factory.cpp
     src/cmd/json.cpp
     src/cmd/unit_functions_generic.cpp
     src/cmd/unit_generic.cpp

--- a/engine/src/cmd/unit_csv.cpp
+++ b/engine/src/cmd/unit_csv.cpp
@@ -847,7 +847,8 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     graphicOptions.MinWarpMultiplier = UnitCSVFactory::GetVariable(unit_key, "Warp_Min_Multiplier", 1.0f);
     graphicOptions.MaxWarpMultiplier = UnitCSVFactory::GetVariable(unit_key, "Warp_Max_Multiplier", 1.0f);
 
-    energy.Set(UnitCSVFactory::GetVariable(unit_key, "Primary_Capacitor", 0.0f));
+    double capacitor = UnitCSVFactory::GetVariable(unit_key, "Primary_Capacitor", 0.0f);
+    energy = Resource<float>(capacitor, 0.0f, capacitor);
     recharge = UnitCSVFactory::GetVariable(unit_key, "Reactor_Recharge", 0.0f);
     jump.drive = UnitCSVFactory::GetVariable(unit_key, "Jump_Drive_Present", false) ? -1 : -2;
     jump.delay = UnitCSVFactory::GetVariable(unit_key, "Jump_Drive_Delay", 0);

--- a/engine/src/cmd/unit_csv_factory.h
+++ b/engine/src/cmd/unit_csv_factory.h
@@ -102,6 +102,7 @@ class UnitCSVFactory {
     }
 
     friend class UnitJSONFactory;
+    friend class UnitOptimizeFactory;
 public:
     static void ParseCSV(VSFileSystem::VSFile &file, bool saved_game);
 

--- a/engine/src/cmd/unit_optimize_factory.cpp
+++ b/engine/src/cmd/unit_optimize_factory.cpp
@@ -1,0 +1,83 @@
+/*
+ * unit_csv_factory.cpp
+ *
+ * Copyright (C) 2020-2022 Daniel Horn, Roy Falk, Stephen G. Tuggy, and
+ * other Vega Strike contributors
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "unit_optimize_factory.h"
+#include "unit_csv_factory.h"
+
+#include "json.h"
+
+void UnitOptimizeFactory::RecuriveParse(std::map<std::string, std::string> unit_attributes,
+                   const std::string& json_text, bool is_root) {
+    json::jobject json = json::jobject::parse(json_text);
+
+    // Parse the data section
+    std::string data = json.get("data");
+    json::jobject data_json = json::jobject::parse(data);
+
+    for (const std::string &key : keys) {
+        // For some reason, parser adds quotes
+        if(data_json.has_key(key)) {
+            const std::string attribute = data_json.get(key);
+            const std::string stripped_attribute = attribute.substr(1, attribute.size() - 2);
+            unit_attributes[key] = stripped_attribute;
+        } else {
+            // If we do this for non-root, we'll overwrite existing attributes
+            if(is_root) {
+                unit_attributes[key] = "";
+            }
+        }
+    }
+
+    // Parse the units array
+    if(json.has_key("units")) {
+        std::vector<std::string> units = json::parsing::parse_array(json.get("units").c_str());
+        // Iterate over root
+        for (const std::string &unit_text : units) {
+            RecuriveParse(unit_attributes, unit_text, false);
+        }
+    } else {
+        // Add moment of intertia
+        if(unit_attributes.count("Mass")) {
+            unit_attributes["Moment_Of_Inertia"] = unit_attributes["Mass"];
+        }
+
+        std::string unit_key = unit_attributes["Key"];
+
+        UnitCSVFactory::units[unit_key] = unit_attributes;
+    }
+}
+
+
+void UnitOptimizeFactory::ParseJSON(VSFileSystem::VSFile &file) {
+    const std::string json_text = file.ReadFull();
+
+
+
+    std::map<std::string, std::string> unit_attributes;
+
+    // Add root
+    unit_attributes["root"] = file.GetRoot();
+
+    RecuriveParse(unit_attributes, json_text, true);
+}

--- a/engine/src/cmd/unit_optimize_factory.h
+++ b/engine/src/cmd/unit_optimize_factory.h
@@ -1,0 +1,38 @@
+#ifndef UNITOPTIMIZEFACTORY_H
+#define UNITOPTIMIZEFACTORY_H
+
+/*
+ * unit_optimize_factory.cpp
+ *
+ * Copyright (C) 2020-2022 Daniel Horn, Roy Falk, Stephen G. Tuggy, and
+ * other Vega Strike contributors
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "vsfilesystem.h"
+
+class UnitOptimizeFactory
+{
+public:
+    static void ParseJSON(VSFileSystem::VSFile &file);
+    static void RecuriveParse(std::map<std::string, std::string> unit_attributes,
+                       const std::string& json_text, bool is_root);
+};
+
+#endif // UNITOPTIMIZEFACTORY_H

--- a/engine/src/cmd/unit_optimize_factory.h
+++ b/engine/src/cmd/unit_optimize_factory.h
@@ -26,6 +26,7 @@
  */
 
 #include <map>
+#include <string>
 
 #include "vsfilesystem.h"
 

--- a/engine/src/cmd/unit_optimize_factory.h
+++ b/engine/src/cmd/unit_optimize_factory.h
@@ -25,6 +25,8 @@
  * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <map>
+
 #include "vsfilesystem.h"
 
 class UnitOptimizeFactory

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -56,6 +56,7 @@
 #include "weapon_factory.h"
 #include "unit_csv_factory.h"
 #include "unit_json_factory.h"
+#include "unit_optimize_factory.h"
 
 #include <algorithm>
 #include <string>
@@ -302,7 +303,15 @@ void InitUnitTables() {
         // TODO: handle master_part_list
     */
 
+    // Really New Init
+    VSFileSystem::VSFile newJsonFile;
+    err = newJsonFile.OpenReadOnly("ships.json", VSFileSystem::UnitFile);
+    if (err <= VSFileSystem::Ok) {
+        UnitOptimizeFactory::ParseJSON(newJsonFile);
 
+    }
+
+    newJsonFile.Close();
 }
 
 void CleanupUnitTables() {


### PR DESCRIPTION
This is a first attempt to reduce units.json file size by moving ships to another file and making it hierarchical.
The aim is to write a identical value once. For example, all variants of the same ship (e.g. llama) share the folder, name, description, etc. If you write these in the parent llama, all variants will apply them. Have a different description for llama.begin, overwrite it for that variant specifically.

Currently, implemented only for Areus (and only for Areus variant) and Llama.begin.

See also related asset [98](https://github.com/vegastrike/Assets-Production/pull/98)
Code Changes:
- [not yet] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation


Issues:
- ~~In loaded game, shield reduce in power~~ (fixed)
- In loaded game, Oswald started as neutral or hostile (non reproducible)
- When re-spawned after dying, I was in an unidentified ship with no mesh and icepicks for weapons. Couldn't dock or die either. (non reproducible)
