### PR TITLE
Actions: migrate release artifact GH action

### DIFF
--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -122,16 +122,9 @@ jobs:
           name: test_results_xml
           path: ${{github.workspace}}/build/test-results/**/*.xml
 
-      #- name: Upload artifacts
-      #  uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
-      #  with:
-      #    path: "${{ github.workspace }}/build/**/*.zip"
-
-      # TODO: Find/write a tool to upload release for Windows
-      # - name: Upload artifacts
-      #  uses: skx/github-action-publish-binaries@44887b225ceca96efd8a912d39c09ad70312af31 # master
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    ARTIFACT_EXT: ${{ matrix.ARTIFACT_EXT }}
-      #  with:
-      #    path: "${{ github.workspace }}/**/*.zip"
+      - name: Upload the artifacts
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "packages/*.${{ matrix.ARTIFACT_EXT }}"

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -129,9 +129,8 @@ jobs:
         run: script/cibuild $FLAGS
 
       - name: Upload the artifacts
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ARTIFACT_EXT: ${{ matrix.ARTIFACT_EXT }}
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          args: "packages/*.${{ matrix.ARTIFACT_EXT }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "packages/*.${{ matrix.ARTIFACT_EXT }}"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -106,16 +106,9 @@ jobs:
           name: test_results_xml
           path: ${{github.workspace}}/build/test-results/**/*.xml
 
-      #- name: Upload the artifacts
-      #  uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
-      #  with:
-      #    args: "packages/*.${{ matrix.ARTIFACT_EXT }}"
-
-      # TODO: Find/write a tool to upload release for Mac OS
-      # - name: Upload the artifacts
-      #  uses: skx/github-action-publish-binaries@44887b225ceca96efd8a912d39c09ad70312af31 # master
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    ARTIFACT_EXT: ${{ matrix.ARTIFACT_EXT }}
-      #  with:
-      #    args: "packages/*.${{ matrix.ARTIFACT_EXT }}"
+      - name: Upload the artifacts
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "packages/*.${{ matrix.ARTIFACT_EXT }}"


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
- [x] CI Change

Issues:
- #858

Purpose:
- What is this pull request trying to do?
  - unify to a single release artifact uploader for all platforms
  - move to an official release artifact uploader instead of just an artifact uploader
  - see https://github.com/softprops/action-gh-release for documentation on usage
- What release is this for?
  - 0.9.0
- Is there a project or milestone we should apply this to?
  - 0.9.x