### PR TITLE
script/bootstrap: Omit SDL 1 and 1.2; update copyleft header

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,7 +9,8 @@
 # @param  : just one parameter, either a 1 or a 0, to indicate whether or not to
 #           UPDATE_ALL_SYSTEM_PACKAGES
 #====================================
-# Copyright (C) 2020-2024 Stephen G. Tuggy, Benjamen R. Meyer, and other Vega Strike contributors
+# Copyright (C) 2020-2025 Roy Falk, Stephen G. Tuggy, Benjamen R. Meyer,
+# and other Vega Strike contributors
 #
 # This file is part of Vega Strike.
 #
@@ -29,7 +30,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2024-12-31 ---"
+echo "--- bootstrap | 2025-08-13 ---"
 echo "------------------------------"
 
 UPDATE_ALL_SYSTEM_PACKAGES="$1"
@@ -53,1082 +54,621 @@ echo "LINUX_VERSION_ID = ${LINUX_VERSION_ID}"
 
 function bootstrapOnDebian()
 {
-  apt-get update
+    apt-get update
 
-  if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
-  then
-    apt-get -qy upgrade
-  fi
+    if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
+    then
+        apt-get -qy upgrade
+    fi
 
-  case "$LINUX_CODENAME" in
-    "bookworm")
-      apt-get -qy remove \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev
-      apt-get -qy autoremove
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg62-turbo-dev \
-                      libexpat1-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python1.81-dev \
-                      libboost-log1.81-dev \
-                      libboost-regex1.81-dev \
-                      libboost-json1.81-dev \
-                      libboost-program-options1.81-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "bullseye")
-      apt-get -qy install \
-      echo "Sorry, Debian bullseye is no longer supported"
-      exit 2
-      ;;
-    "buster")
-      echo "Sorry, Debian buster is no longer supported"
-      ;;
-    "stretch")
-      echo "Sorry, Debian stretch is no longer supported"
-      exit 2
-      ;;
-    *)
-      echo "Sorry, this version of Debian is unsupported"
-      exit 2
-      ;;
-  esac
+    case "$LINUX_CODENAME" in
+        "trixie")
+            apt-get -qy install \
+                            git \
+                            cmake \
+                            python3-dev \
+                            build-essential \
+                            automake \
+                            autoconf \
+                            libarchive-dev \
+                            libpng16-16 \
+                            libpng-dev \
+                            libpng-tools \
+                            libjpeg62-turbo-dev \
+                            libexpat1-dev \
+                            libgtk-3-dev \
+                            libopenal-dev \
+                            libogg-dev \
+                            libvorbis-dev \
+                            libglvnd-dev \
+                            libgl1-mesa-dev \
+                            libsdl2-dev \
+                            libpostproc-dev \
+                            freeglut3-dev \
+                            libboost-python-dev \
+                            libboost-log-dev \
+                            libboost-regex-dev \
+                            libboost-json-dev \
+                            libboost-program-options-dev \
+                            libxmu-dev \
+                            clang \
+                            lsb-release \
+                            opentelemetry-cpp-dev \
+                            libprotobuf-dev
+            ;;
+        "bookworm")
+            apt-get -qy remove \
+                            libboost-python-dev \
+                            libboost-log-dev \
+                            libboost-regex-dev
+            apt-get -qy autoremove
+            apt-get -qy install \
+                            git \
+                            cmake \
+                            python3-dev \
+                            build-essential \
+                            automake \
+                            autoconf \
+                            libarchive-dev \
+                            libpng16-16 \
+                            libpng-dev \
+                            libpng-tools \
+                            libjpeg62-turbo-dev \
+                            libexpat1-dev \
+                            libgtk-3-dev \
+                            libopenal-dev \
+                            libogg-dev \
+                            libvorbis-dev \
+                            libglvnd-dev \
+                            libgl1-mesa-dev \
+                            libsdl2-dev \
+                            libpostproc-dev \
+                            freeglut3-dev \
+                            libboost-python1.81-dev \
+                            libboost-log1.81-dev \
+                            libboost-regex1.81-dev \
+                            libboost-json1.81-dev \
+                            libboost-program-options1.81-dev \
+                            libxmu-dev \
+                            clang \
+                            lsb-release
+            ;;
+        "bullseye"|"buster"|"stretch")
+            echo "Sorry, Debian ${LINUX_CODENAME} is no longer supported"
+            exit 2
+            ;;
+        *)
+            echo "Sorry, this version of Debian is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnUbuntu()
 {
-  apt-get update
+    apt-get update
 
-  if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
-  then
-    apt-get -qy upgrade
-  fi
+    if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
+    then
+        apt-get -qy upgrade
+    fi
 
-  case "$LINUX_CODENAME" in
-    "noble")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "jammy")
-      echo "Sorry, Ubuntu jammy is no longer supported"
-      exit 2
-      ;;
-    "focal")
-      echo "Sorry, Ubuntu focal is no longer supported"
-      exit 2
-      ;;
-    "bionic")
-      echo "Sorry, Ubuntu bionic is no longer supported"
-      exit 2
-      ;;
-    "impish")
-      echo "Sorry, Ubuntu impish is no longer supported"
-      exit 2
-      ;;
-    "hirsute")
-      echo "Sorry, Ubuntu hirsute is no longer supported"
-      exit 2
-      ;;
-    "xenial")
-      echo "Sorry, Ubuntu xenial is no longer supported"
-      exit 2
-      ;;
-    *)
-      echo "Sorry, this version of Ubuntu is unsupported"
-      exit 2
-      ;;
-  esac
+    case "$LINUX_CODENAME" in
+        "noble")
+            apt-get -qy install \
+                            git \
+                            cmake \
+                            python3-dev \
+                            build-essential \
+                            automake \
+                            autoconf \
+                            libarchive-dev \
+                            libpng16-16 \
+                            libpng-dev \
+                            libpng-tools \
+                            libjpeg-turbo8-dev \
+                            libexpat1-dev \
+                            libgdk-pixbuf-2.0-dev \
+                            libgtk-3-dev \
+                            libopenal-dev \
+                            libogg-dev \
+                            libvorbis-dev \
+                            libglvnd-dev \
+                            libgl1-mesa-dev \
+                            libsdl2-dev \
+                            libopengl0 \
+                            libpostproc-dev \
+                            freeglut3-dev \
+                            libboost-python-dev \
+                            libboost-log-dev \
+                            libboost-regex-dev \
+                            libboost-json-dev \
+                            libboost-program-options-dev \
+                            libxmu-dev \
+                            clang \
+                            lsb-release
+            ;;
+        "jammy"|"hirsute"|"impish"|"focal"|"bionic"|"xenial")
+            echo "Sorry, Ubuntu ${LINUX_CODENAME} is no longer supported"
+            exit 2
+            ;;
+        *)
+            echo "Sorry, this version of Ubuntu is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnPopOS ()
 {
-  apt-get update
+    apt-get update
 
-  if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
-  then
-    apt-get -qy upgrade
-  fi
+    if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
+    then
+        apt-get -qy upgrade
+    fi
 
-  case "$LINUX_CODENAME" in
-    "jammy")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "noble")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    *)
-      echo "Sorry, this version of Pop! OS is not currently supported"
-      exit 2
-      ;;
-  esac
+    case "$LINUX_CODENAME" in
+        "jammy")
+            echo "Sorry, Pop! OS jammy is no longer supported"
+            exit 2
+            ;;
+        "noble")
+            apt-get -qy install \
+                            git \
+                            cmake \
+                            python3-dev \
+                            build-essential \
+                            automake \
+                            autoconf \
+                            libarchive-dev \
+                            libpng16-16 \
+                            libpng-dev \
+                            libpng-tools \
+                            libjpeg-turbo8-dev \
+                            libexpat1-dev \
+                            libgdk-pixbuf-2.0-dev \
+                            libgtk-3-dev \
+                            libopenal-dev \
+                            libogg-dev \
+                            libvorbis-dev \
+                            libglvnd-dev \
+                            libgl1-mesa-dev \
+                            libsdl2-dev \
+                            libopengl0 \
+                            libpostproc-dev \
+                            freeglut3-dev \
+                            libboost-python-dev \
+                            libboost-log-dev \
+                            libboost-regex-dev \
+                            libboost-json-dev \
+                            libboost-program-options-dev \
+                            libxmu-dev \
+                            clang \
+                            lsb-release
+            ;;
+        *)
+            echo "Sorry, this version of Pop! OS is not currently supported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnLinuxMint ()
 {
-  apt-get update
+    apt-get update
 
-  if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
-  then
-    apt-get -qy upgrade
-  fi
+    if [ "${UPDATE_ALL_SYSTEM_PACKAGES}" -eq 1 ]
+    then
+        apt-get -qy upgrade
+    fi
 
-  case "$LINUX_CODENAME" in
-    "wilma")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-compat-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "virginia")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-compat-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "victoria")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-compat-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "vera")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-compat-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "vanessa")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-json-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "ulyana")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg62-dev \
-                      libexpat1-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-json-dev \
-                      libboost-regex-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    *)
-      echo "This version of Linux Mint is not directly supported. You may be able to use the corresponding Ubuntu installation package"
-      exit 2
-      ;;
-  esac
+    case "$LINUX_CODENAME" in
+        "wilma")
+            apt-get -qy install \
+                            git \
+                            cmake \
+                            python3-dev \
+                            build-essential \
+                            automake \
+                            autoconf \
+                            libarchive-dev \
+                            libpng16-16 \
+                            libpng-dev \
+                            libpng-tools \
+                            libjpeg-turbo8-dev \
+                            libexpat1-dev \
+                            libgdk-pixbuf-2.0-dev \
+                            libgtk-3-dev \
+                            libopenal-dev \
+                            libogg-dev \
+                            libvorbis-dev \
+                            libglvnd-dev \
+                            libgl1-mesa-dev \
+                            libsdl2-dev \
+                            libopengl0 \
+                            libpostproc-dev \
+                            freeglut3-dev \
+                            libboost-python-dev \
+                            libboost-log-dev \
+                            libboost-regex-dev \
+                            libboost-json-dev \
+                            libboost-program-options-dev \
+                            libxmu-dev \
+                            clang \
+                            lsb-release
+            ;;
+        "virginia"|"victoria"|"vera"|"vanessa"|"ulyana")
+            echo "Sorry, Linux Mint ${LINUX_CODENAME} is no longer supported"
+            exit 2
+            ;;
+        *)
+            echo "This version of Linux Mint is not directly supported. You may be able to use the corresponding Ubuntu installation package"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnOpenSuseLeap ()
 {
-  case "${LINUX_VERSION_ID}" in
-    "15.4")
-      zypper --non-interactive install -y \
-                              libboost_log1_75_0-devel \
-                              libboost_python-py3-1_75_0-devel \
-                              libboost_system1_75_0-devel \
-                              libboost_filesystem1_75_0-devel \
-                              libboost_thread1_75_0-devel \
-                              libboost_regex1_75_0-devel \
-                              libboost_chrono1_75_0-devel \
-                              libboost_atomic1_75_0-devel \
-                              libboost_json1_75_0-devel \
-                              libboost_program_options1_75_0-devel \
-                              cmake \
-                              gcc-c++ \
-                              freeglut-devel \
-                              libopenal0 \
-                              openal-soft-devel \
-                              libSDL-1_2-0 \
-                              libSDL-devel \
-                              libSDL2-devel \
-                              libvorbis-devel \
-                              libglvnd-devel \
-                              libjpeg-turbo \
-                              libjpeg62-devel \
-                              libpng16-devel \
-                              expat \
-                              libexpat-devel \
-                              libgtk-3-0 \
-                              gtk3-devel \
-                              python3-devel \
-                              git \
-                              rpm-build \
-                              clang
-      ;;
-    "15.5")
-      zypper --non-interactive install -y \
-                              libboost_log1_75_0-devel \
-                              libboost_python-py3-1_75_0-devel \
-                              libboost_system1_75_0-devel \
-                              libboost_filesystem1_75_0-devel \
-                              libboost_thread1_75_0-devel \
-                              libboost_regex1_75_0-devel \
-                              libboost_chrono1_75_0-devel \
-                              libboost_atomic1_75_0-devel \
-                              libboost_json1_75_0-devel \
-                              libboost_container1_75_0-devel \
-                              libboost_program_options1_75_0-devel \
-                              cmake \
-                              gcc-c++ \
-                              freeglut-devel \
-                              libopenal0 \
-                              openal-soft-devel \
-                              libSDL-1_2-0 \
-                              libSDL-devel \
-                              libSDL2-devel \
-                              libvorbis-devel \
-                              libglvnd-devel \
-                              libjpeg-turbo \
-                              libjpeg62-devel \
-                              libpng16-devel \
-                              expat \
-                              libexpat-devel \
-                              libgtk-3-0 \
-                              gtk3-devel \
-                              python3-devel \
-                              git \
-                              rpm-build \
-                              clang
-      ;;
-    "15.6")
-      zypper --non-interactive install -y \
-                              libboost_log1_75_0-devel \
-                              libboost_python-py3-1_75_0-devel \
-                              libboost_system1_75_0-devel \
-                              libboost_filesystem1_75_0-devel \
-                              libboost_thread1_75_0-devel \
-                              libboost_regex1_75_0-devel \
-                              libboost_chrono1_75_0-devel \
-                              libboost_atomic1_75_0-devel \
-                              libboost_json1_75_0-devel \
-                              libboost_container1_75_0-devel \
-                              libboost_program_options1_75_0-devel \
-                              cmake \
-                              gcc-c++ \
-                              freeglut-devel \
-                              libopenal0 \
-                              openal-soft-devel \
-                              libSDL-1_2-0 \
-                              libSDL-devel \
-                              libSDL2-devel \
-                              libvorbis-devel \
-                              libglvnd-devel \
-                              libjpeg-turbo \
-                              libjpeg62-devel \
-                              libpng16-devel \
-                              expat \
-                              libexpat-devel \
-                              libgtk-3-0 \
-                              gtk3-devel \
-                              python3-devel \
-                              git \
-                              rpm-build \
-                              clang
-      ;;
-    *)
-      echo "Sorry, this version of openSUSE Leap is unsupported"
-      exit 2
-      ;;
-  esac
+    case "${LINUX_VERSION_ID}" in
+        "15.1"|"15.2"|"15.3"|"15.4"|"15.5")
+            echo "Sorry, openSUSE Leap ${LINUX_VERSION_ID} is no longer supported"
+            exit 2
+            ;;
+        "15.6")
+            zypper --non-interactive install -y \
+                                    libboost_log1_75_0-devel \
+                                    libboost_python-py3-1_75_0-devel \
+                                    libboost_system1_75_0-devel \
+                                    libboost_filesystem1_75_0-devel \
+                                    libboost_thread1_75_0-devel \
+                                    libboost_regex1_75_0-devel \
+                                    libboost_chrono1_75_0-devel \
+                                    libboost_atomic1_75_0-devel \
+                                    libboost_json1_75_0-devel \
+                                    libboost_container1_75_0-devel \
+                                    libboost_program_options1_75_0-devel \
+                                    cmake \
+                                    gcc-c++ \
+                                    freeglut-devel \
+                                    libopenal0 \
+                                    openal-soft-devel \
+                                    libSDL2-devel \
+                                    libvorbis-devel \
+                                    libglvnd-devel \
+                                    libjpeg-turbo \
+                                    libjpeg62-devel \
+                                    libpng16-devel \
+                                    libarchive-devel \
+                                    expat \
+                                    libexpat-devel \
+                                    libgtk-3-0 \
+                                    gtk3-devel \
+                                    python3-devel \
+                                    git \
+                                    rpm-build \
+                                    clang
+            ;;
+        *)
+            echo "Sorry, this version of openSUSE Leap is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnFedora ()
 {
-  case "${LINUX_VERSION_ID}" in
-    30)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    31)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    32)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    33)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    34)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    35)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    36)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    37)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    38)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    39)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    40)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    41)
-      dnf install -y \
-                          git \
-                          cmake \
-                          boost-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    *)
-      echo "Sorry, this version of Fedora is unsupported"
-      exit 2
-      ;;
-  esac
+    case "${LINUX_VERSION_ID}" in
+        30|31|32|33|34|35|36|37|38|39)
+            echo "Sorry, Fedora ${LINUX_VERSION_ID} is no longer supported"
+            exit 2
+            ;;
+        40)
+            dnf install -y \
+                                git \
+                                cmake \
+                                boost-devel \
+                                freeglut-devel \
+                                gcc-c++ \
+                                openal-soft-devel \
+                                SDL2-devel \
+                                libvorbis-devel \
+                                libglvnd-devel \
+                                libjpeg-turbo-devel \
+                                libpng-devel \
+                                expat-devel \
+                                gtk3-devel \
+                                python3-devel \
+                                libarchive-devel \
+                                rpm-build \
+                                make \
+                                clang
+            ;;
+        41)
+            dnf install -y \
+                                git \
+                                cmake \
+                                boost-devel \
+                                freeglut-devel \
+                                gcc-c++ \
+                                openal-soft-devel \
+                                SDL2-devel \
+                                libvorbis-devel \
+                                libglvnd-devel \
+                                libjpeg-turbo-devel \
+                                libpng-devel \
+                                expat-devel \
+                                gtk3-devel \
+                                python3-devel \
+                                libarchive-devel \
+                                rpm-build \
+                                make \
+                                clang
+            ;;
+        42)
+            dnf install -y \
+                                git \
+                                cmake \
+                                boost-devel \
+                                freeglut-devel \
+                                gcc-c++ \
+                                openal-soft-devel \
+                                SDL2-devel \
+                                libvorbis-devel \
+                                libglvnd-devel \
+                                libjpeg-turbo-devel \
+                                libpng-devel \
+                                expat-devel \
+                                gtk3-devel \
+                                python3-devel \
+                                libarchive-devel \
+                                rpm-build \
+                                make \
+                                clang
+            ;;
+        *)
+            echo "Sorry, this version of Fedora is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnCentOS ()
 {
-  case "${LINUX_VERSION_ID}" in
-    "8")
-      dnf -y install dnf-plugins-core
-      dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-      dnf config-manager --set-enabled PowerTools
-      dnf -y install \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    "8.0")
-      dnf -y install dnf-plugins-core
-      dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-      dnf config-manager --set-enabled PowerTools
-      dnf -y install \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          SDL-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    *)
-      echo "Sorry, this version of CentOS is unsupported"
-      exit 2
-      ;;
-  esac
+    case "${LINUX_VERSION_ID}" in
+        "9.5")
+            dnf -y install dnf-plugins-core
+            dnf config-manager --set-enabled devel
+            dnf -y update
+            dnf -y install \
+                                git \
+                                cmake \
+                                boost-devel \
+                                boost-python3-devel \
+                                boost-json \
+                                freeglut-devel \
+                                gcc-c++ \
+                                openal-soft-devel \
+                                SDL2-devel \
+                                libvorbis-devel \
+                                libglvnd-devel \
+                                libjpeg-turbo-devel \
+                                libpng-devel \
+                                expat-devel \
+                                gtk3-devel \
+                                python3-devel \
+                                libarchive-devel \
+                                rpm-build \
+                                make \
+                                clang
+            ;;
+        *)
+            echo "Sorry, this version of CentOS is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnRedHat ()
 {
-  case "${LINUX_VERSION_ID}" in
-    "9.5")
-      dnf -y install dnf-plugins-core
-      dnf config-manager --set-enabled devel
-      dnf -y update
-      dnf -y install \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    *)
-      echo "Sorry, this version of Red Hat is unsupported"
-      exit 2
-      ;;
-  esac
+    case "${LINUX_VERSION_ID}" in
+        "9.5")
+            dnf -y install dnf-plugins-core
+            dnf config-manager --set-enabled devel
+            dnf -y update
+            dnf -y install \
+                                git \
+                                cmake \
+                                boost-devel \
+                                boost-python3-devel \
+                                freeglut-devel \
+                                gcc-c++ \
+                                openal-soft-devel \
+                                SDL2-devel \
+                                libvorbis-devel \
+                                libglvnd-devel \
+                                libjpeg-turbo-devel \
+                                libpng-devel \
+                                expat-devel \
+                                gtk3-devel \
+                                python3-devel \
+                                libarchive-devel \
+                                rpm-build \
+                                make \
+                                clang
+            ;;
+        *)
+            echo "Sorry, this version of Red Hat is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnRockyLinux ()
 {
-  case "${LINUX_VERSION_ID}" in
-    "9.5")
-      dnf -y install dnf-plugins-core
-      dnf config-manager --set-enabled devel
-      dnf -y update
-      dnf -y install \
-                          git \
-                          cmake \
-                          boost-devel \
-                          boost-python3-devel \
-                          boost-json \
-                          freeglut-devel \
-                          gcc-c++ \
-                          openal-soft-devel \
-                          sdl12-compat-devel \
-                          SDL2-devel \
-                          libvorbis-devel \
-                          libglvnd-devel \
-                          libjpeg-turbo-devel \
-                          libpng-devel \
-                          expat-devel \
-                          gtk3-devel \
-                          python3-devel \
-                          rpm-build \
-                          make \
-                          clang
-      ;;
-    *)
-      echo "Sorry, this version of Rocky Linux is unsupported"
-      exit 2
-      ;;
-  esac
+    case "${LINUX_VERSION_ID}" in
+        "9.5")
+            dnf -y install dnf-plugins-core
+            dnf config-manager --set-enabled devel
+            dnf -y update
+            dnf -y install \
+                                git \
+                                cmake \
+                                boost-devel \
+                                boost-python3-devel \
+                                boost-json \
+                                freeglut-devel \
+                                gcc-c++ \
+                                openal-soft-devel \
+                                SDL2-devel \
+                                libvorbis-devel \
+                                libglvnd-devel \
+                                libjpeg-turbo-devel \
+                                libpng-devel \
+                                expat-devel \
+                                gtk3-devel \
+                                python3-devel \
+                                libarchive-devel \
+                                rpm-build \
+                                make \
+                                clang
+            ;;
+        *)
+            echo "Sorry, this version of Rocky Linux is unsupported"
+            exit 2
+            ;;
+    esac
 }
 
 function bootstrapOnManjaro ()
 {
-    pacman -S --refresh --noconfirm cmake \
-                   boost \
-                   clang \
-                   gcc \
-                   gcc-libs \
-                   sdl \
-                   sdl2 \
-                   expat \
-                   gtk3 \
-                   libglvnd \
-                   mesa \
-                   python \
-                   autoconf \
-                   automake \
-                   freeglut \
-                   git \
-                   libjpeg-turbo \
-                   libpng \
-                   libvorbis \
-                   libxmu \
-                   openal \
-                   make
+        pacman -S --refresh --noconfirm cmake \
+                         boost \
+                         clang \
+                         gcc \
+                         gcc-libs \
+                         sdl2 \
+                         expat \
+                         gtk3 \
+                         libglvnd \
+                         mesa \
+                         python \
+                         autoconf \
+                         automake \
+                         freeglut \
+                         git \
+                         libjpeg-turbo \
+                         libpng \
+                         libvorbis \
+                         libxmu \
+                         openal \
+                         libarchive \
+                         make
 }
 
 function bootstrapOnFuntoo ()
 {
-  ego sync
-  dispatch-conf
-  # enable `autounmask-write` so that USE flags
-  # change in the image appropriately
-  USE="-libffi -userland_GNU gles2 X" emerge --autounmask-write \
-        cmake \
-        boost \
-        libsdl \
-        libsdl2 \
-        expat \
-        gtk3 \
-        libglvnd \
-        mesa \
-        python \
-        autoconf \
-        automake \
-        freeglut \
-        git \
-        libjpeg-turbo \
-        libpng \
-        libvorbis \
-        libXmu \
-        openal \
-        make \
-        x11-libs/gtk+
+    ego sync
+    dispatch-conf
+    # enable `autounmask-write` so that USE flags
+    # change in the image appropriately
+    USE="-libffi -userland_GNU gles2 X" emerge --autounmask-write \
+              cmake \
+              boost \
+              libsdl2 \
+              expat \
+              gtk3 \
+              libglvnd \
+              mesa \
+              python \
+              autoconf \
+              automake \
+              freeglut \
+              git \
+              libjpeg-turbo \
+              libpng \
+              libvorbis \
+              libXmu \
+              openal \
+              libarchive \
+              make \
+              x11-libs/gtk+
 }
 
 function bootstrapOnArch ()
 {
-  # NOTE: Arch requires GCC 12 right now
-  # also installing latest GCC.
-  pacman -Sy --noconfirm \
-        base-devel \
-        cmake \
-        boost \
-        llvm \
-        clang \
-        gcc \
-        gcc12 \
-        sdl \
-        sdl2 \
-        expat \
-        gtk3 \
-        libglvnd \
-        mesa \
-        python \
-        freeglut \
-        git \
-        libjpeg-turbo \
-        libpng \
-        libvorbis \
-        libxmu \
-        openal \
-        make
+    # NOTE: Arch requires GCC 12 right now
+    # also installing latest GCC.
+    pacman -Sy --noconfirm \
+              base-devel \
+              cmake \
+              boost \
+              llvm \
+              clang \
+              gcc \
+              gcc12 \
+              sdl2 \
+              expat \
+              gtk3 \
+              libglvnd \
+              mesa \
+              python \
+              freeglut \
+              git \
+              libjpeg-turbo \
+              libpng \
+              libvorbis \
+              libxmu \
+              openal \
+              libarchive \
+              make
 }
 
 case "${LINUX_ID}" in
