### PR TITLE
Bug Fix: Check for /etc/debian_version (0.8.x)

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1402,9 +1402,16 @@ ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Linux)
         SET(CPACK_DEBIAN_PACKAGE_VERSION "${VEGASTRIKE_PKG_VERSION_STR}")
         # Debian Version: /etc/debian_version - <name>/<junk>
         IF (NOT LSB_EXISTS)
+            # this still needs to be true so LSB variables are not used below
+            # even if we don't detect the /etc/debian_version file
             SET(USE_DEBIAN_VERSION TRUE)
-            FILE(READ "/etc/debian_version" DEBIAN_VERSION_DATA)
-            STRING(REGEX MATCH "^(.+)\/.*$" DEBIAN_VERSION_DATA DEBIAN_RELEASE_VERSION)
+            IF (EXISTS "/etc/debian_version")
+                FILE(READ "/etc/debian_version" DEBIAN_VERSION_DATA)
+                STRING(REGEX MATCH "^(.+)\/.*$" DEBIAN_VERSION_DATA DEBIAN_RELEASE_VERSION)
+            ELSE (EXISTS "/etc/debian_version")
+                MESSAGE("Detected dpkg-release but Debian Distro is unknown")
+                SET(DEBIAN_RELEASE_VERSION "Unknown")
+            ENDIF (EXISTS "/etc/debian_version")
         ELSE (NOT LSB_EXISTS)
             SET(USE_DEBIAN_VERSION FALSE)
             SET(DEBIAN_RELEASE_VERSION "Debian Derivative Release Version ${LSB_LINUX_DISTRIBUTION_CODENAME}")


### PR DESCRIPTION
Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] Build system change

Issues:
- #801 

Purpose:
- What is this pull request trying to do?
Check that /etc/debian_version exists Before relying on it existing.

NOTE: The logic was originally setup for Debian distros; however, when run on a non-Debian distro with the Debian Packaging tools installed this file does not exist and in some cases it can cause a problem.