### PR TITLE
Root CMakeLists.txt: Don't download SDL3 or SDL3_image by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ IF (DEFINED ENV{USE_GTEST})
     ENDIF ()
 ENDIF ()
 
-OPTION(INSTALL_SDL3 "Should we download and install SDL3 using FetchContent_MakeAvailable?" ON)
+OPTION(INSTALL_SDL3 "Should we download and install SDL3 using FetchContent_MakeAvailable?" OFF)
 
 # Check if an environment variable with the same name exists
 # and override the option's value if it does.
@@ -393,7 +393,7 @@ IF (DEFINED ENV{INSTALL_SDL3})
     ENDIF ()
 ENDIF ()
 
-OPTION(INSTALL_SDL3_IMAGE "Should we download and install SDL3_image using FetchContent_MakeAvailable?" ON)
+OPTION(INSTALL_SDL3_IMAGE "Should we download and install SDL3_image using FetchContent_MakeAvailable?" OFF)
 
 # Check if an environment variable with the same name exists
 # and override the option's value if it does.


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] (Briefly) Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Change the CMake defaults to not download SDL3 or SDL3_image via FetchContent by default, as requested
- What release is this for? 0.10.x (SDL3 variant)
- Is there a project or milestone we should apply this to? 0.10.x
