### PR TITLE
Fix cargo purchase bug 1267

### DIFF
--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -2482,20 +2482,17 @@ void BaseComputer::draw() {
 bool BaseComputer::buySelectedCargo(int requestedQuantity) {
     Unit *playerUnit = m_player.GetUnit();
     Unit *baseUnit = m_base.GetUnit();
-    if (!(playerUnit && baseUnit)) {
+    Cargo *item = selectedItem();
+
+    if (!(playerUnit && baseUnit && item)) {
         return true;
     }
-    Cargo *item = selectedItem();
-    if (item) {
-        int quantity = (requestedQuantity <= 0 ? item->GetQuantity() : requestedQuantity);
-        quantity = maxQuantityForPlayer(*item, quantity);
-        int index = baseUnit->cargo_hold.GetIndex(*item);        
-        playerUnit->BuyCargo(baseUnit, item, quantity);
-        //Reload the UI -- inventory has changed.  Because we reload the UI, we need to
-        //find, select, and scroll to the thing we bought.  The item might be gone from the
-        //list (along with some categories) after the transaction.
-        refresh();         //This will reload master lists.
-    }
+
+    playerUnit->BuyCargo(baseUnit, item, requestedQuantity);
+    //Reload the UI -- inventory has changed.  Because we reload the UI, we need to
+    //find, select, and scroll to the thing we bought.  The item might be gone from the
+    //list (along with some categories) after the transaction.
+    refresh();         //This will reload master lists.
     return true;
 }
 
@@ -2511,7 +2508,7 @@ bool BaseComputer::buy10Cargo(const EventCommandId &command, Control *control) {
 
 //Buy all of an item from the cargo list.
 bool BaseComputer::buyAllCargo(const EventCommandId &command, Control *control) {
-    return buySelectedCargo(-1);
+    return buySelectedCargo(9999);
 }
 
 //Sell some items from the Cargo list.  Use -1 for quantity to buy all of the item.
@@ -2546,7 +2543,7 @@ bool BaseComputer::sell10Cargo(const EventCommandId &command, Control *control) 
 
 //Sell all of an item from the cargo list.
 bool BaseComputer::sellAllCargo(const EventCommandId &command, Control *control) {
-    return sellSelectedCargo(-1);
+    return sellSelectedCargo(9999);
 }
 
 //Change controls to NEWS mode.

--- a/engine/src/components/cargo_hold.cpp
+++ b/engine/src/components/cargo_hold.cpp
@@ -132,7 +132,7 @@ void CargoHold::AddCargo(ComponentsManager *manager, const Cargo &cargo, bool so
 
     bool found = false;
 
-    for(Cargo c: _items) {
+    for(Cargo& c: _items) {
         if(c.name == cargo.name && c.category == cargo.category) {
             found = true;
             c.quantity += cargo.quantity.Value();

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -312,34 +312,36 @@ bool ComponentsManager::SellUpgrade(ComponentsManager *buyer, Cargo *item, int q
 }
 
 bool ComponentsManager::_Buy(CargoHold *hold, ComponentsManager *seller, Cargo *item, int quantity) {
-    // In theory, item should already have the right quantity.
-    // In practice, base_computer doesn't provide this.
-    item->SetQuantity(quantity);
-
-    if(credits < item->GetPrice() * quantity) {
-        return false;
-    }
-
+    // Some sanity checks
     int index = seller->cargo_hold.GetIndex(*item);
     if(index == -1) {
         return false;
     }
 
-    Cargo sold_cargo = seller->cargo_hold.RemoveCargo(seller, index, quantity);
+    // Check quantity is available in seller's hold
+    quantity = std::min(item->GetQuantity(), quantity);
 
-    if(!hold->CanAddCargo(sold_cargo)) {
-        seller->cargo_hold.AddCargo(seller, sold_cargo);
+    // Check the maximum you can afford
+    int max_affordable_quantity = static_cast<int>(std::floor(credits / item->GetPrice()));
+    quantity = std::min(max_affordable_quantity, quantity);
+
+    // Check the maximum you can fit in your hold
+    int max_stackable_quantity = static_cast<int>(std::floor(hold->AvailableCapacity() / item->GetVolume()));
+    quantity = std::min(max_stackable_quantity, quantity);
+
+    // Sanity check of the quantity - isn't 0 or negative
+    if(quantity <= 0) {
         return false;
     }
 
+    // Actual transaction
+    Cargo sold_cargo = seller->cargo_hold.RemoveCargo(seller, index, quantity);
     ComponentsManager::credits -= item->GetPrice() * quantity;
     hold->AddCargo(this, sold_cargo);
     return true;
 }
 
 bool ComponentsManager::_Sell(CargoHold *hold, ComponentsManager *buyer, Cargo *item, int quantity) {
-    item->SetQuantity(quantity);
-
     CargoHold *buyer_hold = &buyer->cargo_hold;
 
     int index = hold->GetIndex(*item);
@@ -347,9 +349,14 @@ bool ComponentsManager::_Sell(CargoHold *hold, ComponentsManager *buyer, Cargo *
         return false;
     }
 
-    // For now, NPCs can always afford to buy our stuff
+    // Note: For now, NPCs can always afford to buy our stuff
+    // Check the maximum you can fit in your hold
+    // Disabled. Check returns a negative number for small items
+    //int max_stackable_quantity = static_cast<int>(std::floor(buyer->cargo_hold.AvailableCapacity() / item->GetVolume()));
+    //quantity = std::min(max_stackable_quantity, quantity);
 
-    if (!buyer_hold->CanAddCargo(*item)) {
+    // Quantity sanity check - must be positive
+    if (quantity <= 0) {
         return false;
     }
 


### PR DESCRIPTION
Closes #1267 

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. No. Only checked behavior of cargo purchase and sale.


Issues:
- Had to disable space checks on the base side. For items smaller than 1 the value of available space in units of item exceeded max_int and became negative.

@evertvorster, I'd appreciate a play test of this PR.