### PR TITLE
Fix disabled Music & sound crash

### DIFF
--- a/engine/src/audio/renderers/OpenAL/OpenALRenderer.cpp
+++ b/engine/src/audio/renderers/OpenAL/OpenALRenderer.cpp
@@ -210,7 +210,6 @@ struct RendererData {
     }
 
     void suspend() {
-        // FIXME: There's a residual error here on Windows. Can't track down where it's from.
         alGetError();
         checkAlError();
         alcMakeContextCurrent(alContext);


### PR DESCRIPTION
Issue is that audio system initialization order was not right and some audio processing was not properly guarded by checks.

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
- Not fully tested
  * tested that music enabled in config file plays properly
  * both music & sound disabled don't crash any more

On void-linux x86_64 musl libc, bare ALSA sound system (no pulseaudio, no pipewire, nor jack).

But music disabled & "All Sounds" enabled did not output anything, I don't know if this has been broken or if there are any sounds that should have benn played...

Please test under windows, macos ,and other linuxes...

Purpose:
- What is this pull request trying to do?
  * Fixes issue: #1040
  * Related issue: #859

- What release is this for? Next one
- Is there a project or milestone we should apply this to? Next one
