### PR TITLE
Add ability to reload guns 

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -634,6 +634,7 @@ SET(VEGASTRIKE_SOURCES
     src/cmd/nebula.cpp
     src/cmd/planet.cpp
     src/cmd/ship.cpp
+    src/cmd/reload_utils.cpp
     src/cmd/script/c_alike/c_alike.tab.cpp
     src/cmd/script/c_alike/lex.yy.cpp
     src/cmd/script/director.cpp

--- a/engine/src/cmd/basecomputer.h
+++ b/engine/src/cmd/basecomputer.h
@@ -149,6 +149,8 @@ protected:
     bool sellUpgrade(const EventCommandId &command, Control *control);
 //Fix an upgrade on your ship.
     bool fixUpgrade(const EventCommandId &command, Control *control);
+//Reload a gun on your ship.
+    bool reloadUpgrade(const EventCommandId &command, Control *control);
 //Buy ship from the base.
     bool buyShip(const EventCommandId &command, Control *control);
 //Sell ship from your stock

--- a/engine/src/cmd/reload_utils.cpp
+++ b/engine/src/cmd/reload_utils.cpp
@@ -1,0 +1,136 @@
+/*
+ * reload_utils.cpp
+ *
+ * Vega Strike - Space Simulation, Combat and Trading
+ * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Project creator: Daniel Horn
+ * Original development team: As listed in the AUTHORS file
+ * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+ *
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ // -*- mode: c++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#include "reload_utils.h"
+
+#include "cmd/unit_generic.h"
+
+#include <vector>
+
+// This generate an upgrade unit from the name and faction.
+// An upgrade unit is the unit representation of a specific upgrade.
+// e.g. Micro_Driver_ammo__upgrades in units.json
+const Unit *getUnitFromUpgradeName(const string &upgradeName, int myUnitFaction = 0);
+
+
+std::vector<Mount*> GetMountsForName(Unit *unit, const std::string& weapon_unit_name) {
+    std::vector<Mount*> mounts;
+
+    // We need to extract the weapon name (from weapons.json) 
+    // from the parameter weapon_unit_name (from units.json)
+    
+    // First step is to get a unit instance from the weapon_unit_name
+    const Unit *weapon = getUnitFromUpgradeName(weapon_unit_name, FactionUtil::GetUpgradeFaction());
+
+    // Something went wrong
+    if(!weapon) {
+        return mounts;
+    }
+
+    // Now we can extract the weapon's name as it is in weapons.json
+    const std::string weapon_name = weapon->mounts[0].type->name;
+
+    // Finally we iterate over the ship mounts in order to generate a partial list
+    // of mounts with the weapon's name
+    for(Mount& mount : unit->mounts) {
+        if(weapon_name == mount.type->name && mount.ammo != -1) {
+            mounts.push_back(&mount);
+        }
+    }
+
+    return mounts;
+} 
+
+int getMaxAmmo(const std::string& weapon_unit_name) {
+    // First step is to get a unit instance from the weapon_unit_name
+    const Unit *weapon = getUnitFromUpgradeName(weapon_unit_name, FactionUtil::GetUpgradeFaction());
+
+    // Something went wrong
+    if(!weapon) {
+        return -1;
+    }
+
+    // Now we get the first mount, which always holds the actual weapon from weapons.json
+    Mount weapon_mount = weapon->mounts[0];
+
+    // Now we can extract the weapon's max ammo
+    return weapon_mount.ammo;
+}
+
+std::vector<int> getAmmoPerGun(Unit *unit, const std::string& weapon_unit_name) {
+    std::vector<int> ammo_vector;
+
+    for(Mount* mount : GetMountsForName(unit, weapon_unit_name)) {
+        ammo_vector.push_back(mount->ammo);
+    }
+
+    return ammo_vector;
+}
+
+double getReloadCost(const int ammo, const int max_ammo, const double price, const double modifier = 0.05) {
+    double ammo_percent = 1 - static_cast<double>(ammo)/static_cast<double>(max_ammo);
+    return ammo_percent * price * modifier;
+}
+
+std::string getReloadDescription(Unit *unit, const double price, const std::string& weapon_unit_name) {
+    const int max_ammo = getMaxAmmo(weapon_unit_name);
+    std::string description = "#b#Reload cost:#-b#n1.5#";
+
+    int i=1;
+
+
+    for(Mount* mount : GetMountsForName(unit, weapon_unit_name)) {
+        int ammo = mount->ammo;
+
+        // TODO: make modifier configurable in configuration
+        double cost = getReloadCost(ammo, max_ammo, price);
+        double ammo_percent = static_cast<double>(ammo)/static_cast<double>(max_ammo) * 100;
+        description += (boost::format("Gun %1% - ammo: %2%/%3% (%4%%%) cost: %5%#n#")
+                            % i % ammo % max_ammo % ammo_percent % cost).str();
+        i++;
+    }
+
+    return description;
+}
+
+bool canReload(Unit *unit, const std::string& weapon_unit_name) {
+    const int max_ammo = getMaxAmmo(weapon_unit_name);
+    if(max_ammo == -1) {
+        return false;
+    }
+
+    for(Mount* mount : GetMountsForName(unit, weapon_unit_name)) {
+        if(mount->ammo < max_ammo) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/engine/src/cmd/reload_utils.h
+++ b/engine/src/cmd/reload_utils.h
@@ -1,0 +1,38 @@
+/*
+ * reload_utils.h
+ *
+ * Vega Strike - Space Simulation, Combat and Trading
+ * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Project creator: Daniel Horn
+ * Original development team: As listed in the AUTHORS file
+ * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+ *
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef VEGA_STRIKE_ENGINE_CMD_RELOAD_UTILS_H
+#define VEGA_STRIKE_ENGINE_CMD_RELOAD_UTILS_H
+
+#include <string>
+
+class Unit;
+
+bool canReload(Unit *unit, const std::string& weapon_unit_name);
+std::string getReloadDescription(Unit *unit, const double price, const std::string& weapon_unit_name);
+
+#endif // VEGA_STRIKE_ENGINE_CMD_RELOAD_UTILS_H

--- a/engine/src/components/cargo_hold.cpp
+++ b/engine/src/components/cargo_hold.cpp
@@ -100,7 +100,7 @@ Cargo CargoHold::RemoveCargo(ComponentsManager *manager, const std::string& name
 
 Cargo CargoHold::RemoveCargo(ComponentsManager *manager, unsigned int index, 
                            int quantity) {
-    if (!(index < _items.size())) {
+    if (index >= _items.size()) {
         VS_LOG(error, "(previously) FATAL problem...removing cargo that is past the end of array bounds.");
         return Cargo();
     }

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -55,7 +55,10 @@ void ComponentsManager::Load(std::string unit_key) {
     for (const std::string& upgrade : upgrades) {
         std::vector<std::string> parts;
         boost::split(parts, upgrade, boost::is_any_of(":"));
-        if (parts.size() == 2) {
+        if (parts.size() == 1) {
+            const std::string category = parts[0];
+            prohibited_upgrades.emplace_back(category, 0);
+        } else if (parts.size() == 2) {
             const std::string category = parts[0];
             const int limit = std::stoi(parts[1]);
             //const std::pair<const std::string, const int> pair(category, limit);
@@ -89,6 +92,14 @@ double ComponentsManager::GetMass() const {
 
 void ComponentsManager::SetMass(double mass) {
     this->mass = mass;
+}
+
+void ComponentsManager::SetPlayerShip() {
+    player_ship = true;
+}
+
+bool ComponentsManager::PlayerShip() {
+    return player_ship;
 }
 
 void ComponentsManager::DamageRandomSystem() {
@@ -274,24 +285,23 @@ std::string ComponentsManager::GetTitle(bool show_cargo, bool show_star_date, st
     
     // Cargo mass renders your ship harder to manoeuver. Display it.
     double mass_percent = mass / base_mass * 100;
+    const std::string mass_string = (boost::format("base %1%/ current %2% (%3$.0f%%)") % base_mass % mass % mass_percent).str();
     
     if (show_star_date) {
         return (boost::format("Stardate: %1$s      Credits: %2$.2f      "
-                              "Space left: %3$.6g of %4$.6g cubic meters   Mass: %5$.0f%% (base)")
+                              "Space left: %3$.6g of %4$.6g cubic meters   Mass: %5%")
                               % date
                               % credits.Value()
                               % available_volume
                               % empty_volume
-                              % mass_percent)
-                              .str();
+                              % mass_string).str();
     } else {
         return (boost::format("Credits: %1$.2f      "
-                              "Space left: %2$.6g of %3$.6g cubic meters   Mass: %4$.0f%% (base)")
+                              "Space left: %2$.6g of %3$.6g cubic meters   Mass: %4%")
                               % credits.Value()
                               % available_volume
                               % empty_volume
-                              % mass_percent)
-                              .str();
+                              % mass_string).str();
     }
 }
 

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -87,6 +87,9 @@ public:
     double GetMass() const;
     void SetMass(double mass);
 
+    void SetPlayerShip();
+    bool PlayerShip();
+
 // Components
     EnergyContainer fuel = EnergyContainer(ComponentType::Fuel);
     EnergyContainer energy = EnergyContainer(ComponentType::Capacitor);

--- a/engine/src/resource/cargo.cpp
+++ b/engine/src/resource/cargo.cpp
@@ -121,7 +121,8 @@ Cargo::Cargo(boost::json::object json):
     mass(std::stod(JsonGetStringWithDefault(json, "mass", "0.0"))), 
     volume(std::stod(JsonGetStringWithDefault(json, "volume", "0.0"))),
     mission(false), 
-    component((JsonGetStringWithDefault(json, "component", "false")) == "true"),
+    component(GetBool(json, "upgrade", false)),
+    weapon(GetBool(json, "weapon", false)),
     installed(false), 
     integral(false),
     functionality(Resource<double>(1.0, 0.0, 1.0)) {}

--- a/libraries/cmd/unit_csv.cpp
+++ b/libraries/cmd/unit_csv.cpp
@@ -609,6 +609,10 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     // TODO: figure this out.
     std::string unit_key = (saved_game ? "player_ship" : unit_identifier);
 
+    if(saved_game) {
+        SetPlayerShip();
+    }
+
     fullname = UnitCSVFactory::GetVariable(unit_key, "Name", std::string());
 
     tmpstr = UnitCSVFactory::GetVariable(unit_key, "Hud_image", std::string());
@@ -663,6 +667,9 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
             mesh_string, faction,
             getFlightgroup());
 
+    // Should come before cargo or upgrades
+    Load(unit_key); // ComponentsManager
+
     std::string dock_string = UnitCSVFactory::GetVariable(unit_key, "Dock", std::string());
     AddDocks(this, xml, UnitCSVFactory::GetVariable(unit_key, "Dock", std::string()));
 
@@ -694,7 +701,7 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     pImage->CockpitCenter.i = UnitCSVFactory::GetVariable(unit_key, "CockpitX", 0.0f) * xml.unitscale;
     pImage->CockpitCenter.j = UnitCSVFactory::GetVariable(unit_key, "CockpitY", 0.0f) * xml.unitscale;
     pImage->CockpitCenter.k = UnitCSVFactory::GetVariable(unit_key, "CockpitZ", 0.0f) * xml.unitscale;
-    Load(unit_key); // ComponentsManager
+    
     Momentofinertia = GetMass();
 
 

--- a/libraries/cmd/unit_generic.h
+++ b/libraries/cmd/unit_generic.h
@@ -317,7 +317,6 @@ public:
     bool RepairUpgradeCargo(Cargo *item,
             Unit *baseUnit);           //item must not be NULL but baseUnit/credits are only used for pricing.
     Vector MountPercentOperational(int whichmount);
-    bool ReduceToTemplate();
     double Upgrade(const std::string &file, int mountoffset, int subunitoffset, bool force, bool loop_through_mounts);
     bool canDowngrade(const Unit *downgradeor,
             int mountoffset,

--- a/libraries/cmd/unit_util_generic.cpp
+++ b/libraries/cmd/unit_util_generic.cpp
@@ -56,7 +56,6 @@
 #ifndef NO_GFX
 #include "gfx/cockpit.h"
 #endif
-const Unit *makeTemplateUpgrade(string name, int faction); //for percentoperational
 const Unit *getUnitFromUpgradeName(const string &upgradeName, int myUnitFaction = 0); //for percentoperational
 extern const char *DamagedCategory;  //for percentoperational
 using std::string;
@@ -545,24 +544,6 @@ int removeCargo(Unit *my_unit, string s, int quantity, bool erasezero) {
     return c.GetQuantity();
 }
 
-// TODO: I'm almost certain this is no longer relevant.
-// Still need to investigate turrets and weapons.
-void RecomputeUnitUpgrades(Unit *un) {
-    if (un == NULL) {
-        return;
-    }
-    un->ReduceToTemplate();
-
-    for (Cargo& c : un->upgrade_space.GetItems()) {
-        assert(c.IsComponent());
-        
-        if(c.IsIntegral()) {
-            continue;
-        }
-        
-        un->Upgrade(c.GetName(), 0, 0, true, false);
-    }
-}
 
 bool repair(Unit *my_unit) {
     if (!my_unit) {
@@ -924,20 +905,6 @@ float PercentOperational(const Cargo item, Unit *un, std::string name, std::stri
                     }
                 }
             }
-        }
-    } else if (name.find("add_") != 0 && name.find("mult_") != 0) {
-        double percent = 0;
-        if (un->canUpgrade(upgrade, -1, -1, 0, true, percent, makeTemplateUpgrade(un->name, un->faction), false)) {
-            if (percent > 0 && percent < 1) {
-                return percent;
-            } else if (percent
-                    >= 1) { //FIXME workaround for sensors -- see below comment, not sure why sensors report erroneous functional percentage
-                return 1.0;
-            } else {
-                return .5;
-            } //FIXME does not interact well with radar type
-        } else if (percent > 0) {
-            return percent;
         }
     }
     return 1.0;


### PR DESCRIPTION
- Add description of ammo for guns with ammo
- Add reload button when supported and needed
- Display reload button only if gun isn't damaged. Otherwise display fix instead (not ideal)
- Code is by weapon type. So if one microdriver is damaged, you can't reload the other.
- Reload happens one gun at a time of same type. If you have 3 microdrivers with 88%/33%/2%, you'd have to reload the first two first.


Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. Mostly tinkered with the upgrade computer. Basic sanity in flight.


Issues:
- See above
- Did not delete units such as Hephaestus_Mini_ammo__upgrades yet. Once approved, we could delete real ammo but I'm not sure about missiles.

