### PR TITLE
Fix issue 1229

### DIFF
--- a/engine/src/components/drive.cpp
+++ b/engine/src/components/drive.cpp
@@ -126,7 +126,7 @@ void Drive::Load(std::string unit_key) {
 void Drive::SaveToCSV(std::map<std::string, std::string>& unit) const {
     static const double game_speed = configuration()->physics.game_speed;
     static const double game_accel = configuration()->physics.game_accel;
-    static const double game_accel_speed = 1/ (game_speed * game_accel);
+    static const double game_accel_speed = (game_speed * game_accel);
     const double to_degrees = M_PI / 180;
     unit["Maneuver_Yaw"] = yaw.Serialize(to_degrees);
     unit["Maneuver_Pitch"] = pitch.Serialize(to_degrees);


### PR DESCRIPTION
Fix: #1229 

The issue was that when reading a ship file we applied two settings, game_accel and game_speed to several drive attributes. When saving, we incorrectly divided the attributes by 1/game_speed and 1/game_accel.
The bug wasn't caught because both values were 1.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation _only that the save game is saved correctly._

