### PR TITLE
Fix an issue where the pointer to the firing weapon is not valid

### DIFF
--- a/engine/src/cmd/ai/script.cpp
+++ b/engine/src/cmd/ai/script.cpp
@@ -812,23 +812,21 @@ void AIScript::LoadXML() {
                     % parent->name
                     % parent->computer.threatlevel));
         }
-        if (parent->Target()->IsPlayerShip()) {
+
+        Unit* target = parent->Target();
+        if (target && target->IsPlayerShip()) {
             double value;
             const double game_speed = configuration().physics.game_speed_dbl;
             const double game_accel = configuration().physics.game_accel_dbl;
             {
-                Unit *targ = parent->Target();
-                if (targ) {
-                    Vector PosDifference = (targ->Position() - parent->Position()).Cast();
-                    double pdmag = PosDifference.Magnitude();
-                    value = (pdmag - parent->rSize() - targ->rSize());
-                    double myvel =
-                            pdmag > 0 ? PosDifference.Dot(parent->GetVelocity() - targ->GetVelocity()) / pdmag : 0;
-                    if (myvel > 0) {
-                        value -= myvel * myvel / (2 * (parent->drive.retro / parent->GetMass()));
-                    }
-                } else {
-                    value = 10000;
+                
+                Vector PosDifference = (target->Position() - parent->Position()).Cast();
+                double pdmag = PosDifference.Magnitude();
+                value = (pdmag - parent->rSize() - target->rSize());
+                double myvel =
+                        pdmag > 0 ? PosDifference.Dot(parent->GetVelocity() - target->GetVelocity()) / pdmag : 0;
+                if (myvel > 0) {
+                    value -= myvel * myvel / (2 * (parent->drive.retro / parent->GetMass()));
                 }
                 value /= game_speed * game_accel;
             }

--- a/engine/src/cmd/beam.cpp
+++ b/engine/src/cmd/beam.cpp
@@ -356,6 +356,7 @@ Beam::Beam(const Transformation &trans, const WeaponInfo &clne, void *own, Unit 
     Col.a = clne.a;
     impact = ALIVE;
     owner = own;
+    player_fired = firer->IsPlayerShip();
     numframes = 0;
     const int radslices = configuration().physics.tractor.scoop_rad_slices | 1;    //Must be odd
     const int longslices = configuration().physics.tractor.scoop_long_slices;
@@ -622,7 +623,7 @@ bool Beam::Collide(Unit *target, Unit *firer, Unit *superunit) {
             }
         } else {
             Damage damage(appldam, phasdam);
-            target->ApplyDamage(center.Cast() + direction * curlength, normal, damage, colidee, coltmp, owner);
+            target->ApplyDamage(center.Cast() + direction * curlength, normal, damage, colidee, coltmp, owner, player_fired);
         }
         return true;
     }

--- a/engine/src/cmd/beam.h
+++ b/engine/src/cmd/beam.h
@@ -75,6 +75,7 @@ private:
     unsigned char impact;
     bool listen_to_owner;
     void *owner; //may be a dead pointer...never dereferenced
+    bool player_fired;
     QVector center; //in world coordinates as of last physics frame...
     Vector direction;
 

--- a/engine/src/cmd/bolt.cpp
+++ b/engine/src/cmd/bolt.cpp
@@ -252,11 +252,13 @@ Bolt::Bolt(const WeaponInfo *typ,
         const Matrix &orientationpos,
         const Vector &shipspeed,
         void *owner,
+        bool player_fired,
         CollideMap::iterator hint) : cur_position(orientationpos.p), ShipSpeed(shipspeed) {
     VSCONSTRUCT2('t')
     BoltDrawManager &q = BoltDrawManager::GetInstance();
     prev_position = cur_position;
     this->owner = owner;
+    this->player_fired = player_fired;
     this->type = typ;
     bolt_name = typ->file;
     curdist = 0;
@@ -412,7 +414,7 @@ bool Bolt::Collide(Unit *target) {
                 damage,
                 affectedSubUnit,
                 coltmp,
-                owner);
+                owner, player_fired);
         return true;
     }
     return false;

--- a/engine/src/cmd/bolt.h
+++ b/engine/src/cmd/bolt.h
@@ -50,6 +50,7 @@ private:
     Vector ShipSpeed;
     QVector prev_position;//beams don't change heading.
     void *owner;
+    bool player_fired;
     float curdist;
     int decal;//which image it uses
     float bolt_size; // actually squared
@@ -82,6 +83,7 @@ public:
             const Matrix &orientationpos,
             const Vector &ShipSpeed,
             void *owner,
+            bool player_fired,
             CollideMap::iterator hint);//makes a bolt
     void Destroy(unsigned int index);
     //static void Draw();

