### PR TITLE
Refactor damage VDU

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1234,6 +1234,8 @@ IF (USE_GTEST)
         src/components/tests/drive_tests.cpp
         src/components/tests/afterburner_tests.cpp
         src/components/tests/jump_drive_tests.cpp
+        src/components/tests/utils_tests.cpp
+        src/components/tests/operational_tests.cpp
     )
     TARGET_INCLUDE_DIRECTORIES(${TEST_NAME} SYSTEM PRIVATE ${VSE_TST_INCLUDES})
     TARGET_INCLUDE_DIRECTORIES(${TEST_NAME} PRIVATE

--- a/engine/src/components/afterburner.cpp
+++ b/engine/src/components/afterburner.cpp
@@ -34,6 +34,8 @@ Afterburner::~Afterburner()
 Afterburner::Afterburner(EnergyContainer *source) :
     Component(0.0, 0.0, true, true), EnergyConsumer(source, false), thrust(1,0,1), speed(1,0,1) {
     type = ComponentType::Afterburner;
+    upgrade_name = "Afterburner";
+    installed = true;
 }
 
 

--- a/engine/src/components/afterburner_upgrade.cpp
+++ b/engine/src/components/afterburner_upgrade.cpp
@@ -101,5 +101,3 @@ bool AfterburnerUpgrade::Upgrade(const std::string upgrade_key) {
     return true;
 }
 
-
-// TODO: deal with damage somehow

--- a/engine/src/components/afterburner_upgrade.h
+++ b/engine/src/components/afterburner_upgrade.h
@@ -34,6 +34,7 @@ class Afterburner;
  *  The game previously supported both additive and multiplicative upgrades.
  *  I've removed the additive one for simplicity's sake. 
  *  The default value is 1.0 (no change).
+ *  The upgrade can't be damaged. Instead, the afterburner itself can be damaged.
  */
 class AfterburnerUpgrade : public Component {
     Afterburner *afterburner;

--- a/engine/src/components/armor.cpp
+++ b/engine/src/components/armor.cpp
@@ -103,6 +103,10 @@ void Armor::Load(std::string unit_key) {
             }
         }
     }
+
+    if(TotalMaxLayerValue() > 0) {
+        installed = true;
+    }
 }
 
 void Armor::SaveToCSV(std::map<std::string, std::string>& unit) const {

--- a/engine/src/components/cloak.cpp
+++ b/engine/src/components/cloak.cpp
@@ -31,7 +31,7 @@ Cloak::Cloak() :
     EnergyConsumer(nullptr, false, 0)
 {
     type = ComponentType::Cloak;
-    downgrade_private();
+    Downgrade();
 }
 
 Cloak::~Cloak()
@@ -40,11 +40,8 @@ Cloak::~Cloak()
 
 // Component Overrides
 void Cloak::Load(std::string unit_key) {
-    // Energy Consumer
-    SetConsumption(UnitCSVFactory::GetVariable(unit_key, "Cloak_Energy", 0.0));
-
-    // Cloak
-    upgrade_private(unit_key);
+    // Same code so reusing it
+    Upgrade(unit_key);
 }
 
 
@@ -80,7 +77,22 @@ bool Cloak::CanUpgrade(const std::string upgrade_key) const {
 }
 
 bool Cloak::Upgrade(const std::string upgrade_key) {
-    upgrade_private(upgrade_key);
+    Component::Upgrade(upgrade_key);
+
+    SetConsumption(UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Energy", 0.0));
+
+    if(UnitCSVFactory::GetVariable(upgrade_key, "Can_Cloak", false)) {
+        status = CloakingStatus::ready;
+    } else {
+        status = CloakingStatus::disabled;
+    }
+
+    glass = UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Glass", false);
+    rate = UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Rate", 0.0);
+    minimum = UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Min", 0.0);
+    minimum = std::min(1.0, std::max(0.0, minimum));
+    current = 0;
+    installed = true;
 
     return true;
 }
@@ -205,36 +217,4 @@ double Cloak::Consume()
         return 0.0;
     }
     return EnergyConsumer::Consume();
-}
-
-void Cloak::downgrade_private() {
-    Component::Downgrade();
-    SetConsumption(0);
-
-    status = CloakingStatus::disabled;
-
-    rate = 100;
-    glass = false;
-    current = 0;
-    minimum = 0;
-
-
-}
-
-void Cloak::upgrade_private(const std::string upgrade_key) {
-    Component::Upgrade(upgrade_key);
-
-    SetConsumption(UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Energy", 0.0));
-
-    if(UnitCSVFactory::GetVariable(upgrade_key, "Can_Cloak", false)) {
-        status = CloakingStatus::ready;
-    } else {
-        status = CloakingStatus::disabled;
-    }
-
-    glass = UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Glass", false);
-    rate = UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Rate", 0.0);
-    minimum = UnitCSVFactory::GetVariable(upgrade_key, "Cloak_Min", 0.0);
-    minimum = std::min(1.0, std::max(0.0, minimum));
-    current = 0;
 }

--- a/engine/src/components/cloak.h
+++ b/engine/src/components/cloak.h
@@ -149,10 +149,6 @@ public:
     // EnergyConsumer methods
 
     double Consume() override;
-
-private:
-    void downgrade_private();
-    void upgrade_private(const std::string upgrade_key);
 };
 
 #endif // VEGA_STRIKE_ENGINE_COMPONENTS_CLOAK_H

