### PR TITLE
Correct non-combat speed multiplier to 1000x

### DIFF
--- a/engine/src/cmd/movable.cpp
+++ b/engine/src/cmd/movable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Roy Falk, ministerofinformation,
+ * Copyright (C) 2020-2025 Roy Falk, ministerofinformation,
  * Stephen G. Tuggy, and other Vega Strike contributors.
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
@@ -563,16 +563,16 @@ Vector Movable::ClampVelocity(const Vector &velocity, const bool afterburn) {
     double magnitude = velocity.Magnitude();
 
     // If we're using afterburn and have enough energy
-    // TODO: Need to make sure somewhere that damage to Afterburner.speed does not 
+    // TODO: Need to make sure somewhere that damage to Afterburner.speed does not
     // reduce it below Drive.speed
     if(afterburn && (unit->afterburner.CanConsume() || configuration()->fuel.no_fuel_afterburn)) {
-        max_speed = unit->MaxAfterburnerSpeed(); 
+        max_speed = unit->MaxAfterburnerSpeed();
     } else if(unit->drive.CanConsume() ) { //|| configuration()->fuel.no_fuel_thrust) {
         max_speed = unit->MaxSpeed();
     } else {
         max_speed = 0;
     }
-    
+
     if(magnitude > max_speed) {
         return velocity * (max_speed / magnitude);
     }
@@ -627,13 +627,13 @@ Vector Movable::ClampThrust(const Vector &amt1, bool afterburn) {
     Unit *unit = vega_dynamic_cast_ptr<Unit>(this);
 
     const bool finegrainedFuelEfficiency = configuration()->fuel.variable_fuel_consumption;
-    
+
 
     if(!unit->afterburner.CanConsume()) {
         afterburn = false;
     }
-    
-    
+
+
     Vector Res = amt1;
 
     float fuelclamp = (unit->fuel.Level() <= 0) ? configuration()->fuel.no_fuel_thrust : 1;
@@ -654,11 +654,11 @@ Vector Movable::ClampThrust(const Vector &amt1, bool afterburn) {
     if (amt1.k < -unit->drive.retro) {
         Res.k = -unit->drive.retro;
     }
-   
+
     if (afterburn) {
         unit->afterburner.Consume();
     }
-    
+
     return Res;
 }
 
@@ -734,7 +734,7 @@ void Movable::RollTorque(float amt) {
 void Movable::Thrust(const Vector &amt1, bool afterburn) {
     Unit *unit = vega_dynamic_cast_ptr<Unit>(this);
     afterburn = afterburn && unit->afterburner.CanConsume();
-    
+
     //Unit::Thrust( amt1, afterburn );
     {
         Vector amt = ClampThrust(amt1, afterburn);
@@ -786,14 +786,14 @@ void Movable::Thrust(const Vector &amt1, bool afterburn) {
 
 // If in Travel mode (non-combat), speed is limited to x100
 double Movable::MaxSpeed() const {
-    static const double combat_mode_multiplier = configuration()->physics_config.combat_mode_multiplier;
+    const double combat_mode_multiplier = configuration()->physics_config.combat_mode_multiplier;
     const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
     return (unit->computer.combat_mode) ? unit->drive.speed.AdjustedValue() : combat_mode_multiplier * unit->drive.speed.AdjustedValue();
 }
 
 // Same as comment above. It makes less sense to limit travel speed with afterburners to afterburner speed x 100.
 double Movable::MaxAfterburnerSpeed() const {
-    static const double combat_mode_multiplier = configuration()->physics_config.combat_mode_multiplier;
+    const double combat_mode_multiplier = configuration()->physics_config.combat_mode_multiplier;
     const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
 
     //same capped big speed as combat...else different

--- a/engine/src/configuration/configuration.h
+++ b/engine/src/configuration/configuration.h
@@ -1,7 +1,7 @@
 /*
  * configuration.h
  *
- * Copyright (C) 2021-2023 Daniel Horn, Roy Falk, ministerofinformation,
+ * Copyright (C) 2021-2025 Daniel Horn, Roy Falk, ministerofinformation,
  * David Wales, Stephen G. Tuggy, Benjamen R. Meyer, and other Vega Strike contributors
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
@@ -159,7 +159,7 @@ struct EjectConfig {
 
 struct Fuel {
     float afterburner_fuel_usage;
-    
+
 
     /* This used to be Lithium6constant.
      * There's some relevant context that's been removed from the original name of this variable "Lithium6constant" --
@@ -178,7 +178,7 @@ struct Fuel {
     float reactor_idle_efficiency{0.98F};
     float min_reactor_efficiency{0.00001F};
     double ecm_energy_cost{0.05F};
-    
+
     double megajoules_factor{100};
     double fuel_factor{60.0};   // Multiply fuel by this to get fuel by minutes
     double energy_factor{1.0};
@@ -193,7 +193,7 @@ struct Fuel {
     double shield_regeneration_factor{0.1};
 
     // 0 infinite, 1 fuel, 2 energy, 3 ftl_energy, 4 disabled
-    EnergyConsumerSource drive_source{EnergyConsumerSource::Fuel}; 
+    EnergyConsumerSource drive_source{EnergyConsumerSource::Fuel};
     EnergyConsumerSource reactor_source{EnergyConsumerSource::Fuel};
     EnergyConsumerSource afterburner_source{EnergyConsumerSource::Fuel};
     EnergyConsumerSource jump_drive_source{EnergyConsumerSource::FTLEnergy};
@@ -381,7 +381,7 @@ struct PhysicsConfig {
     float percent_missile_match_target_velocity{1.0F};
     double game_speed{1.0};
     double game_accel{1.0};
-    double combat_mode_multiplier{100.0};
+    double combat_mode_multiplier{1000.0};
     float velocity_max{10000.0F};
     float max_player_rotation_rate{24.0F};
     float max_non_player_rotation_rate{360.0F};


### PR DESCRIPTION
Code Changes:
- [X] (Minimally) Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- Fixes https://github.com/vegastrike/Assets-Masters/issues/63

Purpose:
- What is this pull request trying to do? Fix the non-combat speed multiplier, setting its value to 1000x, like it used to be
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