--- a/engine/src/cmd/missile.cpp
+++ b/engine/src/cmd/missile.cpp
@@ -53,13 +53,14 @@
 ////////////////////////////////////////////////////////////////
 /// MissileEffect
 ////////////////////////////////////////////////////////////////
-MissileEffect::MissileEffect(const QVector &pos, float dam, float pdam, float radius, float radmult, void *owner) : pos(
+MissileEffect::MissileEffect(const QVector &pos, float dam, float pdam, float radius, float radmult, void *owner, bool player_fired) : pos(
         pos) {
     damage = dam;
     phasedamage = pdam;
     this->radius = radius;
     radialmultiplier = radmult;
     this->ownerDoNotDereference = owner;
+    this->player_fired = player_fired;
 }
 
 void MissileEffect::ApplyDamage(Unit *smaller) {
@@ -185,7 +186,7 @@ void MissileEffect::DoApplyDamage(Unit *parent, Unit *un, float distance, float 
         Damage damage(this->damage * damage_fraction * damage_left,
                 phasedamage * damage_fraction * damage_left);
         parent->ApplyDamage(pos.Cast(), norm, damage, un, GFXColor(1, 1, 1, 1),
-                ownerDoNotDereference);
+                ownerDoNotDereference, player_fired);
     }
 }
 
@@ -203,7 +204,8 @@ Missile::Missile(const char *filename,
         float time,
         float radialeffect,
         float radmult,
-        float detonation_radius) :
+        float detonation_radius,
+        bool player_fired) :
         Unit(filename, false, faction, modifications),
         time(time),
         damage(damage),
@@ -213,7 +215,8 @@ Missile::Missile(const char *filename,
         detonation_radius(detonation_radius),
         discharged(false),
         retarget(-1),
-        had_target(false) {
+        had_target(false),
+        player_fired(player_fired) {
 }
 
 void Missile::Discharge() {
@@ -223,7 +226,7 @@ void Missile::Discharge() {
                 % ((target != NULL) ? target->name.get() : "NULL")));
         _Universe->activeStarSystem()->AddMissileToQueue(
                 new MissileEffect(Position(), damage, phasedamage,
-                        radial_effect, radial_multiplier, owner));
+                        radial_effect, radial_multiplier, owner, player_fired));
         discharged = true;
     }
 }

--- a/engine/src/cmd/missile.h
+++ b/engine/src/cmd/missile.h
@@ -39,9 +39,10 @@ private:
     float radius;
     float radialmultiplier;
     void *ownerDoNotDereference;
+    bool player_fired;
 
 public:
-    MissileEffect(const QVector &pos, float dam, float pdam, float radius, float radmult, void *owner);
+    MissileEffect(const QVector &pos, float dam, float pdam, float radius, float radmult, void *owner, bool player_fired);
     void ApplyDamage(Unit *);
     const QVector &GetCenter() const;
     float GetRadius() const;
@@ -61,6 +62,7 @@ protected:
     bool discharged;
     bool had_target;
     signed char retarget;
+    bool player_fired;
 public:
     Missile(const char *filename,
             int faction,
@@ -70,7 +72,8 @@ public:
             float time,
             float radialeffect,
             float radmult,
-            float detonation_radius);
+            float detonation_radius,
+            bool player_fired);
 
     Missile(std::vector<Mesh *> m, bool b, int i) : Unit(m, b, i), time(0.0F), damage(0.0F), phasedamage(0.0F), radial_effect(0.0F),
                                                     radial_multiplier(0.0F),

--- a/libraries/cmd/carrier.cpp
+++ b/libraries/cmd/carrier.cpp
@@ -219,7 +219,8 @@ void Carrier::EjectCargo(unsigned int index) {
                                     ejectcargotime,
                                     1,
                                     1,
-                                    1);
+                                    1, 
+                                    unit->IsPlayerShip());
                         }
                     }
                     arot = erot;
@@ -242,7 +243,8 @@ void Carrier::EjectCargo(unsigned int index) {
                             cargotime,
                             1,
                             1,
-                            1);
+                            1, 
+                            unit->IsPlayerShip());
                     arot = rot;
                 }
             }
@@ -255,7 +257,8 @@ void Carrier::EjectCargo(unsigned int index) {
                         cargotime,
                         1,
                         1,
-                        1);
+                        1, 
+                        unit->IsPlayerShip());
                 arot = grot;
             }
             Vector rotation

--- a/libraries/cmd/damageable.h
+++ b/libraries/cmd/damageable.h
@@ -68,7 +68,8 @@ public:
             Damage damage,
             Unit *affected_unit,
             const GFXColor &color,
-            void *ownerDoNotDereference);
+            void *ownerDoNotDereference,
+            bool shooter_is_player = false);
     void DamageRandomSystem(InflictedDamage inflicted_damage, bool player, Vector attack_vector);
     void DamageCargo(InflictedDamage inflicted_damage);
     void Destroy() override; //explodes then deletes