--- a/engine/src/components/component.cpp
+++ b/engine/src/components/component.cpp
@@ -161,6 +161,4 @@ const double Component::GetPrice() const { return price; }
 const double Component::GetMass() const { return mass; }
 const double Component::GetVolume() const { return volume; }
 
-const double Component::GetOperational() const { return operational.Value(); }
-
 const bool Component::Integral() const { return integral; }

--- a/engine/src/components/component.h
+++ b/engine/src/components/component.h
@@ -136,8 +136,6 @@ public:
     const double GetMass() const;
     const double GetVolume() const;
 
-    const double GetOperational() const;
-
     const bool Integral() const;
 };
 #endif // VEGA_STRIKE_ENGINE_COMPONENTS_COMPONENT_H

--- a/engine/src/components/component_utils.cpp
+++ b/engine/src/components/component_utils.cpp
@@ -24,6 +24,7 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
+#include <boost/format.hpp>
 
 #include "component_utils.h"
 
@@ -187,4 +188,27 @@ void ResourceYawPitchRollParser(std::string unit_key, const YPR ypr,
     right *= M_PI / 180.0;
     right_value = Resource<double>(right,right * minimum_functionality,right);
     left_value = Resource<double>(left,right * minimum_functionality,left);
+}
+
+
+/* This function is used by vdu.cpp to print the component
+    with the color showing damage */
+std::string PrintFormattedComponentInHud(double percent, std::string component_name,
+                                         bool damageable,
+                                         std::string GetDamageColor(double)) {
+    const bool print_percent_working = configuration()->graphics.hud.print_damage_percent;
+
+    const std::string damage_color = GetDamageColor(percent);
+    const int int_percent = percent * 100;
+    static const std::string white_color = GetDamageColor(1.0);
+
+    // Note we reset color to white/undamaged at the end of each line
+    if(print_percent_working && damageable) {
+        return (boost::format("%1%%2% (%3%%%)%4%\n") %
+            damage_color % component_name % int_percent % 
+            white_color).str();
+    } else {
+        return (boost::format("%1%%2%%3%\n") %
+            damage_color % component_name % white_color).str();
+    }
 }

--- a/engine/src/components/component_utils.h
+++ b/engine/src/components/component_utils.h
@@ -56,4 +56,10 @@ void DoubleYawPitchRollParser(std::string unit_key, const YPR ypr,
                         Resource<double> &right_value, Resource<double> &left_value,
                         const double minimum_functionality = 0.0);
 
+/* This function is used by vdu.cpp to print the component
+    with the color showing damage */
+std::string PrintFormattedComponentInHud(double percent, std::string component_name,
+                                         bool damageable,
+                                         std::string GetDamageColor(double));
+
 #endif // VEGA_STRIKE_ENGINE_COMPONENTS_COMPONENT_UTILS_H

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -52,6 +52,11 @@
 
 
 class ComponentsManager {
+    bool player_ship = false;
+    
+    // Here we store hud text so we won't have to generate it every cycle
+    // Instead we only do this when something changes
+    std::string hud_text;
 public:
     virtual ~ComponentsManager() = default;
 // Components
@@ -80,7 +85,10 @@ public:
     RepairBot repair_bot;
     ShipFunctions ship_functions;
 
+    
     void DamageRandomSystem();
+    void GenerateHudText(std::string getDamageColor(double));
+    std::string GetHudText();
 };
 
 #endif // VEGA_STRIKE_ENGINE_COMPONENTS_MANAGER_COMPONENT_H

