### PR TITLE
vcpkg builtin-baseline, joystick, etc. 2025-03

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -64,9 +64,9 @@ jobs:
         shell: bash
 
       - name: install-cmake
-        uses: lukka/get-cmake@acb35cf920333f4dc3fc4f424f1b30d5e7d561b4 #v3.31.4
+        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 #v3.31.6
         with:
-          cmakeVersion: 3.31.4
+          cmakeVersion: 3.31.6
           ninjaVersion: 1.11.1
 
       # Restore vcpkg from the GitHub Action cache service. Note that packages are restored by vcpkg's binary caching

--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -23,10 +23,12 @@ jobs:
             cmake-generator: VS2019Win64
             enable-pie:      1
             build-type:      Release
+            is-release:      0
           - os:              windows-2022
             cmake-generator: VS2022Win64
             enable-pie:      1
             build-type:      Debug
+            is-release:      0
 
     env:
       # Indicates the location of vcpkg
@@ -93,7 +95,7 @@ jobs:
 
       - name: run-build-script
         working-directory: ${{ github.workspace }}
-        run: .\script\build.ps1 -Generator ${{ matrix.cmake-generator }} -EnablePIE ${{ matrix.enable-pie }} -BuildType ${{ matrix.build-type }}
+        run: .\script\build.ps1 -Generator ${{ matrix.cmake-generator }} -EnablePIE ${{ matrix.enable-pie }} -BuildType ${{ matrix.build-type }} -IsRelease ${{ matrix.is-release }}
 
       - name: Test
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -75,9 +75,9 @@ jobs:
         shell: bash
 
       - name: install-cmake
-        uses: lukka/get-cmake@acb35cf920333f4dc3fc4f424f1b30d5e7d561b4 #v3.31.4
+        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 #v3.31.6
         with:
-          cmakeVersion: 3.31.4
+          cmakeVersion: 3.31.6
           ninjaVersion: 1.11.1
 
       # Restore vcpkg from the GitHub Action cache service. Note that packages are restored by vcpkg's binary caching

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,18 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.21 FATAL_ERROR)
 
 IF (POLICY CMP0087)
-    cmake_policy(SET CMP0087 NEW)
+    CMAKE_POLICY(SET CMP0087 NEW)
+ENDIF ()
+
+# TODO: this suppresses warnings about CMP0102 caching.
+# We should do something about it instead.
+IF (POLICY CMP0102)
+    CMAKE_POLICY(SET CMP0102 OLD)
 ENDIF ()
 
 IF (POLICY CMP0167)
     CMAKE_POLICY (SET CMP0167 OLD)
-ENDIF (POLICY CMP0167)
+ENDIF ()
 
 # There are a number of custom CMake packages
 # Tell CMake where to find them
@@ -96,10 +102,6 @@ ENDIF ()
 # allowing us to differentiate our Assets API across multiple versions.
 # If a release is missing this value, then version `1` can be assumed.
 SET(VEGASTRIKE_ASSETS_API_VERSION "3")
-
-# TODO: this suppresses warnings about CMP0102 caching.
-# We should do something about it instead.
-CMAKE_POLICY(SET CMP0102 OLD)
 
 PROJECT(Vega_Strike
     VERSION

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -259,10 +259,10 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
     } else {
         window = SDL_CreateWindow("Vega Strike",
                                 SDL_WINDOWPOS_UNDEFINED_DISPLAY(screen_number),
-                                SDL_WINDOWPOS_UNDEFINED_DISPLAY(screen_number), 
+                                SDL_WINDOWPOS_UNDEFINED_DISPLAY(screen_number),
                                 0, 0, video_flags);
     }
