### PR TITLE
Get the game working on macOS again (without PR 754 changes)

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -94,7 +94,7 @@ jobs:
         run: ctest -V -C Release
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
         if: failure()
         with:
             name: test_results_xml

--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
 
       - name: install-cmake
         uses: lukka/get-cmake@v3.21.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,12 +16,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      # matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        # language: ['cpp', 'python']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+      matrix:
+        language: ['cpp', 'python']
 
     steps:
     - name: Checkout repository
@@ -31,7 +27,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@0225834cc549ee0ca93cb085b92954821a145866 #v2.3.5
       # with:
         # languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,4 +41,4 @@ jobs:
         script/build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@0225834cc549ee0ca93cb085b92954821a145866 #v2.3.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
       with:
         fetch-depth: 2
 

--- a/.github/workflows/fortify-on-demand-scan.yml
+++ b/.github/workflows/fortify-on-demand-scan.yml
@@ -16,7 +16,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
 
       - name: Fortify on Demand Scan
         # You may pin to the exact commit or the version.

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -145,7 +145,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
       with:
         fetch-depth: 2
         submodules: false

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -181,7 +181,7 @@ jobs:
     #   run: ctest -V
 
     - name: Upload test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
       if: failure()
       with:
         name: test_results_xml

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -159,7 +159,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
       with:
         fetch-depth: 2
         submodules: false

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
 
     defaults:
       run:
@@ -20,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-10.15
+          - macos-11
         compiler:
           - clang
           - gcc
@@ -33,68 +34,64 @@ jobs:
 
     steps:
 
-    # The following dependencies are already present within macos-* images:
-    # - clang (llvm 12)
-    # - cmake
-    # - expat
-    # - gcc (9, 10, 11)
-    # - git
-    # - jpeg
-    # - libpng
-    # - libvorbis
-    # - python (3.8, 3.9)
-    - name: Install dependencies using homebrew
-      run: brew install boost-python3 gtk+3 gtkglext sdl
+      # The following dependencies are already present within macos-* images:
+      # - clang (llvm)
+      # - cmake
+      # - expat
+      # - gcc
+      # - git
+      # - jpeg
+      # - libpng
+      # - libvorbis
+      # - python
+      - name: Install dependencies using homebrew
+        run: brew install boost-python3 gtk+3 gtkglext sdl
 
-    # The following Apple-provided libraries are deprecated:
-    # * OpenGL as of MacOS 10.14
-    # * GLUT as of MacOS 10.9
-    - name: Optionally install homebrewed OpenGL and GLUT
-      if: ${{ matrix.homebrew-gl }}
-      run: |
-        brew install mesa mesa-glu freeglut
-        ln -s /usr/local/include/GL /usr/local/include/OpenGL
-        ln -s /usr/local/include/GL /usr/local/include/GLUT
-      # ln -s /usr/local/lib/libGL.dylib /usr/local/lib/libOpenGL.dylib
-      # find /usr/local/lib/ -iname '*gl*.dylib'
+      # The following Apple-provided libraries are deprecated:
+      # * OpenGL as of MacOS 10.14
+      # * GLUT as of MacOS 10.9
+      - name: Optionally install homebrewed OpenGL and GLUT
+        if: ${{ matrix.homebrew-gl }}
+        run: |
+          brew install mesa mesa-glu freeglut
+          ln -s /usr/local/include/GL /usr/local/include/OpenGL
+          ln -s /usr/local/include/GL /usr/local/include/GLUT
+        # ln -s /usr/local/lib/libGL.dylib /usr/local/lib/libOpenGL.dylib
+        # find /usr/local/lib/ -iname '*gl*.dylib'
 
-    # The Apple-provided OpenAL is deprecated as of MacOS 10.15
-    - name: Optionally install homebrewed OpenAL
-      if: ${{ matrix.homebrew-al }}
-      run: brew install openal-soft
+      # The Apple-provided OpenAL is deprecated as of MacOS 10.15
+      - name: Optionally install homebrewed OpenAL
+        if: ${{ matrix.homebrew-al }}
+        run: brew install openal-soft
 
-    - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-        submodules: false
+      - name: Check out repository
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+        with:
+          fetch-depth: 2
+          submodules: false
 
-    # Ensure PRs are built against the PR Head
-    # As opposed to the merge commit
-    - name: Conditionally relocate to PR HEAD
-      if: github.event.pull_request
-      run: git checkout HEAD^2
+      - name: Conditionally relocate to PR HEAD
+        if: github.event.pull_request
+        run: git checkout HEAD^2
 