--- a/engine/src/components/computer.cpp
+++ b/engine/src/components/computer.cpp
@@ -38,6 +38,8 @@ Computer::Computer() :
         original_itts(false),
         itts(false),
         combat_mode(true) {
+    upgrade_name = "Computer";
+    installed = true;
 }
 
 

--- a/engine/src/components/drive.cpp
+++ b/engine/src/components/drive.cpp
@@ -43,6 +43,8 @@ Drive::Drive(EnergyContainer *source):
     max_yaw_right(1,0,1), max_pitch_down(1,0,1), max_pitch_up(1,0,1),
     max_roll_left(1,0,1), max_roll_right(1,0,1) {
     type = ComponentType::Drive;
+    upgrade_name = "Drive";
+    installed = true;
 }
 
 Drive::~Drive()

--- a/engine/src/components/ecm.cpp
+++ b/engine/src/components/ecm.cpp
@@ -177,4 +177,5 @@ void ECM::_upgrade(const std::string key) {
     }
 
     ecm = Resource<int>(current_ecm, 0, max_ecm);
+    installed = true;
 }

--- a/engine/src/components/energy_container.cpp
+++ b/engine/src/components/energy_container.cpp
@@ -131,6 +131,9 @@ void EnergyContainer::Load(std::string unit_key) {
     }
 
     operational = level.AdjustedValue() / level.MaxValue();
+    if(level.MaxValue() > 0) {
+        installed = true;
+    }
 }
 
 void EnergyContainer::SaveToCSV(std::map<std::string, std::string>& unit) const {

--- a/engine/src/components/ftl_drive.cpp
+++ b/engine/src/components/ftl_drive.cpp
@@ -28,10 +28,12 @@
 #include "configuration/configuration.h"
 
 FtlDrive::FtlDrive() :
-    Component(),
+    Component(0.0, 0.0, true, true),
     EnergyConsumer(nullptr, false, 0),
     enabled(false) {
     type = ComponentType::FtlDrive;
+    upgrade_name = "FTL Drive";
+    installed = true;
 }
 
 FtlDrive::FtlDrive(EnergyContainer *source):
@@ -39,6 +41,8 @@ FtlDrive::FtlDrive(EnergyContainer *source):
     EnergyConsumer(source, false),
     enabled(false) {
     type = ComponentType::FtlDrive;
+    upgrade_name = "FTL Drive";
+    installed = true;
 }
 
 FtlDrive::~FtlDrive()

--- a/engine/src/components/hull.cpp
+++ b/engine/src/components/hull.cpp
@@ -30,9 +30,11 @@ static const Damage normal_and_phase_damage = Damage(1.0,1.0);
 
 
 Hull::Hull() :
-    Component(),
+    Component(0.0, 0.0, true, true),
     DamageableLayer(0, FacetConfiguration::one, 0.0, normal_and_phase_damage, true) {
     type = ComponentType::Hull;
+    upgrade_name = "Hull";
+    installed = true;
 }
 
 

--- a/engine/src/components/reactor.cpp
+++ b/engine/src/components/reactor.cpp
@@ -62,6 +62,10 @@ void Reactor::Load(std::string unit_key) {
     atom_capacity = capacity * simulation_atom_var;
     SetConsumption(capacity * conversion_ratio);
     operational = capacity.Percent();
+    
+    if(capacity.MaxValue() > 0) {
+        installed = true;
+    }
 }
 
 void Reactor::SaveToCSV(std::map<std::string, std::string>& unit) const {

--- a/engine/src/components/shield.cpp
+++ b/engine/src/components/shield.cpp
@@ -98,6 +98,7 @@ void Shield::Load(std::string unit_key) {
                 facet_strength);
 
             CalculatePercentOperational();
+            installed = true;
             return;
         } catch (std::invalid_argument const& ex) {
             VS_LOG(error, (boost::format("%1%: %2% trying to convert shield_strength_string '%3%' to int") % __FUNCTION__ % ex.what() % shield_strength_string));
@@ -138,6 +139,7 @@ void Shield::Load(std::string unit_key) {
 
         facets = shield_values;
         CalculatePercentOperational();
+        installed = true;
         return;
     }
 
@@ -165,6 +167,7 @@ void Shield::Load(std::string unit_key) {
             number_of_facets = shield_count;
             facets = shield_values;
             CalculatePercentOperational();
+            installed = true;
             return;
         }
     } catch (std::exception const& ex) {

--- a/engine/src/components/ship_functions.cpp
+++ b/engine/src/components/ship_functions.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "ship_functions.h"
+#include "component_utils.h"
 #include "cmd/unit_csv_factory.h"
 
 ShipFunctions::ShipFunctions() :
@@ -128,3 +129,11 @@ void ShipFunctions::Damage(Function function) {
     }
 }
 
+std::string ShipFunctions::GetHudText(std::string getDamageColor(double)) {
+    std::string report;
+    report += PrintFormattedComponentInHud(cockpit.Percent(), "Cockpit", true, getDamageColor);
+    report += PrintFormattedComponentInHud(communications.Percent(), "Communications", true, getDamageColor);
+    report += PrintFormattedComponentInHud(fire_control.Percent(), "Fire Control", true, getDamageColor);
+    report += PrintFormattedComponentInHud(life_support.Percent(), "Life Support", true, getDamageColor);
+    return report;
+}

--- a/engine/src/components/ship_functions.h
+++ b/engine/src/components/ship_functions.h
@@ -67,6 +67,7 @@ public:
     void Damage(Function function);
     void Repair(Function function);
     
+    std::string GetHudText(std::string getDamageColor(double));
 };
 
 #endif // VEGA_STRIKE_ENGINE_COMPONENTS_SHIP_FUNCTIONS_H

