### PR TITLE
Bug Fix: Remove the gitsubmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "data"]
-	path = data
-	url = https://github.com/vegastrike/Assets-Production.git


### PR DESCRIPTION
Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] VCS Change

Issues:
- n/a

Purpose:
- VS is no longer stronly linking the engine with the assets so the submodule linkage has not been maintained.