-    
+
 
     if(!window) {
         VS_LOG_FLUSH_EXIT(fatal, "No window", 1);
@@ -363,7 +363,7 @@ void winsys_init(int *argc, char **argv, char const *window_title, char const *i
     keepRunning = true;
 
     //SDL_INIT_AUDIO|
-    Uint32 sdl_flags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+    constexpr Uint32 sdl_flags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
     g_game.x_resolution = game_options()->x_resolution;
     g_game.y_resolution = game_options()->y_resolution;
     gl_options.fullscreen = game_options()->fullscreen;

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -363,7 +363,12 @@ void winsys_init(int *argc, char **argv, char const *window_title, char const *i
     keepRunning = true;
 
     //SDL_INIT_AUDIO|
+#if defined(NO_SDL_JOYSTICK)
+    constexpr Uint32 sdl_flags = SDL_INIT_VIDEO;
+#else
     constexpr Uint32 sdl_flags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+#endif
+
     g_game.x_resolution = game_options()->x_resolution;
     g_game.y_resolution = game_options()->y_resolution;
     gl_options.fullscreen = game_options()->fullscreen;

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -371,13 +371,6 @@ int main(int argc, char *argv[]) {
 #endif
 
     std::vector<std::vector<char> > temp = ROLES::getAllRolePriorities();
-#if defined(HAVE_SDL)
-#ifndef NO_SDL_JOYSTICK
-    if (SDL_InitSubSystem(SDL_INIT_JOYSTICK)) {
-        VS_LOG_FLUSH_EXIT(fatal, (boost::format("Couldn't initialize SDL: %1%") % SDL_GetError()), 1);
-    }
-#endif
-#endif
 
     InitTime();
     UpdateTime();
@@ -683,7 +676,7 @@ void bootstrap_main_loop() {
         {
             std::vector<std::string> intro_lines;
             boost::split(intro_lines, configuration()->game_start.introduction, boost::is_any_of("\n"));
-            
+
             for(const std::string& line : intro_lines) {
                 UniverseUtil::IOmessage(0, "game", "all", line);
             }

--- a/script/bootstrap.ps1
+++ b/script/bootstrap.ps1
@@ -1,23 +1,30 @@
+##
 # bootstrap.ps1
-
-# Copyright (C) 2021-2025 Stephen G. Tuggy, Benjamen R. Meyer, and other Vega Strike contributors
-
+#
+# Vega Strike - Space Simulation, Combat and Trading
+# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Project creator: Daniel Horn
+# Original development team: As listed in the AUTHORS file
+# Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+#
+#
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
-
+#
 # This file is part of Vega Strike.
-
+#
 # Vega Strike is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # Vega Strike is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+#
 
 
 # You can customize this directory location if desired, but it should be

--- a/script/build.ps1
+++ b/script/build.ps1
@@ -1,30 +1,48 @@
+##
 # build.ps1
-
-# Copyright (C) 2021-2023 Stephen G. Tuggy and other Vega Strike contributors
-
+#
+# Vega Strike - Space Simulation, Combat and Trading
+# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Project creator: Daniel Horn
+# Original development team: As listed in the AUTHORS file
+# Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+#
+#
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
-
+#
 # This file is part of Vega Strike.
-
+#
 # Vega Strike is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # Vega Strike is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+#
 
 
 param(
     [String]$Generator = "VS2019Win64", # Other options include "ninja" and "VS2022Win64"
     [Boolean]$EnablePIE = $false,
-    [String]$BuildType = "Release" # You can also specify "Debug"
+    [String]$BuildType = "Release", # You can also specify "Debug"
+    [Boolean]$IsRelease = $false,
+    [String]$GitTag = "not-applicable", # Git Tag, default empty string for PR builds
+    [String]$GitSha = "not-applicable"  # Git Short SHA Reference, default empty string for PR builds
 )
+
+# Hack around PowerShell not allowing empty string parameters
+if ($GitTag -ieq "not-applicable") {
+    $GitTag = ""
+}
+if ($GitSha -ieq "not-applicable" ) {
+    $GitSha = ""
+}
 
 [String]$cmakePresetName = ""
 if ($Generator -ieq "Ninja") {
@@ -48,6 +66,8 @@ if ($BuildType -ieq "Debug") {
     $cmakePresetName += "debug"
 } elseif ($BuildType -ieq "Release") {
     $cmakePresetName += "release"
+} elseif ($BuildType -ieq "RelWithDebInfo") {
+    $cmakePresetName += "RelWithDebInfo"
 } else {
     Write-Error "Unrecognized value for BuildType: $BuildType"
     exit 1
@@ -66,4 +86,8 @@ $aPossibleBinaryDirs | ForEach-Object {
     if (Test-Path $_) {
         Copy-Item -Force -Verbose $_\*.* .\bin
     }
+}
+
+if ($IsRelease) {
+    Compress-Archive .\bin\* "VegaStrike_${GitTag}_${GitSha}.zip"
 }

--- a/script/package.ps1
+++ b/script/package.ps1
@@ -1,5 +1,5 @@
 ##
-# test.ps1
+# package.ps1
 #
 # Vega Strike - Space Simulation, Combat and Trading
 # Copyright (C) 2001-2025 The Vega Strike Contributors:
@@ -26,12 +26,21 @@
 # along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-
 param(
     [String]$Generator = "VS2019Win64", # Other options include "ninja" and "VS2022Win64"
     [Boolean]$EnablePIE = $false,
-    [String]$BuildType = "Release" # You can also specify "Debug"
+    [String]$BuildType = "Release", # You can also specify "Debug"
+    [String]$GitTag = "not-applicable", # Git Tag, default empty string for PR builds
+    [String]$GitSha = "not-applicable"  # Git Short SHA Reference, default empty string for PR builds
 )
+
+# Hack around PowerShell not allowing empty string parameters
+if ($GitTag -ieq "not-applicable") {
+    $GitTag = ""
+}
+if ($GitSha -ieq "not-applicable" ) {
+    $GitSha = ""
+}
 
 [String]$cmakePresetName = ""
 if ($Generator -ieq "Ninja") {
@@ -66,5 +75,5 @@ if ($BuildType -ieq "Debug") {
 [String]$binaryDir = "$baseDir\build\$cmakePresetName"
 
 Push-Location $baseDir
-ctest -V --preset "test-$cmakePresetName"
+cpack -V --preset "package-$cmakePresetName"
 Pop-Location

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "vega-strike",
     "version-string": "0.10.0",
-    "builtin-baseline": "da4b78d35084ec4e9808aa02017028da03b8d2ab",
+    "builtin-baseline": "24f3d05ac7b8f8644133ed5cb5946ac6b11f449a",
     "dependencies": [
         "boost-python",
         "boost-log",


### PR DESCRIPTION
Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues Fixed:
- Fixes #1062 (joystick functionality)

Known Issues Remaining:
- The game crashed a couple more times. Nothing necessarily new.
- Several more times, certain letters went missing from the HUD, like `n`, `p`, and `z`. This is not a new issue either. It is annoying to see it again though, especially several times in a row.

Purpose:
- What is this pull request trying to do? Sync the master branch with many of the latest packaging, scripting, CMake, and vcpkg changes on the 0.9.x branch. Also update the vcpkg `builtin-baseline` value, in order to pull the latest version of each of our dependencies available from vcpkg as of this date. And finally, fix the long-standing joystick issues.
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
