### PR TITLE
Fix issue where beam weapons fire once

### DIFF
--- a/engine/src/cmd/beam.cpp
+++ b/engine/src/cmd/beam.cpp
@@ -756,6 +756,7 @@ void Beam::UpdatePhysics(const Transformation &trans,
         if (AUDIsPlaying(sound) && refiretime >= simulation_atom_var) {
             AUDStopPlaying(sound);
         }
+        refiretime += simulation_atom_var;
         return;
     }
     if (stability && numframes * simulation_atom_var > stability) {


### PR DESCRIPTION
Fix: #1066

Culprit was a refactoring of heat_sink. This variable was 0 and did nothing in beam.cpp
```
void Beam::UpdatePhysics(const Transformation &trans,const Matrix &m,
        Unit *targ,
        float tracking_cone,
        Unit *targetToCollideWith,
        float HeatSink,
        Unit *firer,
        Unit *superunit) {
...
        refiretime += simulation_atom_var * HeatSink;
        return;
}

```

... except that in unit_generic.cpp, the calling function passed this as the heat_sink, turning 0 to 1:
`(HeatSink ? HeatSink : 1.0f) * mounts[i].functionality`


Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. 
    No. It's a one liner fix and I understand the code now. 
    Relying on the _pull request validation_ is how I got here. Llama.begin has no beam weapons.

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do?
- What release is this for?
- Is there a project or milestone we should apply this to?