### PR TITLE
Parallelize MS builds on 0.9.x

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -312,6 +312,7 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/FI${Vega_Strike_BINARY_DIR}/conf
         "$<$<CXX_COMPILER_ID:MSVC>:/wd4244>"
         "$<$<CXX_COMPILER_ID:MSVC>:/wd4267>"
         "$<$<CXX_COMPILER_ID:MSVC>:/wd4305>"
+        "$<$<CXX_COMPILER_ID:MSVC>:/MP>"
         "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:/Z7>"
         )
 add_link_options("$<$<CXX_COMPILER_ID:MSVC>:/DEBUG>")


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] This is a CI/build system change only

Issues:
- Closes #1399 

Purpose:
- What is this pull request trying to do? Speed up the Microsoft Visual Studio builds of the project by parallelizing them.
- What release is this for? 0.9.x
- Is there a project or milestone we should apply this to? 0.9.x