--- a/libraries/cmd/mount.cpp
+++ b/libraries/cmd/mount.cpp
@@ -308,13 +308,14 @@ bool Mount::PhysicsAlignedFire(Unit *caller,
                         mat,
                         velocity,
                         owner,
+                        caller->IsPlayerShip(),
                         hint[Unit::UNIT_BOLT]).location;             //FIXME turrets won't work! Velocity
                 break;
 
             case WEAPON_TYPE::BALL: {
                 caller->energy.Deplete(true, type->energy_rate);
-                hint[Unit::UNIT_BOLT] =
-                        BoltDrawManager::GetInstance().AddBall(type, mat, velocity, owner, hint[Unit::UNIT_BOLT]);
+                hint[Unit::UNIT_BOLT] = BoltDrawManager::GetInstance().AddBall(
+                    type, mat, velocity, owner, caller->IsPlayerShip(), hint[Unit::UNIT_BOLT]);
                 break;
             }
             case WEAPON_TYPE::PROJECTILE:
@@ -331,7 +332,8 @@ bool Mount::PhysicsAlignedFire(Unit *caller,
                             type->range / type->speed,
                             type->radius,
                             type->radial_speed,
-                            type->pulse_speed /*detonation_radius*/);
+                            type->pulse_speed, /*detonation_radius*/
+                            caller->IsPlayerShip());
                     if (!match_speed_with_target) {
                         temp->drive.speed = type->speed + velocity.Magnitude();
                         temp->afterburner.speed = type->speed + velocity.Magnitude();

--- a/libraries/cmd/unit_functions_generic.cpp
+++ b/libraries/cmd/unit_functions_generic.cpp
@@ -97,7 +97,7 @@ Unit *CreateGameTurret(std::string tur, int faction) {
 }
 
 //un scored a faction kill
-void ScoreKill(Cockpit *cp, Unit *un, Unit *killedUnit) {
+void ScoreKill(bool killer_is_player, Unit *un, Unit *killedUnit) {
     if (un->getUnitType() != Vega_UnitType::unit || killedUnit->getUnitType() != Vega_UnitType::unit) {
         return;
     }
@@ -128,8 +128,11 @@ void ScoreKill(Cockpit *cp, Unit *un, Unit *killedUnit) {
     }
     int upgrades = FactionUtil::GetUpgradeFaction();
     int planets = FactionUtil::GetPlanetFaction();
-    if (cp != NULL) {
-        vector<float> *killlist = &cp->savegame->getMissionData(string("kills"));
+
+    // Killer is player
+    if (killer_is_player) {
+        Cockpit* cockpit = _Universe->AccessCockpit();
+        vector<float> *killlist = &cockpit->savegame->getMissionData(string("kills"));
         while (killlist->size() <= FactionUtil::GetNumFactions()) {
             killlist->push_back((float) 0.0);
         }

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -1609,7 +1609,7 @@ bool Unit::Explode(bool drawit, float timeit) {
                     this->ExplosionRadius()
                             * configuration().physics.explosion_damage_center_flt
                             * configuration().physics.explosion_damage_edge_flt,
-                    NULL));
+                    NULL, false));
         }
         QVector exploc = this->cumulative_transformation.position;
         bool sub = this->isSubUnit();

--- a/libraries/gfx_generic/boltdrawmanager.cpp
+++ b/libraries/gfx_generic/boltdrawmanager.cpp
@@ -125,8 +125,10 @@ CollideMap::iterator BoltDrawManager::AddBall(const WeaponInfo *typ,
         const Matrix &orientationpos,
         const Vector &shipspeed,
         void *owner,
+        bool player_fired,
         CollideMap::iterator hint) {
-    Bolt ball = Bolt(typ, orientationpos, shipspeed, owner, hint);             //FIXME turrets won't work! Velocity
+    //FIXME turrets won't work! Velocity
+    Bolt ball = Bolt(typ, orientationpos, shipspeed, owner, player_fired, hint);
     _balls.push_back(ball);
     return _balls[_balls.size() - 1].location;
 }

--- a/libraries/gfx_generic/boltdrawmanager.h
+++ b/libraries/gfx_generic/boltdrawmanager.h
@@ -59,6 +59,7 @@ public:
             const Matrix &orientationpos,
             const Vector &shipspeed,
             void *owner,
+            bool player_fired,
             CollideMap::iterator hint);
 
     static void Draw();


### PR DESCRIPTION
- Add player_fired bools throughout.
- Get the player unit from the cockpit singleton, bypassing using the invalid void *ownerDoNotDereference.
- Fix bug where target is null and calling target->isPlayerShip seg-faults the game.

Fix #1336 


**Code Changes:**
- [x] Have the PR Validation Tests been run? 

**Issues:**
- None identified.

