### PR TITLE
Refactor gnuhash.h

### DIFF
--- a/engine/src/gnuhash.h
+++ b/engine/src/gnuhash.h
@@ -20,9 +20,10 @@
  * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _GNUHASH_H_
-#define _GNUHASH_H_
+#ifndef VEGA_STRIKE_GNUHASH_H_
+#define VEGA_STRIKE_GNUHASH_H_
 #include <unordered_map>
+#include <cstddef>
 
 #define vsUMap     std::unordered_map
 #define vsHashComp vega_std_overrides::hash_compare
@@ -80,5 +81,5 @@ public:
 
 }
 
-#endif //def _GNUHASH_H_
+#endif //VEGA_STRIKE_GNUHASH_H_
 

--- a/engine/src/gnuhash.h
+++ b/engine/src/gnuhash.h
@@ -66,7 +66,7 @@ public:
                 ^ ((size_t) a((int) (((size_t) key.second) >> 4))));
     }
 };
-#ifdef __GNUC__
+#if defined(__GNUC__) || _MSC_VER >= 17
 //Minimum declaration needed by SharedPool.h
 template<class Key, class Traits = std::less<Key> >
 class hash_compare {

--- a/engine/src/gnuhash.h
+++ b/engine/src/gnuhash.h
@@ -25,7 +25,7 @@
 #include <unordered_map>
 
 #define vsUMap     std::unordered_map
-#define vsHashComp std::hash_compare
+#define vsHashComp vega_std_overrides::hash_compare
 #define vsHash     std::hash
 class Unit;
 
@@ -66,7 +66,10 @@ public:
                 ^ ((size_t) a((int) (((size_t) key.second) >> 4))));
     }
 };
-#if defined(__GNUC__) || _MSC_VER >= 17
+
+}
+
+namespace vega_std_overrides {
 //Minimum declaration needed by SharedPool.h
 template<class Key, class Traits = std::less<Key> >
 class hash_compare {
@@ -74,7 +77,7 @@ public:
     static const size_t bucket_size = 4;
     static const size_t min_buckets = 8;
 };
-#endif
+
 }
 
 #endif //def _GNUHASH_H_


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [Mostly] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Move part of the contents of gnuhash.h out of the `std` namespace, in order to follow best practices, and possibly also in order to fix some compile errors that have cropped up recently.
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
