### PR TITLE
Refactor master part list

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -708,7 +708,10 @@ SET(LIBRESOURCE
     src/resource/resource.cpp
     src/resource/store.cpp
     src/resource/product.cpp
-)
+    src/resource/cargo.cpp
+    src/resource/manifest.cpp
+    src/cmd/json.cpp
+    )
 
 SET(LIBGUI_SOURCES
     src/gui/button.cpp
@@ -853,7 +856,6 @@ ENDIF()
 
 SET(LIBCMD_SOURCES
     src/cmd/alphacurve.cpp
-    src/cmd/cargo.cpp
     src/cmd/carrier.cpp
     src/cmd/collection.cpp
     src/cmd/collide_map.cpp
@@ -871,7 +873,6 @@ SET(LIBCMD_SOURCES
     src/cmd/unit_csv_factory.cpp
     src/cmd/unit_json_factory.cpp
     src/cmd/unit_optimize_factory.cpp
-    src/cmd/json.cpp
     src/cmd/unit_functions_generic.cpp
     src/cmd/unit_generic.cpp
     src/cmd/upgradeable_unit.cpp
@@ -1702,6 +1703,7 @@ IF (USE_GTEST)
         src/damage/tests/object_tests.cpp
         src/resource/tests/buy_sell.cpp
         src/resource/tests/resource_test.cpp
+        src/resource/tests/manifest_tests.cpp
         src/exit_unit_tests.cpp
     )
 

--- a/engine/src/cmd/basecomputer.h
+++ b/engine/src/cmd/basecomputer.h
@@ -29,6 +29,7 @@
 #include "gui/windowcontroller.h"
 #include "cmd/unit_generic.h"
 #include "gui/simplepicker.h"
+#include "cargo_color.h"
 
 //The BaseComputer class displays an interactive screen that supports a
 //number of functions in a base.

--- a/engine/src/cmd/cargo_color.h
+++ b/engine/src/cmd/cargo_color.h
@@ -1,0 +1,43 @@
+/**
+ * cargo_color.h
+ *
+ * Copyright (c) 2001-2002 Daniel Horn
+ * Copyright (c) 2002-2019 pyramid3d and other Vega Strike Contributors
+ * Copyright (c) 2019-2021 Stephen G. Tuggy, and other Vega Strike Contributors
+ * Copyright (C) 2022-2023 Stephen G. Tuggy, Benjamen R. Meyer
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef VEGA_STRIKE_ENGINE_CMD_CARGO_COLOR_H
+#define VEGA_STRIKE_ENGINE_CMD_CARGO_COLOR_H
+
+#include "gfxlib_struct.h"
+#include "cargo.h"
+
+// TODO: remove this. That's what std::pair is for.
+// A stupid struct that is only for grouping 2 different types of variables together in one return value
+class CargoColor {
+public:
+    Cargo cargo;
+    GFXColor color;
+
+    CargoColor() : cargo(), color(1, 1, 1, 1) {
+    }
+};
+
+#endif //VEGA_STRIKE_ENGINE_CMD_CARGO_COLOR_H

--- a/engine/src/cmd/carrier.h
+++ b/engine/src/cmd/carrier.h
@@ -26,9 +26,13 @@
 #ifndef VEGA_STRIKE_ENGINE_CMD_CARRIER_H
 #define VEGA_STRIKE_ENGINE_CMD_CARRIER_H
 
-#include "cargo.h"
+#include "resource/cargo.h"
+#include "gfx/vec.h"
 
 #include <string>
+#include <vector>
+
+class Unit;
 
 // A unit (ship) that carries cargo
 class Carrier {
@@ -39,7 +43,6 @@ public:
     void SortCargo();
     static std::string cargoSerializer(const struct XMLType &input, void *mythis);
 
-    static Unit *makeMasterPartList();
     bool CanAddCargo(const Cargo &carg) const;
     void AddCargo(const Cargo &carg, bool sort = true);
     int RemoveCargo(unsigned int i, int quantity, bool eraseZero = true);

--- a/engine/src/cmd/script/script_call_unit_generic.cpp
+++ b/engine/src/cmd/script/script_call_unit_generic.cpp
@@ -68,9 +68,10 @@
 #include "star_system.h"
 #include "universe.h"
 #include "vs_logging.h"
+#include "manifest.h"
 
 extern const vector<string> &ParseDestinations(const string &value);
-extern Unit &GetUnitMasterPartList();
+
 extern bool PlanetHasLights(Unit *un);
 
 #if 0
@@ -243,57 +244,34 @@ varInst *Mission::call_unit(missionNode *node, int mode) {
         varInst *vireturn = NULL;
         vireturn = call_olist_new(node, mode);
         if (mode == SCRIPT_RUN) {
-            Cargo *ret = NULL;
-            Unit *mpl = &GetUnitMasterPartList();
-            unsigned int max = mpl->numCargo();
-            if (!category.empty()) {
-                size_t Begin, End;
-                mpl->GetSortedCargoCat(category, Begin, End);
-                if (Begin < End) {
-                    unsigned int i = Begin + (rand() % (End - Begin));
-                    ret = &mpl->GetCargo(i);
-                }
-            } else {
-                if (mpl->numCargo()) {
-                    for (unsigned int i = 0; i < 500; i++) {
-                        ret = &mpl->GetCargo(rand() % max);
-                        if (ret->GetName().find("mission") == string::npos) {
-                            break;
-                        }
-                    }
-                } else {
-                    ret = new Cargo(); //mem leak--won't happen
-                }
-            }
-            if (ret) {
-                ret->SetQuantity(quantity);
-                viret = newVarInst(VI_IN_OBJECT);
-                viret->type = VAR_OBJECT;
-                viret->objectname = "string";
-                viret->object = ret->GetNameAddress();
-                ((olist_t *) vireturn->object)->push_back(viret);
-                viret = newVarInst(VI_IN_OBJECT);
-                viret->type = VAR_OBJECT;
-                viret->objectname = "string";
-                viret->object = const_cast<std::string*>(&ret->GetCategory());
-                ((olist_t *) vireturn->object)->push_back(viret);
-                viret = newVarInst(VI_IN_OBJECT);
-                viret->type = VAR_FLOAT;
-                viret->float_val = ret->GetPrice();
-                ((olist_t *) vireturn->object)->push_back(viret);
-                viret = newVarInst(VI_IN_OBJECT);
-                viret->type = VAR_INT;
-                viret->int_val = quantity;
-                ((olist_t *) vireturn->object)->push_back(viret);
-                viret = newVarInst(VI_IN_OBJECT);
-                viret->type = VAR_FLOAT;
-                viret->float_val = ret->GetMass();
-                ((olist_t *) vireturn->object)->push_back(viret);
-                viret = newVarInst(VI_IN_OBJECT);
-                viret->type = VAR_FLOAT;
-                viret->float_val = ret->GetVolume();
-                ((olist_t *) vireturn->object)->push_back(viret);
-            }
+            Cargo c = Manifest::MPL().GetRandomCargoFromCategory(category, quantity);
+
+            viret = newVarInst(VI_IN_OBJECT);
+            viret->type = VAR_OBJECT;
+            viret->objectname = "string";
+            viret->object = c.GetNameAddress();
+            ((olist_t *) vireturn->object)->push_back(viret);
+            viret = newVarInst(VI_IN_OBJECT);
+            viret->type = VAR_OBJECT;
+            viret->objectname = "string";
+            viret->object = const_cast<std::string*>(&c.GetCategory());
+            ((olist_t *) vireturn->object)->push_back(viret);
+            viret = newVarInst(VI_IN_OBJECT);
+            viret->type = VAR_FLOAT;
+            viret->float_val = c.GetPrice();
+            ((olist_t *) vireturn->object)->push_back(viret);
+            viret = newVarInst(VI_IN_OBJECT);
+            viret->type = VAR_INT;
+            viret->int_val = quantity;
+            ((olist_t *) vireturn->object)->push_back(viret);
+            viret = newVarInst(VI_IN_OBJECT);
+            viret->type = VAR_FLOAT;
+            viret->float_val = c.GetMass();
+            ((olist_t *) vireturn->object)->push_back(viret);
+            viret = newVarInst(VI_IN_OBJECT);
+            viret->type = VAR_FLOAT;
+            viret->float_val = c.GetVolume();
+            ((olist_t *) vireturn->object)->push_back(viret);
         }
         debug(3, node, mode, "unit getRandCargo: ");
         printVarInst(3, vireturn);

--- a/engine/src/cmd/unit_csv.cpp
+++ b/engine/src/cmd/unit_csv.cpp
@@ -1424,41 +1424,7 @@ string Unit::WriteUnitString() {
     return writeCSV(unit);
 }
 
-void UpdateMasterPartList(Unit *ret) {
-    for (unsigned int i = 0; i < _Universe->numPlayers(); ++i) {
-        Cockpit *cp = _Universe->AccessCockpit(i);
-        std::vector<std::string> *addedcargoname = &cp->savegame->getMissionStringData("master_part_list_content");
-        std::vector<std::string> *addedcargocat = &cp->savegame->getMissionStringData("master_part_list_category");
-        std::vector<std::string> *addedcargovol = &cp->savegame->getMissionStringData("master_part_list_volume");
-        std::vector<std::string> *addedcargoprice = &cp->savegame->getMissionStringData("master_part_list_price");
-        std::vector<std::string> *addedcargomass = &cp->savegame->getMissionStringData("master_part_list_mass");
-        std::vector<std::string> *addedcargodesc = &cp->savegame->getMissionStringData("master_part_list_description");
-        for (unsigned int j = 0; j < addedcargoname->size(); ++j) {
-            Cargo carg;
-            carg.SetName((*addedcargoname)[j]);
-            carg.SetCategory((j < addedcargocat->size() ? (*addedcargocat)[j] : std::string("Uncategorized")));
-            carg.SetVolume((j < addedcargovol->size() ? XMLSupport::parse_float((*addedcargovol)[j]) : 1.0));
-            carg.SetPrice((j < addedcargoprice->size() ? XMLSupport::parse_float((*addedcargoprice)[j]) : 0.0));
-            carg.SetMass((j < addedcargomass->size() ? XMLSupport::parse_float((*addedcargomass)[j]) : .01));
-            carg.SetDescription(
-                    (j < addedcargodesc->size() ? (*addedcargodesc)[j] : std::string("No Description Added")));
-            carg.SetQuantity(1);
-            ret->cargo.push_back(carg);
-        }
-    }
-    std::sort(ret->cargo.begin(), ret->cargo.end());
-    {
-        Cargo last_cargo;
-        for (int i = ret->numCargo() - 1; i >= 0; --i) {
-            if (ret->GetCargo(i).GetName() == last_cargo.GetName()
-                    && ret->GetCargo(i).GetCategory() == last_cargo.GetCategory()) {
-                ret->RemoveCargo(i, ret->GetCargo(i).GetQuantity(), true);
-            } else {
-                last_cargo = ret->GetCargo(i);
-            }
-        }
-    }
-}
+
 
 
 

--- a/engine/src/cmd/unit_generic.cpp
+++ b/engine/src/cmd/unit_generic.cpp
@@ -77,6 +77,8 @@
 #include "resource/resource.h"
 #include "base_util.h"
 #include "unit_csv_factory.h"
+#include "savegame.h"
+#include "manifest.h"
 
 #include <math.h>
 #include <list>
@@ -96,22 +98,21 @@
 using std::endl;
 using std::list;
 
-std::string getMasterPartListUnitName() {
-    return configuration()->data_config.master_part_list;
-}
 
-Unit *_masterPartList = nullptr;
 
+// This is a left over kludge because I don't want to mess with python interfaces yet.
+// TODO: remove
 Unit *getMasterPartList() {
-    if (_masterPartList == nullptr) {
-        static bool making = true;
-        if (making) {
-            making = false;
-            _masterPartList = Unit::makeMasterPartList();
-            making = true;
+    static Unit ret;
+
+    if(ret.cargo.empty()) {
+        ret.name = "master_part_list";
+        for(const Cargo& c : Manifest::MPL().getItems()) {
+            ret.AddCargo(c);
         }
+
     }
-    return _masterPartList;
+    return &ret;
 }
 
 using namespace XMLSupport;
@@ -2039,7 +2040,6 @@ void Unit::PerformDockingOperations() {
 
 std::set<Unit *> arrested_list_do_not_dereference;
 
-void UpdateMasterPartList(Unit *);
 
 int Unit::ForceDock(Unit *utdw, unsigned int whichdockport) {
     if (utdw->pImage->dockingports.size() <= whichdockport) {
@@ -2062,7 +2062,7 @@ int Unit::ForceDock(Unit *utdw, unsigned int whichdockport) {
     if (this == _Universe->AccessCockpit()->GetParent()) {
         this->RestoreGodliness();
     }
-    UpdateMasterPartList(UniverseUtil::GetMasterPartList());
+    
     unsigned int cockpit = UnitUtil::isPlayerStarship(this);
 
     static float MinimumCapacityToRefuelOnLand =

--- a/engine/src/cmd/unit_generic.h
+++ b/engine/src/cmd/unit_generic.h
@@ -80,6 +80,8 @@ void UncheckUnit( class Unit*un );
 #include "configuration/configuration.h"
 #include "configuration/game_config.h"
 
+#include "cargo_color.h"
+
 extern char *GetUnitDir(const char *filename);
 
 Unit *getMasterPartList();

--- a/engine/src/cmd/weapon_factory.cpp
+++ b/engine/src/cmd/weapon_factory.cpp
@@ -87,7 +87,8 @@ WeaponFactory::WeaponFactory(std::string filename) {
     }
 }
 
-std::string getJSONValue(const json::jobject& object, const std::string &key, const std::string &default_value) {
+// TODO: dup in MPL. Remove
+static std::string getJSONValue(const json::jobject& object, const std::string &key, const std::string &default_value) {
     if(object.has_key(key)) {
         std::string value = object.get(key);
         value = value.substr(1, value.size() - 2);
@@ -97,7 +98,7 @@ std::string getJSONValue(const json::jobject& object, const std::string &key, co
     return default_value;
 }
 
-float getJSONValue(const json::jobject& object, const std::string &key, const float &default_value) {
+static float getJSONValue(const json::jobject& object, const std::string &key, const float &default_value) {
     if(object.has_key(key)) {
         try {
             return std::stof(object.get(key));

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -349,6 +349,10 @@ int main(int argc, char *argv[]) {
 
     //might overwrite the default mission with the command line
     InitUnitTables();
+
+    // Initialise the master parts list before first use.
+    Manifest::MPL();
+
 #ifdef HAVE_PYTHON
     Python::init();
 

--- a/engine/src/resource/cargo.cpp
+++ b/engine/src/resource/cargo.cpp
@@ -27,9 +27,8 @@
 
 #include "cargo.h"
 
-#include "unit_generic.h"
 
-Cargo::Cargo() {
+Cargo::Cargo(): Product() {
     mass = 0;
     volume = 0;
     mission = false;

--- a/engine/src/resource/cargo.h
+++ b/engine/src/resource/cargo.h
@@ -23,11 +23,9 @@
  * You should have received a copy of the GNU General Public License
  * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef VEGA_STRIKE_ENGINE_CMD_CARGO_H
-#define VEGA_STRIKE_ENGINE_CMD_CARGO_H
+#ifndef VEGA_STRIKE_ENGINE_RESOURCE_CARGO_H
+#define VEGA_STRIKE_ENGINE_RESOURCE_CARGO_H
 
-#include "SharedPool.h"
-#include "gfxlib_struct.h"
 #include "product.h"
 
 #include <string>
@@ -44,6 +42,7 @@ protected:
     float functionality;
     float max_functionality;
 
+    friend class Manifest;
 public:
     Cargo();
     Cargo(std::string name, std::string category, float price, int quantity, float mass, float volume,
@@ -83,15 +82,4 @@ public:
     int reduce() { quantity--; return quantity; }
 };
 
-// A stupid struct that is only for grouping 2 different types of variables together in one return value
-// Must come after Cargo for obvious reasons
-class CargoColor {
-public:
-    Cargo cargo;
-    GFXColor color;
-
-    CargoColor() : cargo(), color(1, 1, 1, 1) {
-    }
-};
-
-#endif //VEGA_STRIKE_ENGINE_CMD_CARGO_H
+#endif //VEGA_STRIKE_ENGINE_RESOURCE_CARGO_H

--- a/engine/src/resource/manifest.cpp
+++ b/engine/src/resource/manifest.cpp
@@ -1,0 +1,154 @@
+/*
+ * manifest.cpp
+ *
+ * Copyright (C) 2001-2023 Daniel Horn, Benjaman Meyer, Roy Falk, Stephen G. Tuggy,
+ * and other Vega Strike contributors.
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "manifest.h"
+
+#include <fstream>
+#include <sstream>
+#include <random>
+#include <algorithm>
+#include <iostream>
+
+//#include "xml_support.h"  // TODO: replace this later
+#include "json.h"
+
+
+// TODO: get rid of this helper function and others like it.
+static std::string getJSONValue(const json::jobject& object, const std::string &key, const std::string &default_value) {
+    if(object.has_key(key)) {
+        std::string value = object.get(key);
+        value = value.substr(1, value.size() - 2);
+        return value;
+    }
+
+    return default_value;
+}
+
+static float getJSONValue(const json::jobject& object, const std::string &key, const float &default_value) {
+    if(object.has_key(key)) {
+        try {
+            return std::stof(object.get(key));
+        } catch(...) {}
+        try {
+            return std::stoi(object.get(key));
+        } catch(...) {}
+    }
+
+    return default_value;
+}
+
+
+Manifest::Manifest() {
+    _items = std::vector<Cargo>();
+}
+
+Manifest::Manifest(std::string category) {
+    Manifest& mpl = Manifest::MPL();
+
+    auto predicate = [&category](Cargo c) {return c.GetCategory() == category;};
+    std::copy_if(mpl._items.begin(), mpl._items.end(), 
+             std::back_inserter(_items), predicate);
+}
+
+// Called by MPL if it is empty
+Manifest::Manifest(int dummy) {
+    _items = std::vector<Cargo>();
+
+    // TODO: get this from some configuration maybe?!?
+    static std::string json_filenames[] = {
+        "master_part_list.json",
+        "master_ship_list.json",
+        "master_component_list.json",
+        "master_asteroid_list.json",
+    };
+
+    for(const std::string& json_filename : json_filenames) {
+        std::ifstream ifs(json_filename, std::ifstream::in);
+        std::stringstream buffer;
+        buffer << ifs.rdbuf();
+
+        const std::string json_text = buffer.str();
+
+        std::vector<std::string> parts = json::parsing::parse_array(json_text.c_str());
+        for (const std::string &part_text : parts) {
+            json::jobject part = json::jobject::parse(part_text);
+
+            std::string name = getJSONValue(part, "file", "");
+            std::string category = getJSONValue(part, "categoryname", "");
+
+            Cargo cargo = Cargo(name,
+                                category,
+                                std::stoi(getJSONValue(part, "price", "")),     // Price
+                                1,                                              // Quantity
+                                std::stof(getJSONValue(part, "mass", "")),      // Mass
+                                std::stof(getJSONValue(part, "volume", "")));   // Volume
+            cargo.SetDescription(getJSONValue(part, "description", ""));        // Description
+            _items.push_back(cargo);
+        }
+    }
+}
+
+Manifest& Manifest::MPL() {
+    static Manifest mpl = Manifest(1);
+    
+    return mpl;
+}
+
+Cargo Manifest::GetRandomCargo(int quantity) {
+    // TODO: Need to figure a better solution here
+    if(_items.empty()) {
+        return Cargo();
+    }
+
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> int_dist(0,_items.size()-1);
+
+    int index = int_dist(rng); // TODO: test this gets all items
+    Cargo c = _items[index];
+    c.SetQuantity(quantity);
+    return c;
+}
+
+Cargo Manifest::GetRandomCargoFromCategory(std::string category, int quantity) {
+    Manifest category_manifest = GetCategoryManifest(category);
+
+    // If category is empty, return randomly from MPL itself.
+    if(category_manifest._items.empty()) {
+        return GetRandomCargo(quantity);
+    }
+
+    return category_manifest.GetRandomCargo(quantity);
+}
+
+Manifest Manifest::GetCategoryManifest(std::string category) {
+    Manifest manifest;
+
+    std::copy_if(_items.begin(), _items.end(), back_inserter(manifest._items), 
+            [category](Cargo c) {
+        return c.GetCategory() == category;
+    });
+
+    return manifest;
+}

--- a/engine/src/resource/manifest.h
+++ b/engine/src/resource/manifest.h
@@ -1,0 +1,59 @@
+/*
+ * manifest.h
+ *
+ * Copyright (C) 2001-2023 Daniel Horn, Benjaman Meyer, Roy Falk, Stephen G. Tuggy,
+ * and other Vega Strike contributors.
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MANIFEST_H
+#define MANIFEST_H
+
+#include <vector>
+#include <string>
+
+#include "cargo.h"
+
+/**
+ * A manifest is a list of items in a cargo hold.
+ * The master part list is a special, singleton instance holding all items
+ * in the game. It is read only (const). Its short is MPL.
+ **/
+class Manifest {
+    std::vector<Cargo> _items; 
+
+    Manifest(int dummy); // Create the MPL singleton.
+public:
+    Manifest();
+    Manifest(std::string category); // Create a subset of the MPL for a category
+
+    static Manifest& MPL(); // Get the master part list singleton
+    Cargo GetRandomCargo(int quantity = 0);
+    Cargo GetRandomCargoFromCategory(std::string category, int quantity = 0);
+    Manifest GetCategoryManifest(std::string category);
+
+    std::vector<Cargo> getItems() { return _items; }
+    bool empty() { return _items.empty(); }
+    int size() { return _items.size(); }
+};
+
+
+
+
+#endif //MANIFEST_H

--- a/engine/src/resource/tests/manifest_tests.cpp
+++ b/engine/src/resource/tests/manifest_tests.cpp
@@ -1,0 +1,73 @@
+/*
+ * manifest.cpp
+ *
+ * Copyright (C) 2001-2023 Daniel Horn, Benjaman Meyer, Roy Falk, Stephen G. Tuggy,
+ * and other Vega Strike contributors.
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <random>
+
+#include "manifest.h"
+
+
+TEST(Manifest, Random) {
+    int size = 5;
+
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> int_dist(0,size-1); 
+
+    for(int i=0;i<1000;i++) {
+        int index = int_dist(rng);
+
+        EXPECT_GE(index,0);
+        EXPECT_LT(index,size);
+    }
+}
+
+
+TEST(Manifest, MPL) {
+    boost::filesystem::path full_path(boost::filesystem::current_path());
+    std::cerr << "Current path is : " << full_path << std::endl;
+    std::string path = boost::filesystem::current_path().c_str();
+    path = path + "/../data/";
+
+    boost::filesystem::current_path(path);
+
+    Manifest mpl = Manifest::MPL();
+
+    std::cerr << "MPL Size" << mpl.size() << std::endl << std::flush;
+
+    EXPECT_GT(mpl.size(), 100);
+
+    Manifest food = mpl.GetCategoryManifest("Natural_Products/Food/Confed");
+
+    EXPECT_EQ(food.size(), 4);
+
+    Cargo c = mpl.GetRandomCargoFromCategory("Natural_Products/Food/Confed");
+
+    std::cout << c.GetName() << std::endl;
+
+    EXPECT_GT(c.GetName().size(), 0);
+}

--- a/engine/src/universe_util.h
+++ b/engine/src/universe_util.h
@@ -27,6 +27,7 @@
 #include "cmd/collection.h"
 #include "gfx/vec.h"
 #include "cmd/unit_util.h"
+#include "manifest.h"
 
 #include <string>
 #include <vector>
@@ -358,9 +359,6 @@ Unit *launch(std::string name_string,
         int nr_of_waves,
         QVector pos,
         std::string sqadlogo);
-
-///this gets a random cargo type (useful for cargo missions) from either any category if category is '' or else from a specific category  'Contraband'  comes to mind!
-Cargo getRandCargo(int quantity, std::string category);
 
 ///this gets the current game time since last start in seconds
 //float GetGameTime();

--- a/engine/src/universe_util_generic.cpp
+++ b/engine/src/universe_util_generic.cpp
@@ -51,6 +51,7 @@
 #include "cmd/unit_collide.h"
 #include "cmd/unit_find.h"
 #include "unit_csv_factory.h"
+#include "manifest.h"
 
 #include "python/init.h"
 #include <Python.h>
@@ -202,41 +203,12 @@ namespace UniverseUtil {
         return tmp;
     }
 
-    Cargo getRandCargo(int quantity, string category) {
-        Cargo *ret = NULL;
-        Unit *mpl = &GetUnitMasterPartList();
-        unsigned int max = mpl->numCargo();
-        if (!category.empty()) {
-            size_t Begin, End;
-            mpl->GetSortedCargoCat(category, Begin, End);
-            if (Begin < End) {
-                unsigned int i = Begin + (rand() % (End - Begin));
-                ret = &mpl->GetCargo(i);
-            } else {
-                VS_LOG(info, (boost::format("Cargo category %1% not found") % category));
-            }
-        } else if (mpl->numCargo()) {
-            for (unsigned int i = 0; i < 500; ++i) {
-                ret = &mpl->GetCargo(rand() % max);
-                if (ret->GetName().find("mission") == string::npos) {
-                    break;
-                }
-            }
-        }
-        if (ret) {
-            Cargo tempret = *ret;
-            tempret.SetQuantity(quantity);
-            return tempret;                          //uses copy
-        } else {
-            Cargo newret;
-            newret.SetQuantity(0);
-            return newret;
-        }
-    }
+    return tmp;
+}
 
-    float GetGameTime() {
-        return mission->getGametime();
-    }
+Cargo getRandCargo(int quantity, std::string category) {
+    return Manifest::MPL().GetRandomCargoFromCategory(category, quantity);
+}
 
     float getStarTime() {
         return (float) _Universe->current_stardate.GetCurrentStarTime();


### PR DESCRIPTION
This code decouple the MPL from rest of main body of code and make it and cargo part of resource lib. It makes it easier to test (some basic tests included) and also removes dependencies on the gfx folder among others.

This PR is part of a list of small PRs intended to come before #810. They are intended to clear the way for it and reduce the actual code in it to a manageable level. Note that #810 is a draft PR for review. Once these PR's are merged, I may break it up into smaller chunks for better processing.


Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Removed hard coded pilots, slaves and hitchhikers from the code. All items should be in the MPL json and we should trust it to be so. Pilots and slaves are there. Hitchhikers are not. 
- Removed dynamically generated items. There was code in unit_csv.cpp:1423 (UpdateMasterPartList) that added stuff missing from MPL upon docking. We should expect the MPL to keep a copy of all items in the game. 
- The code in script_call_unit_gen.cpp generated random cargo and had two fall backs. 1st looked for cargo with mission in the name for some reason. The 2nd just created a dummy cargo using new and let it leak with a comment that it won't. I replaced that with something I think is better and more consistent.
- For some reason my PR's now carry more commits than the last one. It's as if I'm not pulling latest before. Not sure why.

