### PR TITLE
Assorted cleanups for lin_time.cpp - take 2

### DIFF
--- a/engine/src/lin_time.cpp
+++ b/engine/src/lin_time.cpp
@@ -97,7 +97,6 @@ void setTimeCompression(float tc) {
 
 bool toggle_pause() {
     static bool paused = false;
-    VS_LOG(debug, "toggle_pause() called in lin_time.cpp");
     if (paused) {
         VS_LOG(debug, "toggle_pause() in lin_time.cpp: Resuming (unpausing)");
         setTimeCompression(1);

--- a/engine/src/lin_time.cpp
+++ b/engine/src/lin_time.cpp
@@ -86,20 +86,6 @@ void reset_time_compression(const KBData &, KBSTATE a) {
     }
 }
 
-void pause_key(const KBData &s, KBSTATE a) {
-    static bool paused = false;
-    if (a == PRESS) {
-        if (paused == false) {
-            timecompression = .0000001;
-            timecount = 0;
-            paused = true;
-        } else {
-            paused = false;
-            reset_time_compression(s, a);
-        }
-    }
-}
-
 float getTimeCompression() {
     return timecompression;
 }

--- a/engine/src/lin_time.cpp
+++ b/engine/src/lin_time.cpp
@@ -63,8 +63,6 @@ double getNewTime() {
 #endif
 }
 
-class NetClient;
-
 int timecount;
 
 void inc_time_compression(const KBData &, KBSTATE a) {


### PR DESCRIPTION
This one should only keep the *really* uncontroversial part of:
https://github.com/vegastrike/Vega-Strike-Engine-Source/pull/1056
so that we can make some progress merging it piecemeal...