--- a/engine/src/components/tests/drive_tests.cpp
+++ b/engine/src/components/tests/drive_tests.cpp
@@ -204,7 +204,7 @@ TEST(Drive, UpgradeDowngrade) {
     // Drive
     upgrade.Downgrade();
 
-    EXPECT_EQ(drive.GetUpgradeName(), "");
+    EXPECT_EQ(drive.GetUpgradeName(), "Drive");
     EXPECT_EQ(drive.GetMass(), 0.0);
 
     DriveExpectEq(drive, 10.0);

--- a/engine/src/components/tests/operational_tests.cpp
+++ b/engine/src/components/tests/operational_tests.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "components/hull.h" 
+#include "cmd/unit_csv_factory.h"
+
+static const std::string upgrades_suffix_string = "__upgrades";
+const std::string reactor_string = "reactor";
+
+
+std::map<std::string,std::string> reactor_map = {
+    { "Hull", "69/100"}
+};
+
+TEST(OperationalTests, DamageSystems) {
+    UnitCSVFactory::LoadUnit(reactor_string + upgrades_suffix_string, reactor_map);
+
+    Hull hull;
+
+    hull.Load(reactor_string + upgrades_suffix_string);
+
+    EXPECT_EQ(hull.PercentOperational(), 0.69);
+}

--- a/engine/src/components/tests/utils_tests.cpp
+++ b/engine/src/components/tests/utils_tests.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <string>
+
+#include "components/component_utils.h" 
+
+std::string dummy_color(double percent) {
+    if(percent == 1.0) {
+        return "white:";
+    } else if(percent == 0.0) {
+        return "grey:";
+    } else if(percent > 0.66) {
+        return "yellow:";
+    } else if(percent > 0.33) {
+        return "orange:";
+    } else {
+        return "red:";
+    } 
+}
+
+
+TEST(UtilsTests, PrintFormattedComponentInHud) {
+    double percents[] = {1.0, 0.0, 0.8, 0.6, 0.4, 0.2, 0.1};
+
+    std::string expected_outputs[] = {"white:Dummy (100%)white:\n",
+                                      "grey:Dummy (0%)white:\n",
+                                      "yellow:Dummy (80%)white:\n",
+                                      "orange:Dummy (60%)white:\n",
+                                      "orange:Dummy (40%)white:\n",
+                                      "red:Dummy (20%)white:\n",
+                                      "red:Dummy (10%)white:\n"};
+
+    for(int i=0;i<7;i++) {
+        std::string output = PrintFormattedComponentInHud(percents[i], "Dummy", true, dummy_color);
+        EXPECT_EQ(output, expected_outputs[i]);
+    }
+}

--- a/engine/src/gfx/cockpit.cpp
+++ b/engine/src/gfx/cockpit.cpp
@@ -1405,7 +1405,6 @@ static void DrawCrosshairs(float x, float y, float wid, float hei, const GFXColo
 extern bool QuitAllow;
 extern bool screenshotkey;
 QVector SystemLocation(std::string system);
-double howFarToJump();
 
 void GameCockpit::Draw() {
     const bool draw_heading_marker = configuration()->graphics.draw_heading_marker;
@@ -1454,7 +1453,7 @@ void GameCockpit::Draw() {
                 if (delta.i != 0 || dest.j != 0 || dest.k != 0) {
                     delta.Normalize();
                     Unit *par = GetParent();
-                    delta = delta * howFarToJump() * 1.01 - (par ? (par->Position()) : QVector(0, 0, 0));
+                    delta = delta * configuration()->physics.distance_to_warp * 1.01 - (par ? (par->Position()) : QVector(0, 0, 0));
                     destination_system_location = delta.Cast();
                     Vector P, Q, R;
                     static float nav_symbol_size =

--- a/engine/src/star_system.cpp
+++ b/engine/src/star_system.cpp
@@ -1388,7 +1388,7 @@ static bool isJumping(const vector<unorigdest *> &pending, Unit *un) {
 }
 
 QVector SystemLocation(std::string system);
-double howFarToJump();
+
 
 QVector ComputeJumpPointArrival(QVector pos, std::string origin, std::string destination) {
     QVector finish = SystemLocation(destination);
@@ -1402,7 +1402,7 @@ QVector ComputeJumpPointArrival(QVector pos, std::string origin, std::string des
         if (pos.MagnitudeSquared()) {
             pos.Normalize();
         }
-        return (dir * .5 + pos * .125) * howFarToJump();
+        return (dir * .5 + pos * .125) * configuration()->physics.distance_to_warp;
     }
     return QVector(0, 0, 0);
 }

--- a/libraries/cmd/unit_csv.cpp
+++ b/libraries/cmd/unit_csv.cpp
@@ -590,7 +590,7 @@ void LoadCockpit(Unit *thus, const string &cockpit) {
 
 const std::string EMPTY_STRING("");
 
-
+extern std::string getDamageColor(double);
 
 void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_game) {
     Unit::XML xml;
@@ -882,6 +882,7 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
         AddCarg(this, integral_components);
     }
 
+    GenerateHudText(getDamageColor);
 }
 
 void Unit::WriteUnit(const char *modifications) {

--- a/libraries/cmd/unit_generic.h
+++ b/libraries/cmd/unit_generic.h
@@ -157,32 +157,6 @@ protected:
     StringPool::Reference csvRow;
 
 public:
-    // Components
-    EnergyContainer fuel = EnergyContainer(ComponentType::Fuel);
-    EnergyContainer energy = EnergyContainer(ComponentType::Capacitor);
-    EnergyContainer ftl_energy = EnergyContainer(ComponentType::FtlCapacitor);
-
-    // TODO: move this to a single constructor?!
-    Reactor reactor = Reactor(&fuel, &energy, &ftl_energy);
-
-    Afterburner afterburner;
-    AfterburnerUpgrade afterburner_upgrade = AfterburnerUpgrade(&afterburner);
-    Cloak cloak = Cloak();
-    Drive drive;
-    DriveUpgrade drive_upgrade = DriveUpgrade(&drive);
-    FtlDrive ftl_drive = FtlDrive(&ftl_energy);
-    JumpDrive jump_drive = JumpDrive(&ftl_energy);
-    CRadar radar;
-
-    Armor armor;
-    Hull hull;
-    Shield shield = Shield(&energy, &ftl_drive, &cloak);
-
-
-    ECM ecm;
-    RepairBot repair_bot;
-    ShipFunctions ship_functions;
-
     /// Repair
     float next_repair_time;
     unsigned int next_repair_cargo;    //(~0 : select randomly)
@@ -259,20 +233,8 @@ public:
     bool GettingDestroyed() const;
 
 
-    // TODO: implement enum class as type safe bitmask...
-    // http://blog.bitwigglers.org/using-enum-classes-as-type-safe-bitmasks/
-    enum Damages {
-        NO_DAMAGE = 0x0,
-        SHIELD_DAMAGED = 0x1,
-        COMPUTER_DAMAGED = 0x2,
-        MOUNT_DAMAGED = 0x4,
-        CARGOFUEL_DAMAGED = 0x8,
-        JUMP_DAMAGED = 0x10,
-        CLOAK_DAMAGED = 0x20,
-        LIMITS_DAMAGED = 0x40,
-        ARMOR_DAMAGED = 0x80
-    };
-    unsigned int damages = Damages::NO_DAMAGE;
+   
+    
 
 /*
  **************************************************************************************


### PR DESCRIPTION
- Instead of generating the text every cycle, we generate the text when damaged.
- As lib_component has no visibility to lib_gfx and colors, we provide the GetDamageColor function as a callback parameter.
- Deleted shadowing components from unit_generic.h.


Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
    Partially. There seems to be an issue with ships losing capacitor and not being able to jump. #1110.
    I have tested the VDU functionality.
    I did not test real time damage reflected in VDU. It should work but it's hard to generate.

Issues:
- #1110 
