### PR TITLE
Remove unused function `showSplashProgress()`

### DIFF
--- a/engine/src/python/star_system_exports.h
+++ b/engine/src/python/star_system_exports.h
@@ -134,7 +134,6 @@ voidEXPORT_UTIL(receivedCustom)
 
 voidEXPORT_UTIL(showSplashScreen)
 voidEXPORT_UTIL(showSplashMessage)
-voidEXPORT_UTIL(showSplashProgress)
 voidEXPORT_UTIL(hideSplashScreen)
 EXPORT_UTIL(isSplashScreenShowing, true)
 

--- a/engine/src/universe_util.cpp
+++ b/engine/src/universe_util.cpp
@@ -201,11 +201,6 @@ void showSplashMessage(const string &text) {
     bootstrap_draw(text, 0);
 }
 
-void showSplashProgress(float progress) //DELETE ?
-{
-    //Unimplemented
-}
-
 void hideSplashScreen() {
     SetStarSystemLoading(false);
 }

--- a/engine/src/universe_util.h
+++ b/engine/src/universe_util.h
@@ -432,7 +432,6 @@ void saveGame(const std::string &savename);
 //Splash stuff
 void showSplashScreen(const std::string &filename);
 void showSplashMessage(const std::string &text);
-void showSplashProgress(float progress);
 void hideSplashScreen();
 bool isSplashScreenShowing();
 

--- a/engine/src/universe_util_server.cpp
+++ b/engine/src/universe_util_server.cpp
@@ -139,9 +139,6 @@ void showSplashScreen(const string &filename) {
 void showSplashMessage(const string &text) {
 }
 
-void showSplashProgress(float progress) {
-}
-
 void hideSplashScreen() {
 }
 


### PR DESCRIPTION
Usage from the python code in Assets-Production has been removed in:
https://github.com/vegastrike/Assets-Production/pull/164

Code Changes:
- [X] Have the PR Validation Tests been run? compiles & rune on linux/musl
- [ ] This is a documentation change only

Issues:
- Depends on the Assets PR being merged first

Purpose:
- What is this pull request trying to do? Remove unused code
- What release is this for? Next
- Is there a project or milestone we should apply this to? Next
