### PR TITLE
Bug Fix: JSON parsing

### DIFF
--- a/engine/src/configuration/configuration.cpp
+++ b/engine/src/configuration/configuration.cpp
@@ -60,10 +60,11 @@ std::string GetString(std::string json_string, const std::string key, bool trim 
 
     // trim off any whitespace from the start or end
     const auto whitespace = " \t\n\r\f\v";
-    const unsigned long int start = value.find_first_not_of(whitespace);
-    const unsigned long int begin = 0;
-    const unsigned long int end = value.find_last_not_of(whitespace);
-    return value.substr(std::max(start, begin), std::min(end, value.length()));
+    const signed long int start = value.find_first_not_of(whitespace);
+    const signed long int the_start = 0;
+    const signed long int end = value.find_last_not_of(whitespace);
+    const signed long int the_end = value.length();
+    return value.substr(std::max(start, the_start), std::min(end, the_end));
 }
 
 bool GetBool(std::string json_string, const std::string key, bool default_value) {


### PR DESCRIPTION
The configuration parsing seemed to be missed in the recent JSON parser conversion.

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- None filed; caught while building master. Somehow this escaped the PR cycle.

Purpose:
- What is this pull request trying to do? Migrate the configuration from the former JSON parser to the Boost::JSON
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x