### PR TITLE
Fix conflicting wchar_t definition error on musl libc

### DIFF
--- a/engine/src/cmd/collide2/opcodetypes.h
+++ b/engine/src/cmd/collide2/opcodetypes.h
@@ -146,7 +146,11 @@ typedef intptr_t opc_ptrdiff_t;
 #if _MSC_VER >= 1300
 typedef unsigned short wint_t;
 #else
+#if defined(HAVE_WCHAR_H)
+#include <wchar.h>
+#else
 typedef wchar_t wint_t;
+#endif
 #endif
 #endif
 #define _WCTYPE_T_DEFINED


### PR DESCRIPTION
Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Please list any related issues : N/A

Purpose:
- What is this pull request trying to do? Fix compilation on void-linux x86_64 with musl libc
- What release is this for? current master HEAD
- Is there a project or milestone we should apply this to? Next one
