### PR TITLE
Fix CPack package filenames; try to get one Windows installer working

### DIFF
--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -63,10 +63,10 @@ jobs:
 
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f #v4.1.3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d #v5.1.0
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: 3.11
 
@@ -122,9 +122,13 @@ jobs:
           name: test_results_xml
           path: ${{github.workspace}}/build/test-results/**/*.xml
 
+      - name: Package the installer(s)
+        working-directory: ${{github.workspace}}/build
+        run: cpack -V
+
       - name: Upload the artifacts
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: "packages/*.${{ matrix.ARTIFACT_EXT }}"
+          files: "packages/*.*"

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -118,4 +118,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: "build/*.dmg"
+          files: "packages/*.*"

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1329,6 +1329,7 @@ IF (WIN32 AND NOT UNIX)
 
     # NSIS, Wix, and compressed archives (7z, Zip)
     SET(CPACK_GENERATOR "NSIS")
+    SET(CPACK_PACKAGE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../packages")
     SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_v${VEGASTRIKE_PKG_VERSION_STR}_${CMAKE_SYSTEM_PROCESSOR}")
     SET(CPACK_PACKAGE_EXECUTABLES "vegastrike.exe" "vegastrike-engine.exe")
 ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -1339,6 +1340,7 @@ ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     # Bundle -> Compressed Disk Image
     # PackageMaker - see https://cmake.org/cmake/help/v3.3/module/CPackPackageMaker.html
     SET(CPACK_GENERATOR "DragNDrop")
+    SET(CPACK_PACKAGE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../packages")
     SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_v${VEGASTRIKE_PKG_VERSION_STR}_${CMAKE_SYSTEM_PROCESSOR}")
     SET(CPACK_PACKAGE_EXECUTABLES "vegastrike-engine.app/Contents/MacOS/vegastrike-engine")
 ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Linux)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1328,8 +1328,9 @@ IF (WIN32 AND NOT UNIX)
     SET(CPACK_NSIS_MODIFY_PATH ON)
 
     # NSIS, Wix, and compressed archives (7z, Zip)
-    SET(CPACK_GENERATOR "NSIS" "NSIS64" "WIX" "7Z" "ZIP")
-    SET(CPACK_PACKAGE_EXECUTABLES "vegastrike.exe" "vegastrike-engine.exe" "vega-meshtool.exe" "vegasettings.exe")
+    SET(CPACK_GENERATOR "NSIS")
+    SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_v${VEGASTRIKE_PKG_VERSION_STR}_${CMAKE_SYSTEM_PROCESSOR}")
+    SET(CPACK_PACKAGE_EXECUTABLES "vegastrike.exe" "vegastrike-engine.exe")
 ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     MESSAGE(STATUS "Configuring Packaging for macOS")
     # There's a few options for MacOSX; not sure what we want to use
@@ -1338,6 +1339,7 @@ ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     # Bundle -> Compressed Disk Image
     # PackageMaker - see https://cmake.org/cmake/help/v3.3/module/CPackPackageMaker.html
     SET(CPACK_GENERATOR "DragNDrop")
+    SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_v${VEGASTRIKE_PKG_VERSION_STR}_${CMAKE_SYSTEM_PROCESSOR}")
     SET(CPACK_PACKAGE_EXECUTABLES "vegastrike-engine.app/Contents/MacOS/vegastrike-engine")
 ELSEIF (CMAKE_SYSTEM_NAME STREQUAL Linux)
     MESSAGE(STATUS "Configuring Packaging for Linux")


### PR DESCRIPTION
Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- N/A?

Purpose:
- What is this pull request trying to do? Fix the filenames for the macOS DMG installer packages generated; get a single Windows installer format working, with the correct filename for that as well
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