-  "debian")
-    bootstrapOnDebian
-    ;;
-  "ubuntu")
-    bootstrapOnUbuntu
-    ;;
-  "pop")
-    bootstrapOnPopOS
-    ;;
-  "linuxmint")
-    bootstrapOnLinuxMint
-    ;;
-  "opensuse-leap")
-    bootstrapOnOpenSuseLeap
-    ;;
-  "fedora")
-    bootstrapOnFedora
-    ;;
-  "centos")
-    bootstrapOnCentOS
-    ;;
-  "rhel")
-    bootstrapOnRedHat
-    ;;
-  "redhat")
-    bootstrapOnRedHat
-    ;;
-  "rocky")
-    bootstrapOnRockyLinux
-    ;;
-  "manjaro")
-    bootstrapOnManjaro
-    ;;
-  "funtoo")
-    bootstrapOnFuntoo
-    ;;
-  "arch")
-    bootstrapOnArch
-    ;;
-  *)
-    echo "Sorry, unrecognized/unsupported Linux distribution"
-    exit 2
-    ;;
+    "debian")
+        bootstrapOnDebian
+        ;;
+    "ubuntu")
+        bootstrapOnUbuntu
+        ;;
+    "pop")
+        bootstrapOnPopOS
+        ;;
+    "linuxmint")
+        bootstrapOnLinuxMint
+        ;;
+    "opensuse-leap")
+        bootstrapOnOpenSuseLeap
+        ;;
+    "fedora")
+        bootstrapOnFedora
+        ;;
+    "centos")
+        bootstrapOnCentOS
+        ;;
+    "rhel")
+        bootstrapOnRedHat
+        ;;
+    "redhat")
+        bootstrapOnRedHat
+        ;;
+    "rocky")
+        bootstrapOnRockyLinux
+        ;;
+    "manjaro")
+        bootstrapOnManjaro
+        ;;
+    "funtoo")
+        bootstrapOnFuntoo
+        ;;
+    "arch")
+        bootstrapOnArch
+        ;;
+    *)
+        echo "Sorry, unrecognized/unsupported Linux distribution"
+        exit 2
+        ;;
 esac
 
 mkdir -p /usr/src/Vega-Strike-Engine-Source


### PR DESCRIPTION
Code Changes:
- [x] This is a CI / build system change only

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Drop SDL 1 and 1.2 from the bootstrap script at long last. All the versions of Vega Strike we currently support use SDL 2, so the time has come.
- What release is this for? 0.9.x and up, potentially
- Is there a project or milestone we should apply this to? In this PR, I'm making the change on the `master` branch. So it applies to 0.10.x.
