### PR TITLE
Remove rand01

### DIFF
--- a/engine/src/gfx/cockpit.cpp
+++ b/engine/src/gfx/cockpit.cpp
@@ -89,6 +89,7 @@
 #include "cmd/weapon_info.h"
 #include "gfx/cockpit_gfx.h"
 #include "cmd/dock_utils.h"
+#include "resource/random_utils.h"
 
 #include <cstddef>
 #include <cfloat>
@@ -96,7 +97,6 @@
 using std::min;
 using std::max;
 
-extern float rand01();
 using VSFileSystem::SoundFile;
 #define SWITCH_CONST (.9)
 /* The smaller VERYNEAR_CONST is, the worse Z-Buffer precision will be. So keep this above 0.004) */
@@ -1787,7 +1787,7 @@ void GameCockpit::Draw() {
                         if (damage < .985) {
                             if (vdu_time[vd] >= 0) {
                                 if (damage > .001 && (cockpit_time > (vdu_time[vd] + (1 - damage)))) {
-                                    if (rand01() > SWITCH_CONST) {
+                                    if (randomDouble() > SWITCH_CONST) {
                                         vdu_time[vd] = -cockpit_time;
                                     }
                                 }
@@ -1808,7 +1808,7 @@ void GameCockpit::Draw() {
                                  *
                                  *  }*/
                             } else if (cockpit_time > ((1 - (-vdu_time[vd])) + (damage))) {
-                                if (rand01() > SWITCH_CONST) {
+                                if (randomDouble() > SWITCH_CONST) {
                                     vdu_time[vd] = cockpit_time;
                                 }
                             }

--- a/engine/src/gfx/cockpit_gfx.cpp
+++ b/engine/src/gfx/cockpit_gfx.cpp
@@ -39,10 +39,10 @@
 #include "nav/navcomputer.h"
 #include "gfx/gauge.h"
 #include "gfx/cockpit_gfx_utils.h"
+#include "resource/random_utils.h"
 
 #include <algorithm>
 
-extern float rand01();
 #define SWITCH_CONST (.9)
 
 // got to move this to some more generic place
@@ -330,7 +330,7 @@ void DrawGauges( GameCockpit *cockpit, Unit *un, Gauge *gauges[],
                 un->ship_functions.Value(Function::cockpit);
             if (gauge_time[i] >= 0) {
                 if ( damage > .0001 && ( cockpit_time > ( gauge_time[i]+(1-damage) ) ) )
-                    if (rand01() > SWITCH_CONST)
+                    if (randomDouble() > SWITCH_CONST)
                         gauge_time[i] = -cockpit_time;
                 /*else {
                  *  static string gauge_static = vs_config->getVariable("graphics","gauge_static","static.ani");
@@ -338,7 +338,7 @@ void DrawGauges( GameCockpit *cockpit, Unit *un, Gauge *gauges[],
                  *  vdu_ani.DrawAsVSSprite(gauges[i]);
                  *  }*/
             } else if ( cockpit_time > ( ( ( 1-(-gauge_time[i]) )+damage ) ) ) {
-                if (rand01() > SWITCH_CONST)
+                if (randomDouble() > SWITCH_CONST)
                     gauge_time[i] = cockpit_time;
             }
         }
@@ -553,7 +553,7 @@ void DrawRadar(const Radar::Sensor& sensor, float  cockpit_time, float radar_tim
         if (damage < .985) {
             if (radar_time >= 0) {
                 if ( damage > .001 && ( cockpit_time > radar_time+(1-damage) ) ) {
-                    if (rand01() > SWITCH_CONST)
+                    if (randomDouble() > SWITCH_CONST)
                         radar_time = -cockpit_time;
                 } else {
                     static Animation radar_ani( "static_round.ani", true, .1, BILINEAR );
@@ -561,7 +561,7 @@ void DrawRadar(const Radar::Sensor& sensor, float  cockpit_time, float radar_tim
                     radar_ani.DrawAsVSSprite( radarSprites[1] );
                 }
             } else if ( cockpit_time > ( ( 1-(-radar_time) )+damage ) ) {
-                if (rand01() > SWITCH_CONST)
+                if (randomDouble() > SWITCH_CONST)
                     radar_time = cockpit_time;
             }
         }

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -77,7 +77,6 @@ extern void CacheJumpStar(bool);
 extern void SortStarSystems(vector<StarSystem *> &ss, StarSystem *drawn);
 extern void bootstrap_first_loop();
 extern bool RefreshGUI();
-extern float rand01();
 extern int timecount;
 extern StarSystem *GetLoadedStarSystem(const char *system);
 extern bool screenshotkey;

--- a/libraries/cmd/damageable.cpp
+++ b/libraries/cmd/damageable.cpp
@@ -40,6 +40,7 @@
 #include "cmd/ai/comm_ai.h"
 #include "gfx_generic/mesh.h"
 #include "src/vega_cast_utils.h"
+#include "resource/random_utils.h"
 
 #include <algorithm>
 #include "configuration/configuration.h"
@@ -335,7 +336,6 @@ void Damageable::ApplyDamage(const Vector &pnt,
 // TODO: get rid of extern
 extern bool DestroySystem(float hull_percent, float numhits);
 extern bool DestroyPlayerSystem(float hull_percent, float numhits);
-extern float rand01();
 extern const Unit *loadUnitByCache(std::string name, int faction);
 
 void Damageable::DamageRandomSystem(InflictedDamage inflicted_damage, bool player, Vector attack_vector) {
@@ -371,7 +371,7 @@ void Damageable::DamageRandomSystem(InflictedDamage inflicted_damage, bool playe
     // Damage is calculated as 0.25 * rand + 0.75 * (hull_damage)/(current_hull)
     // Therefore,
     double indiscriminate_system_destruction = configuration()->physics.indiscriminate_system_destruction;
-    double random_damage_factor = indiscriminate_system_destruction * rand01();
+    double random_damage_factor = indiscriminate_system_destruction * randomDouble();
     double hull_damage_modifier = 1 - indiscriminate_system_destruction;
     double hull_damage_factor = hull_damage_modifier * (1 - hull_damage / unit->hull.Get());
     unit->DamageRandSys(random_damage_factor + hull_damage_factor, attack_vector);

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -81,6 +81,7 @@
 #include "root_generic/savegame.h"
 #include "resource/manifest.h"
 #include "cmd/dock_utils.h"
+#include "resource/random_utils.h"
 
 #include <math.h>
 #include <list>
@@ -219,9 +220,7 @@ extern void PlayDockingSound(int dock);
     return false;
 }*/
 
-float rand01() {
-    return (float) rand() / (float) RAND_MAX;
-}
+
 
 /* UGLYNESS short fix */
 unsigned int apply_float_to_unsigned_int(float tmp) {
@@ -1135,7 +1134,7 @@ Unit *findUnitInStarsystem(const void *unitDoNotDereference) {
 void Unit::DamageRandSys(float dam, const Vector &vec) {
     // TODO: take actual damage into account when damaging components.
     float deg = fabs(180 * atan2(vec.i, vec.k) / M_PI);
-    float randnum = rand01();
+    float randnum = randomDouble();
     const float inv_min_dam = 1.0F - configuration()->physics.min_damage;
     const float inv_max_dam = 1.0F - configuration()->physics.max_damage;
     if (dam < inv_max_dam) {
@@ -1173,7 +1172,7 @@ void Unit::DamageRandSys(float dam, const Vector &vec) {
         damages |= Damages::COMPUTER_DAMAGED;
         return;
     }
-    if (rand01() < configuration()->physics.thruster_hit_chance) {
+    if (randomDouble() < configuration()->physics.thruster_hit_chance) {
         // This is fairly severe. One or two hits can disable the engine.
         // Note that retro can be damaged by both this and above.
         // Drive can also be damaged by code below - really computer.
@@ -1484,7 +1483,7 @@ bool DestroySystem(float hull_percent, float numhits) {
     if (numhits > 1) {
         chance = pow(chance, numhits);
     }
-    return rand01() > chance;
+    return randomDouble() > chance;
 }
 
 bool DestroyPlayerSystem(float hull_percent, float numhits) {
@@ -1496,7 +1495,7 @@ bool DestroyPlayerSystem(float hull_percent, float numhits) {
     if (numhits > 1) {
         chance = pow(chance, numhits);
     }
-    bool ret = (rand01() > chance);
+    bool ret = (randomDouble() > chance);
     if (ret) {
         //VS_LOG(warning, "DAAAAAAMAGED!!!!");
     }
@@ -3449,7 +3448,6 @@ using std::string;
  *** UNIT_REPAIR STUFF                                                               **
  **************************************************************************************
  */
-extern float rand01();
 
 bool isWeapon(std::string name) {
     if (name.find("Weapon") != std::string::npos) {


### PR DESCRIPTION
replace with random_utils/randomDouble

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. _There were also existing unit tests in random_utils._


(Unrelated) Issues:
- Llama.begin can't buy overdrive. I think this is by design but need to be sure.
- Ship info gives a python error due to KeyError: 'ecm'
- integral upgrades - listed as possible to buy
- integral upgrades kept getting added up when buying other stuff (this was seen/fixed already)
- can't buy a shield (Hyena)

Not seen issue:
- #1110 
- #1066 

I'm 99% certain these are all unrelated to my changes.