### PR TITLE
Fix wrong <sys/signal.h> inclusion

### DIFF
--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -68,7 +68,7 @@
 #include "configuration/configuration.h"
 #include <time.h>
 #if !defined(_WIN32) && !defined (__HAIKU__)
-#include <sys/signal.h>
+#include <signal.h>
 #endif
 
 #if defined (_MSC_VER) && defined (_DEBUG)


### PR DESCRIPTION
This has been seen on void-linux x86_64, musl-libc

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- May need to check if this is OK on macOS too (I think it should)

Purpose:
- What is this pull request trying to do? Fixing a POSIX non-compliance warning
- What release is this for? Next one
- Is there a project or milestone we should apply this to? Next one
