### PR TITLE
Move mass to ComponentsManager

### DIFF
--- a/engine/src/cmd/ai/aggressive.cpp
+++ b/engine/src/cmd/ai/aggressive.cpp
@@ -325,7 +325,7 @@ bool AggressiveAI::ProcessLogicItem(const AIEvents::AIEvresult &item) {
                 value = (pdmag - parent->rSize() - targ->rSize());
                 double myvel = PosDifference.Dot(parent->GetVelocity() - targ->GetVelocity()) / value;        ///pdmag;
                 if (myvel > 0) {
-                    value -= myvel * myvel / (2 * (parent->drive.retro / parent->getMass()));
+                    value -= myvel * myvel / (2 * (parent->drive.retro / parent->GetMass()));
                 }
             } else {
                 value = 10000;
@@ -1565,7 +1565,7 @@ void AggressiveAI::ExecuteNoEnemies() {
         } else if (lurk_on_arrival > 0) {
             lurk_on_arrival -= simulation_atom_var;
             //slowdown
-            parent->Thrust(-parent->getMass() * parent->UpCoordinateLevel(parent->GetVelocity()) / simulation_atom_var,
+            parent->Thrust(-parent->GetMass() * parent->UpCoordinateLevel(parent->GetVelocity()) / simulation_atom_var,
                     false);
             parent->ftl_drive.Disable();
             if (lurk_on_arrival <= 0) {

--- a/engine/src/cmd/ai/fire.cpp
+++ b/engine/src/cmd/ai/fire.cpp
@@ -308,7 +308,7 @@ float Priority(Unit *me, Unit *targ, float gunrange, float rangetotarget, float 
                         "Targetting",
                         "MassInertialPriorityCutoff",
                         "5000"));
-        if (me->getMass() > mass_inertial_priority_cutoff) {
+        if (me->GetMass() > mass_inertial_priority_cutoff) {
             static float mass_inertial_priority_scale =
                     XMLSupport::parse_float(vs_config->getVariable("AI",
                             "Targetting",
@@ -320,7 +320,7 @@ float Priority(Unit *me, Unit *targ, float gunrange, float rangetotarget, float 
             Vector ourToThem = targ->Position() - me->Position();
             ourToThem.Normalize();
             inertial_priority =
-                    mass_inertial_priority_scale * (.5 + .5 * (normv.Dot(ourToThem))) * me->getMass() * Speed;
+                    mass_inertial_priority_scale * (.5 + .5 * (normv.Dot(ourToThem))) * me->GetMass() * Speed;
         }
     }
     static float

--- a/engine/src/cmd/ai/flybywire.cpp
+++ b/engine/src/cmd/ai/flybywire.cpp
@@ -71,7 +71,7 @@ using Orders::MatchAngularVelocity;
 
 #define MATCHLINVELEXECUTE()                                                                         \
     do {                                                                                             \
-        parent->Thrust( (parent->getMass()                                                           \
+        parent->Thrust( (parent->GetMass()                                                           \
                          *(parent->ClampVelocity( desired,                                           \
                                                   afterburn )+FrameOfRef-velocity)/simulation_atom_var), \
                        afterburn );                                                                  \

--- a/engine/src/cmd/ai/navigation.cpp
+++ b/engine/src/cmd/ai/navigation.cpp
@@ -139,12 +139,12 @@ void MoveTo::SetDest(const QVector &target) {
 }
 
 bool MoveToParent::OptimizeSpeed(Unit *parent, float v, float &a, float max_speed) {
-    v += (a / parent->getMass()) * simulation_atom_var;
+    v += (a / parent->GetMass()) * simulation_atom_var;
     if ((!max_speed) || fabs(v) <= max_speed) {
         return true;
     }
     float deltaa =
-            parent->getMass() * (fabs(v) - max_speed) / simulation_atom_var;       //clamping should take care of it
+            parent->GetMass() * (fabs(v) - max_speed) / simulation_atom_var;       //clamping should take care of it
     a += (v > 0) ? -deltaa : deltaa;
     return false;
 }
@@ -201,7 +201,7 @@ bool MoveToParent::Execute(Unit *parent, const QVector &targetlocation) {
             }
             return done;
         }
-        thrust = (-parent->getMass() / simulation_atom_var) * last_velocity;
+        thrust = (-parent->GetMass() / simulation_atom_var) * last_velocity;
     } else {
         float div = 1.0f;
         float vdiv = 1.0f;
@@ -225,7 +225,7 @@ bool MoveToParent::Execute(Unit *parent, const QVector &targetlocation) {
         }
         //start with Forward/Reverse:
         float t =
-                CalculateDecelTime(heading.k, last_velocity.k, thrust.k, parent->drive.retro / div, parent->getMass());
+                CalculateDecelTime(heading.k, last_velocity.k, thrust.k, parent->drive.retro / div, parent->GetMass());
         if (t < THRESHOLD) {
             thrust.k =
                     (thrust.k > 0 ? -parent->drive.retro
@@ -240,14 +240,14 @@ bool MoveToParent::Execute(Unit *parent, const QVector &targetlocation) {
                             / simulation_atom_var;
         }
         OptimizeSpeed(parent, last_velocity.k, thrust.k, max_velocity.k / vdiv);
-        t = CalculateBalancedDecelTime(heading.i, last_velocity.i, thrust.i, parent->getMass());
+        t = CalculateBalancedDecelTime(heading.i, last_velocity.i, thrust.i, parent->GetMass());
         if (t < THRESHOLD) {
             thrust.i = -thrust.i;
         } else if (t < simulation_atom_var) {
             thrust.i *= (t - (simulation_atom_var - t)) / simulation_atom_var;
         }
         OptimizeSpeed(parent, last_velocity.i, thrust.i, max_velocity.i / vdiv);
-        t = CalculateBalancedDecelTime(heading.j, last_velocity.j, thrust.j, parent->getMass());
+        t = CalculateBalancedDecelTime(heading.j, last_velocity.j, thrust.j, parent->GetMass());
         if (t < THRESHOLD) {
             thrust.j = -thrust.j;
         } else if (t < simulation_atom_var) {
@@ -352,7 +352,7 @@ void ChangeHeading::Execute() {
     bool cheater = false;
     static float min_for_no_oversteer =
             XMLSupport::parse_float(vs_config->getVariable("AI", "min_angular_accel_cheat", "50"));
-    if (AICheat && ((parent->drive.yaw + parent->drive.pitch) * 180 / (PI * parent->getMass()) > min_for_no_oversteer)
+    if (AICheat && ((parent->drive.yaw + parent->drive.pitch) * 180 / (PI * parent->GetMass()) > min_for_no_oversteer)
             && !parent->isSubUnit()) {
         if (xswitch || yswitch) {
             Vector P, Q, R;
@@ -671,7 +671,7 @@ void AutoLongHaul::Execute() {
     if (!parent->ftl_drive.Enabled() && parent->graphicOptions.RampCounter == 0) {
         deactivatewarp = false;
     }
-    double mass = parent->getMass();
+    double mass = parent->GetMass();
     double minaccel =
             mymin(parent->drive.lateral,
                     mymin(parent->drive.vertical, mymin(parent->drive.forward, parent->drive.retro)));

--- a/engine/src/cmd/ai/script.cpp
+++ b/engine/src/cmd/ai/script.cpp
@@ -825,7 +825,7 @@ void AIScript::LoadXML() {
                     double myvel =
                             pdmag > 0 ? PosDifference.Dot(parent->GetVelocity() - targ->GetVelocity()) / pdmag : 0;
                     if (myvel > 0) {
-                        value -= myvel * myvel / (2 * (parent->drive.retro / parent->getMass()));
+                        value -= myvel * myvel / (2 * (parent->drive.retro / parent->GetMass()));
                     }
                 } else {
                     value = 10000;

--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -1473,7 +1473,7 @@ void BaseComputer::recalcTitle() {
                 const float basemass = atof(UniverseUtil::LookupUnitStat(playerUnit->name, "", "Mass").c_str());
                 float massEffect = 0.0;
                 if (basemass > 0) {
-                    massEffect = 100 * playerUnit->getMass() / basemass;
+                    massEffect = 100 * playerUnit->GetMass() / basemass;
                 }
                 if (showStardate) {
                     playerTitle = (boost::format("Stardate: %1$s      Credits: %2$.2f      "

--- a/engine/src/cmd/beam.cpp
+++ b/engine/src/cmd/beam.cpp
@@ -548,7 +548,7 @@ bool Beam::Collide(Unit *target, Unit *firer, Unit *superunit) {
                             * (appldam
                                     / sqrt( /*(target->sim_atom_multiplier
                                                  > 0) ? target->sim_atom_multiplier : */ 1.0)
-                                    * std::min(1.0f, target->getMass())));
+                                    * std::min(1.0, target->GetMass())));
                 }
             }
             float ors_m = o_ors_m, trs_m = o_trs_m, ofs = o_o;

--- a/engine/src/cmd/building.cpp
+++ b/engine/src/cmd/building.cpp
@@ -91,7 +91,7 @@ void Building::UpdatePhysics2(const Transformation &trans,
         {
             tmp1 = 200 * q.Cross(p);
         }
-        NetLocalTorque += ((tmp1 - tmp1 * (tmp1.Dot(GetAngularVelocity()) / tmp1.Dot(tmp1)))) * 1. / Mass;
+        NetLocalTorque += ((tmp1 - tmp1 * (tmp1.Dot(GetAngularVelocity()) / tmp1.Dot(tmp1)))) * 1. / static_cast<float>(GetMass());
     }
     SetCurPosition(tmp);
 }

--- a/engine/src/cmd/cont_terrain.cpp
+++ b/engine/src/cmd/cont_terrain.cpp
@@ -420,7 +420,7 @@ void ContinuousTerrain::Collide(Unit *un, Matrix t) {
             if (autocol) {
                 static float mass = 1000;
                 un->ApplyForce(
-                        bigNormal * .4 * un->Mass * fabs(bigNormal.Dot((un->GetVelocity() / simulation_atom_var))));
+                        bigNormal * .4 * un->GetMass() * fabs(bigNormal.Dot((un->GetVelocity() / simulation_atom_var))));
 
                 Damage damage(.5 * fabs(bigNormal.Dot(un->GetVelocity())) * mass * simulation_atom_var);
 

--- a/engine/src/cmd/planet.cpp
+++ b/engine/src/cmd/planet.cpp
@@ -434,8 +434,7 @@ void Planet::InitPlanet(QVector x,
     const float densityOfJumpPoint = configuration()->physics.density_of_jump_point;
     //const float massofplanet = configuration()->physics.mass_of_planet;
     hull.Set((4.0 / 3.0) * M_PI * radius * radius * radius * (notJumppoint ? densityOfRock : densityOfJumpPoint));
-    this->Mass =
-            (4.0 / 3.0) * M_PI * radius * radius * radius * (notJumppoint ? densityOfRock : (densityOfJumpPoint / 100000));
+    this->SetMass((4.0 / 3.0) * M_PI * radius * radius * radius * (notJumppoint ? densityOfRock : (densityOfJumpPoint / 100000)));
     SetAI(new PlanetaryOrbit(this, vely, pos, x, y, orbitcent, parent));     //behavior
     terraintrans = nullptr;
 

--- a/engine/src/cmd/terrain.cpp
+++ b/engine/src/cmd/terrain.cpp
@@ -71,7 +71,7 @@ void Terrain::SetTransformation(const Matrix &Mat) {
 }
 
 void Terrain::ApplyForce(Unit *un, const Vector &normal, float dist) {
-    un->ApplyForce(normal * .4 * un->getMass()
+    un->ApplyForce(normal * .4 * un->GetMass()
             * fabs(normal.Dot((un->GetVelocity() / simulation_atom_var))
                     + fabs(dist) / (simulation_atom_var)));
     Damage damage(.5 * fabs(normal.Dot(un->GetVelocity())) * mass * simulation_atom_var);

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -32,8 +32,23 @@
 #include "component_utils.h"
 #include "resource/random_utils.h"
 #include "configuration/configuration.h"
+#include "cmd/unit_csv_factory.h"
 
+void ComponentsManager::Load(std::string unit_key) {
+    mass = base_mass = UnitCSVFactory::GetVariable(unit_key, "Mass", 0.0);
+}
 
+void ComponentsManager::Serialize(std::map<std::string, std::string>& unit) const {
+    unit["Mass"] = std::to_string(base_mass);
+}
+
+double ComponentsManager::GetMass() const {
+    return mass;
+}
+
+void ComponentsManager::SetMass(double mass) {
+    this->mass = mass;
+}
 
 void ComponentsManager::DamageRandomSystem() {
     double percent = 1 - hull.Percent();

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -60,8 +60,22 @@ class ComponentsManager {
     // Here we store hud text so we won't have to generate it every cycle
     // Instead we only do this when something changes
     std::string hud_text;
+
+    friend class Movable;
+
+protected:
+    // TODO: make it change with fuel consumption
+    double mass;
+    double base_mass;
 public:
     virtual ~ComponentsManager() = default;
+
+    void Load(std::string unit_key);
+    void Serialize(std::map<std::string, std::string>& unit) const;
+
+    double GetMass() const;
+    void SetMass(double mass);
+
 // Components
     EnergyContainer fuel = EnergyContainer(ComponentType::Fuel);
     EnergyContainer energy = EnergyContainer(ComponentType::Capacitor);

--- a/engine/src/gfx/cockpit.cpp
+++ b/engine/src/gfx/cockpit.cpp
@@ -494,7 +494,7 @@ float GameCockpit::LookupUnitStat(int stat, Unit *target) {
         case UnitImages<void>::MASSEFFECT: {
             float basemass = atof(UniverseUtil::LookupUnitStat(target->name, "", "Mass").c_str());
             if (basemass > 0) {
-                return 100 * target->getMass() / basemass;
+                return 100 * target->GetMass() / basemass;
             } else {
                 return 0;
             }

--- a/libraries/cmd/carrier.cpp
+++ b/libraries/cmd/carrier.cpp
@@ -392,7 +392,7 @@ void Carrier::EjectCargo(unsigned int index) {
                 const float velmul = configuration()->physics.eject_cargo_speed;
                 cargo->SetOwner(unit);
                 cargo->SetVelocity(unit->Velocity * velmul + randVector(-.25, .25).Cast());
-                cargo->setMass(tmp->GetMass());
+                cargo->SetMass(tmp->GetMass());
                 if (name.length() > 0) {
                     cargo->name = name;
                 } else if (tmp) {
@@ -462,7 +462,7 @@ int Carrier::RemoveCargo(unsigned int i, int quantity, bool eraseZero) {
 
     const bool usemass = configuration()->physics.use_cargo_mass;
     if (usemass) {
-        unit->setMass(unit->getMass() - quantity * carg->GetMass());
+        unit->SetMass(unit->GetMass() - quantity * carg->GetMass());
     }
 
     carg->quantity -= quantity;
@@ -477,7 +477,7 @@ void Carrier::AddCargo(const Cargo &carg, bool sort) {
 
     const bool usemass = configuration()->physics.use_cargo_mass;
     if (usemass) {
-        unit->setMass(unit->getMass() + carg.quantity.Value() * carg.GetMass());
+        unit->SetMass(unit->GetMass() + carg.quantity.Value() * carg.GetMass());
     }
 
     bool found = false;
@@ -706,7 +706,7 @@ bool Carrier::SellCargo(unsigned int i, int quantity, float &creds, Cargo &carg,
     Unit *unit = vega_dynamic_cast_ptr<Unit>(this);
 
     if (i < 0 || i >= unit->cargo.size() || !buyer->CanAddCargo(unit->cargo[i])
-            || unit->getMass() < unit->cargo[i].GetMass()) {
+            || unit->GetMass() < unit->cargo[i].GetMass()) {
         return false;
     }
     carg = unit->cargo[i];

--- a/libraries/cmd/collision.cpp
+++ b/libraries/cmd/collision.cpp
@@ -50,7 +50,7 @@ Collision::Collision(Unit *unit, const QVector &location, const Vector &normal) 
     cockpit = _Universe->isPlayerStarship(unit); // smcp/thcp
     unit_type = unit->getUnitType();
     is_player_ship = _Universe->isPlayerStarship(unit);
-    mass = std::max(unit->getMass(), static_cast<float>(configuration()->physics.minimum_mass));
+    mass = std::max(unit->GetMass(), configuration()->physics.minimum_mass);
     position = unit->Position();
     velocity = unit->GetVelocity();
 }

--- a/libraries/cmd/drawable.cpp
+++ b/libraries/cmd/drawable.cpp
@@ -929,7 +929,7 @@ void Drawable::Split(int level) {
         unit->SubUnits.prepend(splitsub = new Unit(tempmeshes, true, unit->faction));
         splitsub->hull.Set(1000.0);
         splitsub->name = "debris";
-        splitsub->setMass(configuration()->physics.debris_mass * splitsub->getMass() / level);
+        splitsub->SetMass(configuration()->physics.debris_mass * splitsub->GetMass() / level);
         splitsub->pImage->timeexplode = .1;
         if (splitsub->meshdata[0]) {
             Vector loc = splitsub->meshdata[0]->Position();
@@ -938,7 +938,7 @@ void Drawable::Split(int level) {
                 locm = 1;
             }
             splitsub->ApplyForce(
-                    splitsub->meshdata[0]->rSize() * configuration()->graphics.explosion_force * 10 * splitsub->getMass() * loc
+                    splitsub->meshdata[0]->rSize() * configuration()->graphics.explosion_force * 10 * splitsub->GetMass() * loc
                             / locm);
             loc.Set(rand(), rand(), rand() + .1);
             loc.Normalize();
@@ -949,7 +949,7 @@ void Drawable::Split(int level) {
     old.clear();
     this->meshdata.clear();
     this->meshdata.push_back(nullptr);     //the shield
-    unit->Mass *= configuration()->physics.debris_mass;
+    unit->SetMass(unit->GetMass() * configuration()->physics.debris_mass);
 }
 
 void Drawable::LightShields(const Vector &pnt, const Vector &normal, float amt, const GFXColor &color) {

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -104,11 +104,12 @@ void Movable::GetOrientation(Vector &p, Vector &q, Vector &r) const {
 }
 
 Vector Movable::GetNetAcceleration() const {
+    const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
     Vector p, q, r;
     GetOrientation(p, q, r);
     Vector res(NetLocalForce.i * p + NetLocalForce.j * q + NetLocalForce.k * r);
     res += NetForce;
-    return res / Mass;
+    return res / static_cast<float>(unit->mass);
 }
 
 Vector Movable::GetNetAngularAcceleration() const {
@@ -130,7 +131,7 @@ float Movable::GetMaxAccelerationInDirectionOf(const Vector &ref, bool afterburn
     float tr = (lref.k == 0) ? 0 : fabs(((lref.k > 0) ? unit->drive.forward.Value() : unit->drive.retro.Value()) / lref.k);
     float trqmin = (tr < tq) ? tr : tq;
     float tm = tp < trqmin ? tp : trqmin;
-    return lref.Magnitude() * tm / Mass;
+    return lref.Magnitude() * tm / static_cast<float>(unit->mass);
 }
 
 void Movable::SetVelocity(const Vector &v) {
@@ -291,6 +292,8 @@ void Movable::Rotate(const Vector &axis) {
 }
 
 Vector Movable::ResolveForces(const Transformation &trans, const Matrix &transmat) {
+    const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
+
     //First, save theoretical instantaneous acceleration (not time-quantized) for GetAcceleration()
     SavedAccel = GetNetAcceleration();
     SavedAngAccel = GetNetAngularAcceleration();
@@ -328,7 +331,7 @@ Vector Movable::ResolveForces(const Transformation &trans, const Matrix &transma
     if (NetForce.i || NetForce.j || NetForce.k) {
         temp2 += InvTransformNormal(transmat, NetForce);
     }
-    temp2 = temp2 / Mass;
+    temp2 = temp2 / static_cast<float>(unit->mass);
     temp = temp2 * simulation_atom_var;
     if (!(FINITE(temp2.i) && FINITE(temp2.j) && FINITE(temp2.k))) {
         VS_LOG(info, "NetForce transform skrewed");
@@ -368,7 +371,7 @@ Vector Movable::ResolveForces(const Transformation &trans, const Matrix &transma
     if (air_res_coef != 0.0F || lateral_air_res_coef != 0.0F) {
         float velmag = Velocity.Magnitude();
         Vector AirResistance = Velocity
-                * (air_res_coef * velmag / Mass) * (corner_max.i - corner_min.i) * (corner_max.j - corner_min.j);
+                * (air_res_coef * velmag / static_cast<float>(unit->mass)) * (corner_max.i - corner_min.i) * (corner_max.j - corner_min.j);
         if (AirResistance.Magnitude() > velmag) {
             Velocity.Set(0, 0, 0);
         } else {
@@ -379,7 +382,7 @@ Vector Movable::ResolveForces(const Transformation &trans, const Matrix &transma
                 Vector lateralVel = p * Velocity.Dot(p) + q * Velocity.Dot(q);
                 AirResistance = lateralVel
                         * (lateral_air_res_coef * velmag
-                                / Mass) * (corner_max.i - corner_min.i) * (corner_max.j - corner_min.j);
+                                / static_cast<float>(unit->mass)) * (corner_max.i - corner_min.i) * (corner_max.j - corner_min.j);
                 if (AirResistance.Magnitude() > lateralVel.Magnitude()) {
                     Velocity = r * Velocity.Dot(r);
                 } else {
@@ -507,8 +510,9 @@ void Movable::ApplyLocalForce(const Vector &Vforce) {
 }
 
 void Movable::Accelerate(const Vector &Vforce) {
+    const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
     if (FINITE(Vforce.i) && FINITE(Vforce.j) && FINITE(Vforce.k)) {
-        NetForce += Vforce * Mass;
+        NetForce += Vforce * static_cast<float>(unit->mass);
     } else {
         VS_LOG(error, "fatal force");
     }

--- a/libraries/cmd/movable.h
+++ b/libraries/cmd/movable.h
@@ -45,22 +45,6 @@ class Movable {
 protected:
 
 public:
-    //mass of this unit (may change with cargo)
-    // TODO: subclass with return Mass+fuel;
-    float Mass;
-
-    float getMass() {
-        return Mass;
-    }
-
-    float getMass() const {
-        return Mass;
-    }
-
-    void setMass(float mass) {
-        Mass = mass;
-    }
-
     // Fields
     //The velocity this unit has in World Space
     Vector cumulative_velocity;
@@ -223,10 +207,6 @@ public:
 
     float GetMoment() const {
         return Momentofinertia; // TODO: subclass with return Momentofinertia+fuel;
-    }
-
-    float GetMass() const {
-        return Mass; // TODO: subclass with return Mass+fuel;
     }
 
     //Sets if forces should resolve on this unit or not

--- a/libraries/cmd/unit_csv.cpp
+++ b/libraries/cmd/unit_csv.cpp
@@ -670,8 +670,8 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     pImage->CockpitCenter.i = UnitCSVFactory::GetVariable(unit_key, "CockpitX", 0.0f) * xml.unitscale;
     pImage->CockpitCenter.j = UnitCSVFactory::GetVariable(unit_key, "CockpitY", 0.0f) * xml.unitscale;
     pImage->CockpitCenter.k = UnitCSVFactory::GetVariable(unit_key, "CockpitZ", 0.0f) * xml.unitscale;
-    Mass = UnitCSVFactory::GetVariable(unit_key, "Mass", 1.0f);
-    Momentofinertia = Mass;
+    Load(unit_key); // ComponentsManager
+    Momentofinertia = GetMass();
 
 
     // Hull
@@ -1029,7 +1029,7 @@ const std::map<std::string, std::string> Unit::UnitToMap() {
         }
         unit["Cargo"] = carg;
     }
-    unit["Mass"] = tos(Mass);
+    Serialize(unit); // ComponentsManager
 
     hull.SaveToCSV(unit);
     armor.SaveToCSV(unit);

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -1457,7 +1457,7 @@ Unit *makeBlankUpgrade(string templnam, int faction) {
         int q = bl->GetCargo(i).GetQuantity();
         bl->RemoveCargo(i, q);
     }
-    bl->setMass(0);
+    bl->SetMass(0);
     return bl;
 }
 
@@ -2781,17 +2781,9 @@ bool Unit::UpAndDownGrade(const Unit *up,
     if (numave) {
         percentage = percentage / numave;
     }
-    if (0 && touchme && up->Mass && numave) {
-        float multiplyer = ((downgrade) ? -1 : 1);
-        Mass += multiplyer * percentage * up->Mass;
-        if (Mass < (templ ? templ->Mass : .000000001)) {
-            Mass = (templ ? templ->Mass : .000000001);
-        }
-        Momentofinertia += multiplyer * percentage * up->Momentofinertia;
-        if (Momentofinertia < (templ ? templ->Momentofinertia : 0.00000001)) {
-            Momentofinertia = (templ ? templ->Momentofinertia : 0.00000001);
-        }
-    }
+    
+    // TODO: intertial dampener component - reduces mass
+
     if (gen_downgrade_list) {
         if (downgrade && percentage > configuration()->general.remove_downgrades_less_than_percent) {
             for (vsUMap<int, DoubleName>::iterator i = tempdownmap.begin(); i != tempdownmap.end(); ++i) {


### PR DESCRIPTION
Mass, as an attribute fits better in LibComponent. Upgrades make changes to the ships mass and so it makes sense mass would be part of the library and not part of a subclass.

**Future proposal:** 
Right now, Movable is a subclass of Unit, which is a subclass of LibComponent::ComponentsManager. We could move it up so Unit will subclass Movable. If we then make mass protected, we could clean Movable code. In particular, stuff like this will go away:
```
const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
...
temp2 = temp2 / static_cast<float>(unit->mass);
```

**Code Changes:**
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation _not yet_


Issues:
- None

@evertvorster , @kheckwrecker - I'd appreciate a play testing of this. 