### PR TITLE
Fix collide2 librarization (was: conflicting wchar_t def.)

### DIFF
--- a/libraries/collide2/opcodetypes.h
+++ b/libraries/collide2/opcodetypes.h
@@ -152,7 +152,11 @@ typedef unsigned short wint_t;
 #if defined(HAVE_WCHAR_H)
 #include <wchar.h>
 #else
+#if defined(HAVE_WCHAR_H)
+#include <wchar.h>
+#else
 typedef wchar_t wint_t;
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
The commit 3d6e88e054e3401242d67d36fc40c5ec7e1399ee has been lost during the collide2 library move. Redo it to its new location.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? None
- [ ] This is a documentation change only

Issues:
- None

Purpose:
- What is this pull request trying to do? refix
- What release is this for? next
- Is there a project or milestone we should apply this to? next
