### PR TITLE
Update actions/upload-artifact from v3 to v4 in two workflow files th…

### DIFF
--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -144,7 +144,7 @@ jobs:
       #   run: ctest -V
 
       - name: Upload test results
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         if: failure()
         with:
           name: test_results_xml

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
…at got missed (gh-actions-pr.yml and scorecards-analysis.yml)

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [X] This is a CI / build system change only

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Fix the gh-actions-pr workflow that is currently broken as of 2025-01-30
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
