### PR TITLE
Fix bug 1477

### DIFF
--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -2085,6 +2085,7 @@ bool BaseComputer::isTransactionOK(const Cargo &originalItem, TransactionType tr
     Unit *baseUnit = m_base.GetUnit();
     bool havemoney = true;
     bool havespace = true;
+    bool upgrade_already_installed = false;
     switch (transType) {
         case BUY_CARGO:
             //Enough credits and room for the item in the ship.
@@ -2132,15 +2133,15 @@ bool BaseComputer::isTransactionOK(const Cargo &originalItem, TransactionType tr
             //cargo.mission == true means you can't do the transaction.
             havemoney = item.GetPrice() * quantity <= ComponentsManager::credits;
             havespace = (playerUnit->upgrade_space.CanAddCargo(item) || upgradeNotAddedToCargo(item.GetCategory()));
-
+            upgrade_already_installed = playerUnit->UpgradeAlreadyInstalled(item);
             //UpgradeAllowed must be first -- short circuit && operator
-            if (UpgradeAllowed(item, playerUnit) && havemoney && havespace && !item.IsMissionFlag()) {
+            if (UpgradeAllowed(item, playerUnit) && havemoney && havespace && !upgrade_already_installed &&!item.IsMissionFlag()) {
                 return true;
             } else {
                 if (!havemoney) {
                     color_insufficient_money_flag = true;
                 }
-                if (!havespace) {
+                if (!havespace || upgrade_already_installed) {
                     color_insufficient_space_flag = true;
                 }
             }

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -217,6 +217,18 @@ bool ComponentsManager::AllowedUpgrade(const Cargo& upgrade) const {
     return true;
 }
 
+bool ComponentsManager::UpgradeAlreadyInstalled(const Cargo& upgrade) const {
+    const ComponentType component_type = GetComponentTypeFromName(upgrade.GetName());
+    const Component *component = GetComponentByType(component_type);
+    if(component) {
+        return component->Installed();
+    }
+
+    // Note that this method returns true for error, so we err on the side of caution
+    // and not install an upgrade.
+    return true;
+}
+
 /** A convenience struct to hold the data used below */
 struct HudText {
     const Component *component;
@@ -411,6 +423,12 @@ bool ComponentsManager::_Sell(CargoHold *hold, ComponentsManager *buyer, Cargo *
 }
 
 Component* ComponentsManager::GetComponentByType(const ComponentType type) {
+    return const_cast<Component*>(
+        static_cast<const ComponentsManager&>(*this).GetComponentByType(type)
+    );
+}
+
+const Component* ComponentsManager::GetComponentByType(const ComponentType type) const {
     switch(type) {
         case ComponentType::Hull: return &hull;
         case ComponentType::Armor: return &armor;

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -123,6 +123,7 @@ public:
 
     bool ShipDamaged() const;
     bool AllowedUpgrade(const Cargo& upgrade) const;
+    bool UpgradeAlreadyInstalled(const Cargo& upgrade) const;
     void DamageRandomSystem();
     void GenerateHudText(std::string getDamageColor(double));
     std::string GetHudText();
@@ -135,6 +136,7 @@ public:
     bool SellUpgrade(ComponentsManager *seller, Cargo *item, int quantity);
 
     Component* GetComponentByType(const ComponentType type);
+    const Component* GetComponentByType(const ComponentType type) const;
 private:
     bool _Buy(CargoHold *hold, ComponentsManager *seller, Cargo *item, int quantity);
     bool _Sell(CargoHold *hold, ComponentsManager *buyer, Cargo *item, int quantity);


### PR DESCRIPTION
Check we don't have upgrades of this type (e.g. capacitors) installed.

Co-authored by ChatGPT - avoid code duplication in const/non-const identical methods.

**Code Changes:**
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation. Tested the issue only.


Issues:
- Some prohibited upgrades get red color and others purple. Not sure why.

