### PR TITLE
Task fix 937 - missing json.h header

### DIFF
--- a/engine/src/cmd/controls_factory.cpp
+++ b/engine/src/cmd/controls_factory.cpp
@@ -77,8 +77,8 @@ std::map<std::string, std::map<std::string, std::string>> parseControlsJSON(VSFi
                     control_attributes["multiline"] = "false";
                 }
             } else {
-                const std::string attribute = JsonGetStringWithDefault(control, key, "");
-                control_attributes[key] = attribute;
+                const std::string text = boost::json::value_to<std::string>(control.at(key));
+                control_attributes[key] = text;
             }
         }
         
@@ -88,17 +88,7 @@ std::map<std::string, std::map<std::string, std::string>> parseControlsJSON(VSFi
     return controls_map;
 }
 
-static std::vector<std::string> split (const std::string &s, char delim) {
-    std::vector<std::string> result;
-    std::stringstream ss (s);
-    std::string item;
 
-    while (getline (ss, item, delim)) {
-        result.push_back (item);
-    }
-
-    return result;
-}
 
 static std::vector<double> splitAndConvert (const std::string &s, char delim) {
     std::vector<double> result;

--- a/engine/src/configuration/configuration.cpp
+++ b/engine/src/configuration/configuration.cpp
@@ -60,10 +60,11 @@ std::string GetString(std::string json_string, const std::string key, bool trim 
 
     // trim off any whitespace from the start or end
     const auto whitespace = " \t\n\r\f\v";
-    const unsigned long int start = value.find_first_not_of(whitespace);
-    const unsigned long int begin = 0;
-    const unsigned long int end = value.find_last_not_of(whitespace);
-    return value.substr(std::max(start, begin), std::min(end, value.length()));
+    const signed long int start = value.find_first_not_of(whitespace);
+    const signed long int the_start = 0;
+    const signed long int end = value.find_last_not_of(whitespace);
+    const signed long int the_end = value.length();
+    return value.substr(std::max(start, the_start), std::min(end, the_end));
 }
 
 bool GetBool(std::string json_string, const std::string key, bool default_value) {

--- a/engine/src/configuration/configuration.h
+++ b/engine/src/configuration/configuration.h
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <boost/json.hpp>
 
 #include "components/energy_consumer.h"
 
@@ -198,7 +199,7 @@ struct Fuel {
     double minimum_drive{0.15};
 
     Fuel();
-    Fuel(const std::string config);
+    Fuel(boost::json::object object);
 };
 
 struct HudConfig {
@@ -458,7 +459,7 @@ struct GameStart {
     std::string introduction;
 
     GameStart();
-    GameStart(const std::string config);
+    GameStart(boost::json::object object);
 };
 
 }

--- a/engine/src/configuration/graphics_config.cpp
+++ b/engine/src/configuration/graphics_config.cpp
@@ -8,12 +8,9 @@
 
 
 // TODO: delete this. Graphics2Config should be generated automatically from config.json
-Graphics2Config::Graphics2Config(const std::string config) {
-    boost::json::value json_value = boost::json::parse(config);
-    boost::json::object root = json_value.get_object();
-
-    if (root.if_contains("graphics")) {
-        boost::json::object graphics = root.at("graphics").get_object();
+Graphics2Config::Graphics2Config(boost::json::object object) {
+    if (object.if_contains("graphics")) {
+        boost::json::object graphics = object.at("graphics").get_object();
         ConditionalJsonGet(graphics, screen, "screen");
         ConditionalJsonGet(graphics, resolution_x, "resolution_x");
         ConditionalJsonGet(graphics, resolution_y, "resolution_y");

--- a/engine/src/configuration/graphics_config.h
+++ b/engine/src/configuration/graphics_config.h
@@ -28,6 +28,8 @@
 #ifndef VEGA_STRIKE_ENGINE_PYTHON_CONFIG_GRAPHICS_CONFIG_H
 #define VEGA_STRIKE_ENGINE_PYTHON_CONFIG_GRAPHICS_CONFIG_H
 
+#include <boost/json.hpp>
+
 // TODO: remove the other GraphicsConfig and rename this
 struct Graphics2Config {
     int screen{0};
@@ -35,7 +37,7 @@ struct Graphics2Config {
     int resolution_y{1080};
 
     Graphics2Config() = default;
-    Graphics2Config(const std::string config);
+    Graphics2Config(boost::json::object object);
 };
 
 

--- a/engine/src/resource/json_utils.cpp
+++ b/engine/src/resource/json_utils.cpp
@@ -22,15 +22,67 @@
  * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "json_utils.h"
+
+#include <string>
+#include <vector>
+#include <boost/algorithm/string.hpp>
 #include <boost/json.hpp>
+
+
+
 
 
 const std::string JsonGetStringWithDefault(boost::json::object object, 
                                            const std::string& key, 
                                            const char* default_value) {
-    if (object.if_contains(key)) {
-        return boost::json::value_to<std::string>(object.at(key));
+    boost::json::value value = JsonGetValue(object, key);
+    if(value != nullptr) {
+        return boost::json::value_to<std::string>(value);
+    } else {
+        return default_value;
+    }
+}
+
+bool GetBool(boost::json::object object, const std::string key, bool default_value) {
+    boost::json::value value = JsonGetValue(object, key);
+    if(value != nullptr) {
+        return boost::json::value_to<bool>(value);
+    } else {
+        return default_value;
+    }
+}
+
+double GetDouble(boost::json::object object, const std::string key, double default_value) {
+    boost::json::value value = JsonGetValue(object, key);
+    if(value != nullptr) {
+        return boost::json::value_to<double>(value);
+    } else {
+        return default_value;
+    }
+}
+
+const boost::json::value JsonGetValue(boost::json::object object, 
+                                      const std::string& key) {
+    // key can be a set of keys delimited by `|` so traverse
+    // the JSON structure through the list of keys
+    // boost::json support using `/` as a delimiter though
+    std::vector<std::string> key_sections;
+    boost::split(key_sections, key, boost::is_any_of("|"));
+
+
+    for(const std::string& key_section : key_sections) {
+        if (object.if_contains(key_section)) {
+            boost::json::value json_value = object.at(key_section);
+
+            if(key_sections.back() == key_section) {
+                return json_value;
+            } else {
+                object = json_value.get_object();
+            }
+        }
     }
 
-    return default_value;
+    return nullptr;
 }
+

--- a/engine/src/resource/json_utils.h
+++ b/engine/src/resource/json_utils.h
@@ -50,8 +50,18 @@ const T JsonGetWithDefault(boost::json::object object,
     return default_value;
 }
 
+
+
+// This function supports multi-level key
 const std::string JsonGetStringWithDefault(boost::json::object object, 
                                            const std::string& key, 
                                            const char* default_value);
+
+// This function supports multi-level key
+const boost::json::value JsonGetValue(boost::json::object object, 
+                                      const std::string& key);
+
+bool GetBool(boost::json::object object, const std::string key, bool default_value);
+double GetDouble(boost::json::object object, const std::string key, double default_value);
 
 #endif //VEGA_STRIKE_ENGINE_RESOURCE_JSON_UTILS_H


### PR DESCRIPTION
This fixes bug 937, which was somehow introduced to master.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. minimal. Check the game runs. Fought with Oswald.


Issues:
- ship view produces an error in python because my assets are aligned to #936. Shouldn't be an issue otherwise.

