### PR TITLE
Remove Windows 2019 builds (trimmed-down version)

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -19,14 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os:              windows-2019
-            triplet:         x64-win10
-            preset-name:     VS2019Win64-pie-enabled-release
-            cmake-generator: VS2019Win64
-            enable-pie:      1
-            build-type:      Release
-            python-version:  3.12.10
-            is-release:      0
           - os:              windows-2022
             triplet:         x64-win10
             preset-name:     VS2022Win64-pie-enabled-debug
@@ -52,6 +44,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 2
+          submodules: false
 
       - name: Restore vcpkg cache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -68,9 +63,9 @@ jobs:
           update-environment: false
 
       - name: install-cmake
-        uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 #v4.0.2
+        uses: lukka/get-cmake@6b3e96a9bc9976b8b546346fdd102effedae0ca8 # v4.0.3
         with:
-          cmakeVersion: 4.0.2
+          cmakeVersion: 4.0.3
           ninjaVersion: 1.12.1
 
       - name: run-vcpkg
@@ -100,6 +95,10 @@ jobs:
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-${{ matrix.os }}-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json') }}
+
+      - name: Run the tests
+        working-directory: ${{ github.workspace }}
+        run: ctest -V --preset "test-${{ matrix.preset-name }}"
 
       - name: Upload test results
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 #v4.3.3

--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -25,7 +25,7 @@ jobs:
             cmake-generator: VS2022Win64
             enable-pie:      1
             build-type:      Debug
-            python-version:  3.13.4
+            python-version:  3.13.5
             is-release:      0
           - os:              windows-2025
             triplet:         x64-win10
@@ -33,7 +33,7 @@ jobs:
             cmake-generator: VS2022Win64
             enable-pie:      1
             build-type:      RelWithDebInfo
-            python-version:  3.13.4
+            python-version:  3.13.5
             is-release:      0
 
     env:

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - os:              windows-2022
             triplet:         x64-win10
-            preset-name:     VS2022Win64-pie-enabled-debug
+            preset-name:     VS2022Win64-pie-enabled-RelWithDebInfo
             cmake-generator: VS2022Win64
             enable-pie:      1
             build-type:      RelWithDebInfo

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -27,7 +27,7 @@ jobs:
             cmake-generator: VS2022Win64
             enable-pie:      1
             build-type:      RelWithDebInfo
-            python-version:  3.13.4
+            python-version:  3.13.5
             is-release:      1
           - os:              windows-2025
             triplet:         x64-win10
@@ -35,7 +35,7 @@ jobs:
             cmake-generator: VS2022Win64
             enable-pie:      1
             build-type:      RelWithDebInfo
-            python-version:  3.13.4
+            python-version:  3.13.5
             is-release:      1
 
     env:

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -21,14 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os:              windows-2019
-            triplet:         x64-win10
-            preset-name:     VS2019Win64-pie-enabled-release
-            cmake-generator: VS2019Win64
-            enable-pie:      1
-            build-type:      RelWithDebInfo
-            python-version:  3.12.10
-            is-release:      1
           - os:              windows-2022
             triplet:         x64-win10
             preset-name:     VS2022Win64-pie-enabled-debug
@@ -52,9 +44,7 @@ jobs:
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
 
     steps:
-      # Set env vars needed for vcpkg to leverage the GitHub Action cache as a storage
-      # for Binary Caching.
-      # Also process the `github.sha` value to produce the SHORT_SHA we'll need later
+      # Process the `github.sha` value to produce the SHORT_SHA we'll need later
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
@@ -69,6 +59,9 @@ jobs:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 2
+          submodules: false
 
       - name: Restore vcpkg cache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -85,9 +78,9 @@ jobs:
           update-environment: false
 
       - name: install-cmake
-        uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 #v4.0.2
+        uses: lukka/get-cmake@6b3e96a9bc9976b8b546346fdd102effedae0ca8 # v4.0.3
         with:
-          cmakeVersion: 4.0.2
+          cmakeVersion: 4.0.3
           ninjaVersion: 1.12.1
 
       - name: run-vcpkg

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -27,7 +27,7 @@ jobs:
           #- macos-14
         python-version:
           #- 3.12.8
-          - 3.13.4
+          - 3.13.5
         compiler:
           - AppleClang
           #- clang

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -29,7 +29,7 @@ jobs:
           #- macos-14
         python-version:
           #- 3.12.8
-          - 3.13.4
+          - 3.13.5
         compiler:
           - AppleClang
           #- clang


### PR DESCRIPTION
Please answer the following:

Code Changes:
- [x] This is a CI/build system change only

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Remove the attempted Windows 2019 builds, so that our CI starts working again. Trimmed-down version of #1228 
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
