### PR TITLE
Fix #1122 and #1123

### DIFF
--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -2330,6 +2330,7 @@ void BaseComputer::loadListPicker(TransactionList &tlist,
     SimplePickerCell *parentCell = NULL;                //Place to add new items.  NULL = Add to picker.
     for (size_t i = 0; i < tlist.masterList.size(); i++) {
         Cargo &item = tlist.masterList.at(i).cargo;
+
         std::string icategory = getDisplayCategory(item);
         if (icategory != currentCategory) {
             //Create new cell(s) for the new category.
@@ -3065,6 +3066,13 @@ void BaseComputer::loadBuyUpgradeControls(void) {
     repair.cargo.SetPrice(basicRepairPrice() * playerUnit->RepairCost());
     repair.cargo.SetDescription(BASIC_REPAIR_DESC);
     tlist.masterList.push_back(repair);
+
+    // Filter integral from masterlist
+    auto integral_items = std::remove_if(tlist.masterList.begin(), tlist.masterList.end(),
+                        [](CargoColor cc) {
+                          return cc.cargo.GetIntegral();
+                        });
+    tlist.masterList.erase(integral_items, tlist.masterList.end());
 
     //Load the upgrade picker from the master tlist.
     SimplePicker *basePicker = static_cast< SimplePicker * > ( window()->findControlById("BaseUpgrades"));

--- a/engine/src/resource/cargo.cpp
+++ b/engine/src/resource/cargo.cpp
@@ -38,7 +38,7 @@ Cargo::Cargo(): Product() {
 
 Cargo::Cargo(std::string name, std::string category, float price, int quantity,
              float mass, float volume, float functionality, float max_functionality,
-             bool mission, bool installed) :
+             bool mission, bool installed, bool integral) :
         Product(name, quantity, price), category(category) {
     this->mass = mass;
     this->volume = volume;
@@ -48,6 +48,7 @@ Cargo::Cargo(std::string name, std::string category, float price, int quantity,
     this->max_functionality = max_functionality;
     this->mission = mission;
     this->installed = installed;
+    this->integral = integral;
 }
 
 float Cargo::GetFunctionality() {
@@ -68,6 +69,10 @@ void Cargo::SetFunctionality(float func) {
 
 void Cargo::SetInstalled(bool installed) {
     this->installed = installed;
+}
+
+void Cargo::SetIntegral(bool installed) {
+    this->integral = installed;
 }
 
 void Cargo::SetMaxFunctionality(float func) {
@@ -110,6 +115,9 @@ bool Cargo::GetInstalled() const {
     return this->installed;
 }
 
+bool Cargo::GetIntegral() const {
+    return this->integral;
+}
 
 const std::string &Cargo::GetCategory() const {
     return category;
@@ -165,3 +173,6 @@ bool Cargo::operator<(const Cargo &other) const {
 }
 
 
+void Cargo::Add(int quantity) {
+    this->quantity += quantity;
+}

--- a/engine/src/resource/cargo.h
+++ b/engine/src/resource/cargo.h
@@ -39,6 +39,7 @@ protected:
     float volume;
     bool mission;
     bool installed; // TODO: move down to ShipModule
+    bool integral;
     float functionality;
     float max_functionality;
 
@@ -46,13 +47,15 @@ protected:
 public:
     Cargo();
     Cargo(std::string name, std::string category, float price, int quantity, float mass, float volume,
-          float functionality = 1.0f, float max_functionality= 1.0f, bool mission = false, bool installed = false);
+          float functionality = 1.0f, float max_functionality= 1.0f, bool mission = false, 
+          bool installed = false, bool integral = false);
 
     float GetFunctionality();
     float GetMaxFunctionality();
     void SetDescription(const std::string &description);
     void SetFunctionality(float func);
     void SetInstalled(bool installed);
+    void SetIntegral(bool installed);
     void SetMaxFunctionality(float func);
     void SetMissionFlag(bool flag);
     void SetPrice(float price);
@@ -64,6 +67,7 @@ public:
 
     bool GetMissionFlag() const;
     bool GetInstalled() const;
+    bool GetIntegral() const;
     const std::string &GetCategory() const;
     const std::string &GetContent() const;
     const std::string &GetDescription() const;
@@ -76,6 +80,7 @@ public:
     float GetPrice() const;
     bool operator==(const Cargo &other) const;
     bool operator<(const Cargo &other) const;
+    void Add(int quantity);
 
     // Only for enslave
     // TODO: replace this hack

--- a/libraries/cmd/carrier.cpp
+++ b/libraries/cmd/carrier.cpp
@@ -485,7 +485,20 @@ void Carrier::AddCargo(const Cargo &carg, bool sort) {
     if (usemass) {
         unit->setMass(unit->getMass() + carg.quantity.Value() * carg.GetMass());
     }
-    unit->cargo.push_back(carg);
+
+    bool found = false;
+
+    for(Cargo c: this->cargo) {
+        if(c.GetName() == carg.GetName() && c.GetCategory() == carg.GetCategory()) {
+            found = true;
+            c.Add(carg.GetQuantity());
+        }
+    }
+
+    if(!found) {
+        unit->cargo.push_back(carg);
+    }
+    
     if (sort) {
         SortCargo();
     }

--- a/libraries/cmd/unit_csv.cpp
+++ b/libraries/cmd/unit_csv.cpp
@@ -555,9 +555,11 @@ static void AddCarg(Unit *thus, const string &cargos) {
             bool mission = nextElementBool(cargos, elemstart, elemend, false);
             bool installed = nextElementBool(cargos, elemstart, elemend,
                     category.find("upgrades/") == 0);
+            bool integral = nextElementBool(cargos, elemstart, elemend,
+                    category.find("upgrades/integral") == 0);
 
             Cargo carg(name, category, price, quantity, mass, volume, functionality,
-                       max_functionality, mission, installed);
+                       max_functionality, mission, installed, integral);
 
 
 
@@ -872,7 +874,18 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
 
     // Add integral components
     // Make this a factor of unit price
-    if(!saved_game) {
+    if(saved_game) {
+        // If we are loading a saved game, we assume the integral components are already installed.
+        // However, we still need to set them as integral and ensure quantity is 1 for each.
+        // Note: In the future, we may want to support multiple integral components.
+        for(Cargo& cargo : this->cargo) {
+            if(cargo.GetCategory().find("upgrades/integral") == 0) {
+                cargo.SetQuantity(1);
+                cargo.SetInstalled(true);
+                cargo.SetIntegral(true);
+            }
+        }
+    } else {
         const std::string integral_components =
         "{hull;upgrades/integral;12000;1;0.1;0.1;1;1;@cargo/hull_patches.image@The ship's hull.;0;1}\
         {afterburner;upgrades/integral;2000;1;0.1;0.1;1;1;@upgrades/afterburner_generic.image@Engine overdrive. Increases thrust at the expense of decreased fuel efficiency.;0;1}\

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -2911,12 +2911,6 @@ bool Unit::ReduceToTemplate() {
     vector<Cargo> savedCargo;
     savedCargo.swap(cargo);
 
-    // Remove integral components, because they become duplicates
-    savedCargo.erase(std::remove_if(savedCargo.begin(),
-                                    savedCargo.end(),
-                                    [](const Cargo& c) { return c.GetCategory().find("upgrades/integral") == 0; }),
-                                    savedCargo.end());
-
     vector<Mount> savedWeap;
     savedWeap.swap(mounts);
     const Unit *temprate = makeFinalBlankUpgrade(name, faction);


### PR DESCRIPTION
Fixes #1122
Fixes #1123 

- Prevent integral components from appearing on the upgrade buy side.
- When adding cargo, check if can add to existing entry
- Mark added integral components as integral in unit_csv
- Remove code from unit_generic. We deal with this in unit_csv when loading.
- Add integral attribute to cargo

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. Minimal. It's very hard to play-test the game because the ship launches at very high speed and maintains it, making combat and landing on stations impossible.

Tested changes in the following ways:
1. in Upgrade screen
2. In flight, checked components are listed properly.
3. Saved game and checked the json.


Issues:
- None related to my changes.

