### PR TITLE
0.9.x: Don't install any Start Menu shortcuts. Leave that to the Assets installer

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1344,7 +1344,8 @@ IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
     SET(CPACK_NSIS_HELP_LINK "https://vega-strike.org")
     SET(CPACK_NSIS_URL_INFO_ABOUT "https://vega-strike.org/about")
     SET(CPACK_NSIS_CONTACT "maintainers@vega-strike.org")
-    SET(CPACK_NSIS_MODIFY_PATH ON)
+    SET(CPACK_NSIS_MODIFY_PATH OFF)
+    SET(CPACK_NSIS_MENU_LINKS "")
 
     # Windows installer format(s) to output
     SET(CPACK_GENERATOR "NSIS64")


### PR DESCRIPTION
Code Changes:
- [X] This is an installer change only

Issues Addressed:
- Fixes #1130 

Known Issues Remaining:
- Nothing new that I'm aware of

Purpose:
- What is this pull request trying to do? Remove any Start Menu or desktop shortcuts created by this installer. Leave shortcut creation to the vsUTCS installer
- What release is this for? 0.9.1
- Is there a project or milestone we should apply this to? 0.9.x
