### PR TITLE
Windows CI workflows: Clean up caching logic a bit

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -68,7 +68,6 @@ jobs:
 
       - name: run-vcpkg
         uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
-        if: steps.cache-vcpkg-restore.outputs.cache-hit != 'true'
         env:
           Python3_ROOT_DIR: ${{ steps.vega-py-setup.outputs.python-path }}
           Python_ROOT_DIR: ${{ steps.vega-py-setup.outputs.python-path }}

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -83,7 +83,6 @@ jobs:
 
       - name: run-vcpkg
         uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
-        if: steps.cache-vcpkg-restore.outputs.cache-hit != 'true'
         env:
           Python3_ROOT_DIR: ${{ steps.vega-py-setup.outputs.python-path }}
           Python_ROOT_DIR: ${{ steps.vega-py-setup.outputs.python-path }}


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] This is a CI/build system change only

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Clean up the Windows caching logic in the CI a bit
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