-    - name: Build it
-      env:
-        MY_OS_NAME: macos
-        COMPILER:   ${{ matrix.compiler }}
-        FLAGS:      -DCMAKE_FIND_FRAMEWORK=LAST
-        OPENALDIR:  "/usr/local/opt/openal-soft"
-      run: script/cibuild $FLAGS
+      - name: Build it
+        env:
+          MY_OS_NAME: macos
+          COMPILER:   ${{ matrix.compiler }}
+          FLAGS:      -DCMAKE_FIND_FRAMEWORK=LAST
+          OPENALDIR:  "/usr/local/opt/openal-soft"
+        run: script/cibuild $FLAGS
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      env:
-        GTEST_OUTPUT: xml
-        GTEST_COLOR: 1
-      run: ctest -V
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        env:
+          GTEST_OUTPUT: xml
+          GTEST_COLOR: 1
+        run: ctest -V
 
-    - name: Upload test results
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: test_results_xml
-        path: ${{github.workspace}}/build/test-results/**/*.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        if: failure()
+        with:
+          name: test_results_xml
+          path: ${{github.workspace}}/build/test-results/**/*.xml

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         os:
           - macos-11
+          - macos-12
         compiler:
           - clang
           - gcc

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
         with:
           name: SARIF file
           path: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 bin/
 build/
 build-*/
+cmake-build/
+cmake-build-*/
 data/
 ext/
 *.pyc

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -285,12 +285,27 @@ void init_opengl_extensions() {
 #ifndef __APPLE_PANTHER_GCC33_CLI__
         glLockArraysEXT_p   = nullptr;
         glUnlockArraysEXT_p = nullptr;
+#else
+        glLockArraysEXT_p = nullptr;
+        glUnlockArraysEXT_p = nullptr;
 #endif /*__APPLE_PANTHER_GCC33_CLI__*/
 #endif
         VS_LOG(debug, "OpenGL::GL_EXT_compiled_vertex_array unsupported");
     }
 #endif
