### PR TITLE
April 2025 updates to MacPorts build infrastructure

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -382,9 +382,12 @@
       },
       "cacheVariables": {
         "CMAKE_PREFIX_PATH": "/opt/local",
-        "Boost_INCLUDE_DIR": "/opt/local/libexec/boost/1.81/include",
+        "Boost_INCLUDE_DIR": "/opt/local/libexec/boost/1.87/include",
+        "Boost_DIR": "/opt/local/libexec/boost/1.87/lib/cmake/Boost-1.87.0",
         "CMAKE_FIND_FRAMEWORK": "LAST",
-        "PythonInstalledVia": "MacPorts"
+        "PythonInstalledVia": "MacPorts",
+        "INSTALL_GTEST": "OFF",
+        "USE_GTEST": "OFF"
       }
     },
     {


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] (Enough to verify that the game runs) Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues Fixed:
- N/A

Known Issues Remaining:
- Same as before, I believe

Purpose:
- What is this pull request trying to do? Fix the MacPorts builds for compatibility with older versions of macOS, which have broken recently
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
