### PR TITLE
Remove unused macro: activeSys

### DIFF
--- a/engine/src/universe_util.cpp
+++ b/engine/src/universe_util.cpp
@@ -57,8 +57,6 @@ extern Animation *GetSplashScreen();
 extern const vector<string> &ParseDestinations(const string &value);
 
 using std::string;
-//less to write
-#define activeSys _Universe->activeStarSystem()
 
 void ClientServerSetLightContext(int lightcontext) {
     GFXSetLightContext(lightcontext);
@@ -222,6 +220,3 @@ void sendCustom(int cp, string cmd, string args, string id) {
     receivedCustom(cp, true, cmd, args, id);
 }
 }
-
-#undef activeSys
-

--- a/engine/src/universe_util.h
+++ b/engine/src/universe_util.h
@@ -441,6 +441,4 @@ void startMenuInterface(bool firsttime,
         string alert = string());         //If game fails, bring it back to a common starting point.
 }
 
-#undef activeSys
-
 #endif //VEGA_STRIKE_ENGINE_UNIVERSE_UTIL_GENERIC_H

--- a/engine/src/universe_util_server.cpp
+++ b/engine/src/universe_util_server.cpp
@@ -38,9 +38,6 @@ void SetStarSystemLoading(bool value) {
 
 using std::string;
 
-//less to write
-#define activeSys _Universe->activeStarSystem()
-
 void ClientServerSetLightContext(int lc) {
 }
 
@@ -162,6 +159,3 @@ void sendCustom(int cp, string cmd, string args, string id) {
     VSServer->sendCustom(cp, cmd, args, id);
 }
 }
-
-#undef activeSys
-


### PR DESCRIPTION
I could have named this PR "less to read"... ;-)

It is unused in those files.
The only use is in `engine/src/universe_util_generic.cpp` where I left it untouched. And where it is undefined at EOF.

Code Changes:
- [X] Have the PR Validation Tests been run? compiles + runs on linux/musl
- [ ] This is a documentation change only

Issues:
- none ?

Purpose:
- What is this pull request trying to do? Remove dead code
- What release is this for? Next
- Is there a project or milestone we should apply this to? Next
