### PR TITLE
Fix mass calculations

### DIFF
--- a/engine/src/components/cargo_hold.cpp
+++ b/engine/src/components/cargo_hold.cpp
@@ -100,7 +100,7 @@ Cargo CargoHold::RemoveCargo(ComponentsManager *manager, const std::string& name
 
 Cargo CargoHold::RemoveCargo(ComponentsManager *manager, unsigned int index, 
                            int quantity) {
-    if (!(index < _items.size())) {
+    if (index >= _items.size()) {
         VS_LOG(error, "(previously) FATAL problem...removing cargo that is past the end of array bounds.");
         return Cargo();
     }

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -55,7 +55,10 @@ void ComponentsManager::Load(std::string unit_key) {
     for (const std::string& upgrade : upgrades) {
         std::vector<std::string> parts;
         boost::split(parts, upgrade, boost::is_any_of(":"));
-        if (parts.size() == 2) {
+        if (parts.size() == 1) {
+            const std::string category = parts[0];
+            prohibited_upgrades.emplace_back(category, 0);
+        } else if (parts.size() == 2) {
             const std::string category = parts[0];
             const int limit = std::stoi(parts[1]);
             //const std::pair<const std::string, const int> pair(category, limit);
@@ -89,6 +92,14 @@ double ComponentsManager::GetMass() const {
 
 void ComponentsManager::SetMass(double mass) {
     this->mass = mass;
+}
+
+void ComponentsManager::SetPlayerShip() {
+    player_ship = true;
+}
+
+bool ComponentsManager::PlayerShip() {
+    return player_ship;
 }
 
 void ComponentsManager::DamageRandomSystem() {
@@ -274,24 +285,23 @@ std::string ComponentsManager::GetTitle(bool show_cargo, bool show_star_date, st
     
     // Cargo mass renders your ship harder to manoeuver. Display it.
     double mass_percent = mass / base_mass * 100;
+    const std::string mass_string = (boost::format("base %1%/ current %2% (%3$.0f%%)") % base_mass % mass % mass_percent).str();
     
     if (show_star_date) {
         return (boost::format("Stardate: %1$s      Credits: %2$.2f      "
-                              "Space left: %3$.6g of %4$.6g cubic meters   Mass: %5$.0f%% (base)")
+                              "Space left: %3$.6g of %4$.6g cubic meters   Mass: %5%")
                               % date
                               % credits.Value()
                               % available_volume
                               % empty_volume
-                              % mass_percent)
-                              .str();
+                              % mass_string).str();
     } else {
         return (boost::format("Credits: %1$.2f      "
-                              "Space left: %2$.6g of %3$.6g cubic meters   Mass: %4$.0f%% (base)")
+                              "Space left: %2$.6g of %3$.6g cubic meters   Mass: %4%")
                               % credits.Value()
                               % available_volume
                               % empty_volume
-                              % mass_percent)
-                              .str();
+                              % mass_string).str();
     }
 }
 

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -87,6 +87,9 @@ public:
     double GetMass() const;
     void SetMass(double mass);
 
+    void SetPlayerShip();
+    bool PlayerShip();
+
 // Components
     EnergyContainer fuel = EnergyContainer(ComponentType::Fuel);
     EnergyContainer energy = EnergyContainer(ComponentType::Capacitor);

--- a/engine/src/resource/cargo.cpp
+++ b/engine/src/resource/cargo.cpp
@@ -121,7 +121,8 @@ Cargo::Cargo(boost::json::object json):
     mass(std::stod(JsonGetStringWithDefault(json, "mass", "0.0"))), 
     volume(std::stod(JsonGetStringWithDefault(json, "volume", "0.0"))),
     mission(false), 
-    component((JsonGetStringWithDefault(json, "component", "false")) == "true"),
+    component(GetBool(json, "upgrade", false)),
+    weapon(GetBool(json, "weapon", false)),
     installed(false), 
     integral(false),
     functionality(Resource<double>(1.0, 0.0, 1.0)) {}

--- a/libraries/cmd/unit_csv.cpp
+++ b/libraries/cmd/unit_csv.cpp
@@ -609,6 +609,10 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     // TODO: figure this out.
     std::string unit_key = (saved_game ? "player_ship" : unit_identifier);
 
+    if(saved_game) {
+        SetPlayerShip();
+    }
+
     fullname = UnitCSVFactory::GetVariable(unit_key, "Name", std::string());
 
     tmpstr = UnitCSVFactory::GetVariable(unit_key, "Hud_image", std::string());
@@ -663,6 +667,9 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
             mesh_string, faction,
             getFlightgroup());
 
+    // Should come before cargo or upgrades
+    Load(unit_key); // ComponentsManager
+
     std::string dock_string = UnitCSVFactory::GetVariable(unit_key, "Dock", std::string());
     AddDocks(this, xml, UnitCSVFactory::GetVariable(unit_key, "Dock", std::string()));
 
@@ -694,7 +701,7 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     pImage->CockpitCenter.i = UnitCSVFactory::GetVariable(unit_key, "CockpitX", 0.0f) * xml.unitscale;
     pImage->CockpitCenter.j = UnitCSVFactory::GetVariable(unit_key, "CockpitY", 0.0f) * xml.unitscale;
     pImage->CockpitCenter.k = UnitCSVFactory::GetVariable(unit_key, "CockpitZ", 0.0f) * xml.unitscale;
-    Load(unit_key); // ComponentsManager
+    
     Momentofinertia = GetMass();
 
 

--- a/libraries/cmd/unit_generic.h
+++ b/libraries/cmd/unit_generic.h
@@ -317,7 +317,6 @@ public:
     bool RepairUpgradeCargo(Cargo *item,
             Unit *baseUnit);           //item must not be NULL but baseUnit/credits are only used for pricing.
     Vector MountPercentOperational(int whichmount);
-    bool ReduceToTemplate();
     double Upgrade(const std::string &file, int mountoffset, int subunitoffset, bool force, bool loop_through_mounts);
     bool canDowngrade(const Unit *downgradeor,
             int mountoffset,

--- a/libraries/cmd/unit_util_generic.cpp
+++ b/libraries/cmd/unit_util_generic.cpp
@@ -56,7 +56,6 @@
 #ifndef NO_GFX
 #include "gfx/cockpit.h"
 #endif
-const Unit *makeTemplateUpgrade(string name, int faction); //for percentoperational
 const Unit *getUnitFromUpgradeName(const string &upgradeName, int myUnitFaction = 0); //for percentoperational
 extern const char *DamagedCategory;  //for percentoperational
 using std::string;
@@ -545,24 +544,6 @@ int removeCargo(Unit *my_unit, string s, int quantity, bool erasezero) {
     return c.GetQuantity();
 }
 
-// TODO: I'm almost certain this is no longer relevant.
-// Still need to investigate turrets and weapons.
-void RecomputeUnitUpgrades(Unit *un) {
-    if (un == NULL) {
-        return;
-    }
-    un->ReduceToTemplate();
-
-    for (Cargo& c : un->upgrade_space.GetItems()) {
-        assert(c.IsComponent());
-        
-        if(c.IsIntegral()) {
-            continue;
-        }
-        
-        un->Upgrade(c.GetName(), 0, 0, true, false);
-    }
-}
 
 bool repair(Unit *my_unit) {
     if (!my_unit) {
@@ -924,20 +905,6 @@ float PercentOperational(const Cargo item, Unit *un, std::string name, std::stri
                     }
                 }
             }
-        }
-    } else if (name.find("add_") != 0 && name.find("mult_") != 0) {
-        double percent = 0;
-        if (un->canUpgrade(upgrade, -1, -1, 0, true, percent, makeTemplateUpgrade(un->name, un->faction), false)) {
-            if (percent > 0 && percent < 1) {
-                return percent;
-            } else if (percent
-                    >= 1) { //FIXME workaround for sensors -- see below comment, not sure why sensors report erroneous functional percentage
-                return 1.0;
-            } else {
-                return .5;
-            } //FIXME does not interact well with radar type
-        } else if (percent > 0) {
-            return percent;
         }
     }
     return 1.0;


### PR DESCRIPTION
- basecomputer.cpp:sellUpgrade calling UnitUtil::RecomputeUnitUpgrades was the culprit. It re-added cargo items several times.
- Fix bug in AllowedUpgrade which returned the reverse.
- Fix bug in ComponentsManager parsing of prohibited upgrades to correctly parse entries without explicit limit number.
- Fix bug in cargo, where upgrade and weapon fields were not correctly read. This resulted in inability to choose mount to upgrade.
- Implement PlayerShip and SetPlayerShip in ComponentsManager
- Polish GetTitle to provide base_mass and mass
- Remove some unused functions or comment out in case used in API


Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation _no yet_

What I tested:
- Mass is correctly loaded from save game. 
- Mass is displayed correctly in ship computer.
- Mass is changed correctly when buying and selling cargo/upgrade.
- Capacity is changed correctly when buying selling cargo/upgrade.
- Upgrades behave as expected in base computer. Can buy and sell stuff. Can buy weapons correctly, etc.

Issues:
- I think old save games save mass **with** upgrades and cargo. As such you would need to manually adjust this or figure out another solution.

fix #1268 
