### PR TITLE
Windows-CI.yml, Windows-Release.yml: Remove Windows 2019…

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -19,14 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os:              windows-2019
-            triplet:         x64-win10
-            preset-name:     VS2019Win64-pie-enabled-release
-            cmake-generator: VS2019Win64
-            enable-pie:      1
-            build-type:      Release
-            python-version:  3.12.10
-            is-release:      0
           - os:              windows-2022
             triplet:         x64-win10
             preset-name:     VS2022Win64-pie-enabled-debug

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -21,14 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os:              windows-2019
-            triplet:         x64-win10
-            preset-name:     VS2019Win64-pie-enabled-release
-            cmake-generator: VS2019Win64
-            enable-pie:      1
-            build-type:      RelWithDebInfo
-            python-version:  3.12.10
-            is-release:      1
           - os:              windows-2022
             triplet:         x64-win10
             preset-name:     VS2022Win64-pie-enabled-debug


### PR DESCRIPTION
… since GitHub Actions will no longer support it in a few days

Code Changes:
- [x] This is a CI / build system change only (well, more or less)

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Remove Windows 2019 from the set of operating systems we build on, since GitHub Actions will no longer support it in a few days
- What release is this for? All of them, going forward
- Is there a project or milestone we should apply this to? 0.10.x?