-#ifndef __APPLE__
+#if defined (__MACOSX__)
+    if (vsExtensionSupported("GL_EXT_multi_draw_arrays")) {
+        glMultiDrawArrays_p = (PFNGLMULTIDRAWARRAYSEXTPROC)
+                GET_GL_PROC((GET_GL_PTR_TYP) "glMultiDrawArraysEXT");
+        glMultiDrawElements_p = (PFNGLMULTIDRAWELEMENTSEXTPROC)
+                GET_GL_PROC((GET_GL_PTR_TYP) "glMultiDrawElementsEXT");
+        VS_LOG(trace, "OpenGL::GL_EXT_multi_draw_arrays supported");
+    } else {
+        glMultiDrawArrays_p = nullptr;
+        glMultiDrawElements_p = nullptr;
+        VS_LOG(debug, "OpenGL::GL_EXT_multi_draw_arrays unsupported");
+    }
+#else
     if (vsExtensionSupported("GL_EXT_multi_draw_arrays")) {
         glMultiDrawArrays_p = (PFNGLMULTIDRAWARRAYSEXTPROC)
                 GET_GL_PROC((GET_GL_PTR_TYP) "glMultiDrawArraysEXT");
@@ -304,13 +319,6 @@ void init_opengl_extensions() {
     }
 #endif
 
-#ifdef __APPLE__
-    glColorTable_p = (PFNGLCOLORTABLEEXTPROC)(dlsym(RTLD_SELF, "glColorTableEXT"));
-    glMultiTexCoord2fARB_p     = (PFNGLMULTITEXCOORD2FARBPROC)(dlsym(RTLD_SELF, "glMultiTexCoord2fARB"));
-    glMultiTexCoord4fARB_p     = (PFNGLMULTITEXCOORD4FARBPROC)(dlsym(RTLD_SELF, "glMultiTexCoord4fARB"));
-    glClientActiveTextureARB_p = (PFNGLCLIENTACTIVETEXTUREARBPROC)(dlsym(RTLD_SELF, "glClientActiveTextureARB"));
-    glActiveTextureARB_p = (PFNGLCLIENTACTIVETEXTUREARBPROC)(dlsym(RTLD_SELF, "glActiveTextureARB"));
-#else
 #ifndef NO_VBO_SUPPORT
     glBindBufferARB_p = (PFNGLBINDBUFFERARBPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glBindBuffer");
     glGenBuffersARB_p = (PFNGLGENBUFFERSPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glGenBuffers");
@@ -434,7 +442,6 @@ void init_opengl_extensions() {
         glDeleteProgram_p = (PFNGLDELETEPROGRAMPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glDeleteProgram");
     }
     //fixme
-#endif
 
 #ifdef GL_FOG_DISTANCE_MODE_NV
     if (vsExtensionSupported("GL_NV_fog_distance")) {
@@ -621,7 +628,7 @@ void GFXInit(int argc, char **argv) {
     }
 
     bool vidsupported = (gl_options.rect_textures
-            || (vsExtensionSupported("GL_ARB_texture_non_power_of_two") && vsVendorMatch("nvidia")));
+                         || (vsExtensionSupported("GL_ARB_texture_non_power_of_two") && vsVendorMatch("nvidia")));
 
     gl_options.pot_video_textures = game_options()->pot_video_textures ? true : vidsupported;
 

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -98,7 +98,7 @@
 #endif
 
 PFNGLBINDBUFFERARBPROC glBindBufferARB_p = nullptr;
-PFNGLGENBUFFERSARBPROC glGenBuffersARB_p = nullptr;
+PFNGLGENBUFFERSPROC glGenBuffersARB_p = nullptr;
 PFNGLDELETEBUFFERSARBPROC glDeleteBuffersARB_p = nullptr;
 PFNGLBUFFERDATAARBPROC glBufferDataARB_p = nullptr;
 PFNGLMAPBUFFERARBPROC glMapBufferARB_p = nullptr;
@@ -313,7 +313,7 @@ void init_opengl_extensions() {
 #else
 #ifndef NO_VBO_SUPPORT
     glBindBufferARB_p = (PFNGLBINDBUFFERARBPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glBindBuffer");
-    glGenBuffersARB_p = (PFNGLGENBUFFERSARBPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glGenBuffers");
+    glGenBuffersARB_p = (PFNGLGENBUFFERSPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glGenBuffers");
     glDeleteBuffersARB_p = (PFNGLDELETEBUFFERSARBPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glDeleteBuffers");
     glBufferDataARB_p = (PFNGLBUFFERDATAARBPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glBufferData");
     glMapBufferARB_p = (PFNGLMAPBUFFERARBPROC) GET_GL_PROC((GET_GL_PTR_TYP) "glMapBuffer");

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -282,13 +282,8 @@ void init_opengl_extensions() {
         VS_LOG(trace, "OpenGL::GL_EXT_compiled_vertex_array supported");
     } else {
 #ifdef __APPLE__
-#ifndef __APPLE_PANTHER_GCC33_CLI__
-        glLockArraysEXT_p   = nullptr;
-        glUnlockArraysEXT_p = nullptr;
-#else
         glLockArraysEXT_p = nullptr;
         glUnlockArraysEXT_p = nullptr;
-#endif /*__APPLE_PANTHER_GCC33_CLI__*/
 #endif
         VS_LOG(debug, "OpenGL::GL_EXT_compiled_vertex_array unsupported");
     }

--- a/engine/src/gldrv/gl_program.cpp
+++ b/engine/src/gldrv/gl_program.cpp
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2001-2022 Daniel Horn, pyramid3d, Stephen G. Tuggy,
+ * gl_program.cpp
+ *
+ * Copyright (C) 2001-2023 Daniel Horn, pyramid3d, Stephen G. Tuggy,
  * and other Vega Strike contributors.
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
@@ -60,11 +62,11 @@ static ProgramCache::key_type cacheKey(const std::string &vp, const std::string 
         }
     }
     return std::pair<unsigned int, std::pair<std::string, std::string> >(defhash,
-            std::pair<std::string, std::string>(vp, fp));
+                                                                         std::pair<std::string, std::string>(vp, fp));
 }
 
 static bool validateLog(GLuint obj, bool shader,
-        bool allowSoftwareEmulation = false) {
+                        bool allowSoftwareEmulation = false) {
     // Retrieve compiler log
     const GLsizei LOGBUF = 1024;
     GLsizei infologLength = 0;
@@ -117,10 +119,10 @@ void printLog(GLuint obj, bool shader) {
 }
 
 static VSFileSystem::VSError getProgramSource(const std::string &path,
-        std::vector<std::string> &lines,
-        std::set<std::string> &processed_includes,
-        char *buf,
-        size_t buflen) {
+                                              std::vector<std::string> &lines,
+                                              std::set<std::string> &processed_includes,
+                                              char *buf,
+                                              size_t buflen) {
     std::string dirname = path.substr(0, path.find_last_of('/'));
 
     VSFileSystem::VSFile f;
@@ -163,8 +165,8 @@ static VSFileSystem::VSError getProgramSource(const std::string &path,
                     }
                 } else {
                     VS_LOG(warning, (boost::format("WARNING: broken include directive at file %1%, line %2% - skipping")
-                            % path.c_str()
-                            % lineno));
+                                     % path.c_str()
+                                     % lineno));
                 }
             } else {
                 // Append a line to the list
@@ -212,13 +214,13 @@ static std::string appendDefines(const std::string &prog, const char *extra_defi
 
     if (firstline.find("#version") != std::string::npos) {
         return firstline
-                + "\n" + std::string(extra_defines)
-                + "\n#line 1"
-                + prog.substr(nlpos);
+               + "\n" + std::string(extra_defines)
+               + "\n#line 1"
+               + prog.substr(nlpos);
     } else {
         return std::string(extra_defines)
-                + "\n#line 0\n"
-                + prog;
+               + "\n#line 0\n"
+               + prog;
     }
 }
 
@@ -282,8 +284,8 @@ static int GFXCreateProgramNoCache(const char *vprogram, const char *fprogram, c
         } else if (!validateLog(vproghandle, true)) {
             printLog(vproghandle, true);
             VS_LOG(error,
-                    (boost::format("Vertex Program Error: Failed log validation for %1%. Inspect log above for details.")
-                            % vprogram));
+                   (boost::format("Vertex Program Error: Failed log validation for %1%. Inspect log above for details.")
+                    % vprogram));
             glDeleteShader_p(vproghandle);
             return 0;
         }
@@ -306,8 +308,8 @@ static int GFXCreateProgramNoCache(const char *vprogram, const char *fprogram, c
             // FIXME: Should this be fproghandle instead of vproghandle? Same throughout this if block?
             printLog(vproghandle, true);
             VS_LOG(error,
-                    (boost::format("Vertex Program Error: Failed log validation for %1%. Inspect log above for details.")
-                            % vprogram));
+                   (boost::format("Vertex Program Error: Failed log validation for %1%. Inspect log above for details.")
+                    % vprogram));
             glDeleteShader_p(vproghandle);
             glDeleteShader_p(fproghandle);
             return 0;
@@ -329,9 +331,9 @@ static int GFXCreateProgramNoCache(const char *vprogram, const char *fprogram, c
     } else if (!validateLog(sp, false)) {
         printLog(sp, false);
         VS_LOG(error,
-                (boost::format(
-                        "Shader Program Error: Failed log validation for vp:%1% fp:%2%. Inspect log above for details.")
-                        % vprogram % fprogram));
+               (boost::format(
+                       "Shader Program Error: Failed log validation for vp:%1% fp:%2%. Inspect log above for details.")
+                % vprogram % fprogram));
         glDeleteShader_p(vproghandle);
         glDeleteShader_p(fproghandle);
         glDeleteProgram_p(sp);
@@ -501,7 +503,7 @@ GameSpeed GFXGetFramerate() {
     gameplaydata[((unsigned int) gpdcounter++) % NUMFRAMESLOOK] = curframe;
     unsigned int i = 0;
     if (!(curframe == JUSTRIGHT
-            || (curframe == TOOFAST && defaultprog == hifiprog) || (curframe == TOOSLOW && defaultprog == 0))) {
+          || (curframe == TOOFAST && defaultprog == hifiprog) || (curframe == TOOSLOW && defaultprog == 0))) {
         for (; i < lim; ++i) {
             if (curframe != gameplaydata[((unsigned int) (gpdcounter - i)) % NUMFRAMESLOOK]) {
                 break;
@@ -718,4 +720,3 @@ int GFXNamedShaderConstant(char *progID, const char *name) {
 int GFXGetProgramVersion() {
     return programVersion;
 }
-


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- Please list any related issues
- Relates to #533 

Purpose:
- What is this pull request trying to do? Get the game working on macOS again, this time without all the changes from the PR 754 refactor. Also, update several of the GitHub Actions to the latest version available.
- What release is this for? 0.9.x, presumably
- Is there a project or milestone we should apply this to? 0.9.x, presumably

Additional Notes:

During play testing, I kept encountering crashes after loading certain savegames. (I think that at least some of these may be the same issue previously reported as #761 .) I also hit the crash in the `Mesh` destructor at least once. (#716 ) And finally, there's the issue with no text on macOS (#786)