### PR TITLE
Update Copyright Headers to 2026 in Remaining Files (0.11.x)

### DIFF
--- a/doc/AUTHORS
+++ b/doc/AUTHORS
@@ -49,3 +49,12 @@ Bob Hedgewood
 
 NASA USGS
     * Planet textures
+
+Additional Developers not mentioned elsewhere
+-----------------------------------------
+
+Alex 'CubOfJudahsLion' Feterman
+
+Anth0rx
+
+Konstantinos Arvanitis

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,8 +1,10 @@
 ##
 # CMakeLists.txt
 #
+# Vega Strike - Space Simulation, Combat and Trading
 # Copyright (C) 2001-2023 Daniel Horn, pyramid3d, Stephen G. Tuggy,
 # Benjamen R. Meyer, and other Vega Strike contributors
+# Copyright (C) 2026 The Vega Strike Contributors
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #
@@ -10,16 +12,16 @@
 #
 # Vega Strike is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # Vega Strike is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 

--- a/doc/man/CMakeLists.txt
+++ b/doc/man/CMakeLists.txt
@@ -1,8 +1,10 @@
 ##
 # CMakeLists.txt
 #
+# Vega Strike - Space Simulation, Combat and Trading
 # Copyright (C) 2001-2023 Daniel Horn, pyramid3d, Stephen G. Tuggy,
 # Benjamen R. Meyer, and other Vega Strike contributors
+# Copyright (C) 2026 The Vega Strike Contributors
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #
@@ -10,16 +12,16 @@
 #
 # Vega Strike is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # Vega Strike is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -2,12 +2,10 @@
 # CMakeLists.txt
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
-# Original development team: As listed in the AUTHORS file. Specifically:
-# safemode, Anth0rx, pyramid, Nachum Barcohen, Rune Morling
+# Original development team: As listed in the AUTHORS file. Specifically: safemode, Anth0rx, pyramid, Nachum Barcohen, Rune Morling
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/cmake-config.h.in
+++ b/engine/cmake-config.h.in
@@ -2,11 +2,10 @@
  * cmake-config.h.in
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/datascripts/convertbfxm.sh
+++ b/engine/datascripts/convertbfxm.sh
@@ -3,11 +3,10 @@
 # convertbfxm.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/datascripts/fixmusic.sh
+++ b/engine/datascripts/fixmusic.sh
@@ -3,11 +3,10 @@
 # fixmusic.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/datascripts/m3uloki_add.sh
+++ b/engine/datascripts/m3uloki_add.sh
@@ -3,11 +3,10 @@
 # m3uloki_add.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/launcher/general.cpp
+++ b/engine/launcher/general.cpp
@@ -2,11 +2,10 @@
  * general.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/launcher/general.h
+++ b/engine/launcher/general.h
@@ -2,11 +2,10 @@
  * general.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/launcher/resource.h
+++ b/engine/launcher/resource.h
@@ -2,11 +2,10 @@
  * resource.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/launcher/saveinterface.cpp
+++ b/engine/launcher/saveinterface.cpp
@@ -2,11 +2,10 @@
  * saveinterface.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Rune Morling
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/c/select.cpp
+++ b/engine/mission/c/select.cpp
@@ -2,11 +2,10 @@
  * select.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/central.cpp
+++ b/engine/mission/include/central.cpp
@@ -2,11 +2,10 @@
  * central.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/central.h
+++ b/engine/mission/include/central.h
@@ -2,11 +2,10 @@
  * central.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/display_gtk.cpp
+++ b/engine/mission/include/display_gtk.cpp
@@ -2,11 +2,10 @@
  * display_gtk.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/display_gtk.h
+++ b/engine/mission/include/display_gtk.h
@@ -2,11 +2,10 @@
  * display_gtk.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/easydom.cpp
+++ b/engine/mission/include/easydom.cpp
@@ -2,11 +2,10 @@
  * easydom.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/easydom.h
+++ b/engine/mission/include/easydom.h
@@ -2,11 +2,10 @@
  * easydom.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/file.cpp
+++ b/engine/mission/include/file.cpp
@@ -2,11 +2,10 @@
  * file.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/file.h
+++ b/engine/mission/include/file.h
@@ -2,11 +2,10 @@
  * file.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/general.cpp
+++ b/engine/mission/include/general.cpp
@@ -2,11 +2,10 @@
  * general.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/general.h
+++ b/engine/mission/include/general.h
@@ -2,11 +2,10 @@
  * general.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/hashtable.cpp
+++ b/engine/mission/include/hashtable.cpp
@@ -2,11 +2,10 @@
  * hashtable.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alan Shieh
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/hashtable.h
+++ b/engine/mission/include/hashtable.h
@@ -2,11 +2,10 @@
  * hashtable.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alan Shieh
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/xml_support.cpp
+++ b/engine/mission/include/xml_support.cpp
@@ -2,11 +2,10 @@
  * xml_support.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/mission/include/xml_support.h
+++ b/engine/mission/include/xml_support.h
@@ -2,11 +2,10 @@
  * xml_support.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/CMakeLists.txt
+++ b/engine/objconv/CMakeLists.txt
@@ -2,11 +2,10 @@
 # CMakeLists.txt
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/MeshParse/mesh_xml.cpp
+++ b/engine/objconv/MeshParse/mesh_xml.cpp
@@ -2,11 +2,10 @@
  * mesh_xml.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/MeshParse/template_generator.cpp
+++ b/engine/objconv/MeshParse/template_generator.cpp
@@ -2,11 +2,10 @@
  * template_generator.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/asteroidgen.cpp
+++ b/engine/objconv/asteroidgen.cpp
@@ -2,11 +2,10 @@
  * asteroidgen.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/asteroidgen.py
+++ b/engine/objconv/asteroidgen.py
@@ -2,11 +2,10 @@
 # asteroidgen.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/basemaker/base_maker.cpp
+++ b/engine/objconv/basemaker/base_maker.cpp
@@ -2,11 +2,10 @@
  * base_maker.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/basemaker/base_maker_texture.cpp
+++ b/engine/objconv/basemaker/base_maker_texture.cpp
@@ -2,11 +2,10 @@
  * base_maker_texture.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/basemaker/base_maker_texture.h
+++ b/engine/objconv/basemaker/base_maker_texture.h
@@ -2,11 +2,10 @@
  * base_maker_texture.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/basemaker/sprite.cpp
+++ b/engine/objconv/basemaker/sprite.cpp
@@ -1,6 +1,10 @@
 /*
+ * sprite.cpp
+ *
+ * Vega Strike - Space Simulation, Combat and Trading
  * Copyright (C) 2001-2022 Daniel Horn, pyramid3d, Stephen G. Tuggy,
  * and other Vega Strike contributors.
+ * Copyright (C) 2026 The Vega Strike Contributors
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *
@@ -17,7 +21,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+ * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 

--- a/engine/objconv/basemaker/sprite.h
+++ b/engine/objconv/basemaker/sprite.h
@@ -2,11 +2,10 @@
  * sprite.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/blender_xmesh_export.py
+++ b/engine/objconv/blender_xmesh_export.py
@@ -9,18 +9,18 @@
 # Copyright (C) 2021 daviewales
 # Copyright (C) 2025, 2026 Stephen G. Tuggy
 #
-# This file is free software: you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# This file is distributed in the hope that it will be useful,
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this file.  If not, see <https://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 

--- a/engine/objconv/blender_xmesh_export.py
+++ b/engine/objconv/blender_xmesh_export.py
@@ -3,11 +3,10 @@
 # blender_xmesh_export.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/blender_xmesh_export.py
+++ b/engine/objconv/blender_xmesh_export.py
@@ -2,28 +2,25 @@
 ##
 # blender_xmesh_export.py
 #
-# Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2026 The Vega Strike Contributors:
-# Project creator: Daniel Horn
-# Original development team: As listed in the AUTHORS file
-# Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+# Copyright (C) dandandaman
+# Copyright (C) 2007 ace123
+# Copyright (C) 2013 cellsafemode, klaussfreire
+# Copyright (C) 2020 pyramid3d
+# Copyright (C) 2021 daviewales
+# Copyright (C) 2025, 2026 Stephen G. Tuggy
 #
-# https://github.com/vegastrike/Vega-Strike-Engine-Source
-#
-# This file is part of Vega Strike.
-#
-# Vega Strike is free software: you can redistribute it and/or modify
+# This file is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Vega Strike is distributed in the hope that it will be useful,
+# This file is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+# along with this file.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 

--- a/engine/objconv/blender_xmesh_import.py
+++ b/engine/objconv/blender_xmesh_import.py
@@ -2,28 +2,26 @@
 ##
 # blender_xmesh_import.py
 #
-# Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2026 The Vega Strike Contributors:
-# Project creator: Daniel Horn
-# Original development team: As listed in the AUTHORS file
-# Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+# xmesh_import.py | Python Script for Blender3D | imports a VegaStrike .xmesh
+# Copyright (C) 2005 Alex 'CubOfJudahsLion' Feterman, dandandaman
+# Copyright (C) 2007 ace123
+# Copyright (C) 2013 cellsafemode, klaussfreire
+# Copyright (C) 2020 pyramid3d
+# Copyright (C) 2025, 2026 Stephen G. Tuggy
 #
-# https://github.com/vegastrike/Vega-Strike-Engine-Source
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
 #
-# This file is part of Vega Strike.
-#
-# Vega Strike is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Vega Strike is distributed in the hope that it will be useful,
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+# along with this program; if not, see
+# <https://www.gnu.org/licenses/>.
 #
 """
 Name: 'VegaStrike (.xmesh)...'

--- a/engine/objconv/blender_xmesh_import.py
+++ b/engine/objconv/blender_xmesh_import.py
@@ -1,5 +1,30 @@
 #!BPY
-
+##
+# blender_xmesh_import.py
+#
+# Vega Strike - Space Simulation, Combat and Trading
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
+# Project creator: Daniel Horn
+# Original development team: As listed in the AUTHORS file
+# Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+#
+# https://github.com/vegastrike/Vega-Strike-Engine-Source
+#
+# This file is part of Vega Strike.
+#
+# Vega Strike is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Vega Strike is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+#
 """
 Name: 'VegaStrike (.xmesh)...'
 Blender: 237

--- a/engine/objconv/blender_xmesh_import.txt
+++ b/engine/objconv/blender_xmesh_import.txt
@@ -1,11 +1,15 @@
 0. LICENSING AND DISTRIBUTION
 
 xmesh_import.py | Python Script for Blender3D | imports a VegaStrike .xmesh
-Copyright (C)2005 Alex Feterman
+Copyright (C) 2005 Alex 'CubOfJudahsLion' Feterman, dandandaman
+Copyright (C) 2007 ace123
+Copyright (C) 2013 cellsafemode, klaussfreire
+Copyright (C) 2020 pyramid3d
+Copyright (C) 2025, 2026 Stephen G. Tuggy
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
+as published by the Free Software Foundation; either version 3
 of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
@@ -14,8 +18,8 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+along with this program; if not, see
+<https://www.gnu.org/licenses/>.
 
 (In a nutshell: you're free to contribute and distribute, but
 never to profit from this utility.)

--- a/engine/objconv/cargoconvert.cpp
+++ b/engine/objconv/cargoconvert.cpp
@@ -2,11 +2,10 @@
  * cargoconvert.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/configparser.py
+++ b/engine/objconv/configparser.py
@@ -3,11 +3,10 @@
 # configparser.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file. Specifically: Daniel Aleksandrow
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/csv.py
+++ b/engine/objconv/csv.py
@@ -2,11 +2,10 @@
 # csv.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/csvexport.py
+++ b/engine/objconv/csvexport.py
@@ -3,11 +3,10 @@
 # csvexport.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file. Specifically: geoscope
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/csvimport.py
+++ b/engine/objconv/csvimport.py
@@ -3,11 +3,10 @@
 # csvimport.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file. Specifically: geoscope
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/dattoxml.cpp
+++ b/engine/objconv/dattoxml.cpp
@@ -2,11 +2,10 @@
  * dattoxml.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/flipunits/flipunits.sh
+++ b/engine/objconv/flipunits/flipunits.sh
@@ -3,11 +3,10 @@
 # flipunits.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/flipunits/rotateunits.sh
+++ b/engine/objconv/flipunits/rotateunits.sh
@@ -3,11 +3,10 @@
 # rotateunits.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/hashtest.cpp
+++ b/engine/objconv/hashtest.cpp
@@ -2,11 +2,10 @@
  * hashtest.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/imageproc/alphaextender.cpp
+++ b/engine/objconv/imageproc/alphaextender.cpp
@@ -2,11 +2,10 @@
  * alphaextender.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/imageproc/change_channels.cpp
+++ b/engine/objconv/imageproc/change_channels.cpp
@@ -2,11 +2,10 @@
  * change_channels.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/imageproc/mover.cpp
+++ b/engine/objconv/imageproc/mover.cpp
@@ -2,11 +2,10 @@
  * mover.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/imageproc/normalmap.cpp
+++ b/engine/objconv/imageproc/normalmap.cpp
@@ -2,11 +2,10 @@
  * normalmap.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/imageproc/shrinker.cpp
+++ b/engine/objconv/imageproc/shrinker.cpp
@@ -2,11 +2,10 @@
  * shrinker.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/imageproc/starremover.cpp
+++ b/engine/objconv/imageproc/starremover.cpp
@@ -2,11 +2,10 @@
  * starremover.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/CMakeLists.txt
+++ b/engine/objconv/mesher/CMakeLists.txt
@@ -2,11 +2,10 @@
 # CMakeLists.txt
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/mesher/Converter.cpp
+++ b/engine/objconv/mesher/Converter.cpp
@@ -2,11 +2,10 @@
  * Converter.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Converter.h
+++ b/engine/objconv/mesher/Converter.h
@@ -2,11 +2,10 @@
  * Converter.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/BFXM_to_Wavefront.cpp
+++ b/engine/objconv/mesher/Modules/BFXM_to_Wavefront.cpp
@@ -2,11 +2,10 @@
  * BFXM_to_Wavefront.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/BFXM_to_XMesh.cpp
+++ b/engine/objconv/mesher/Modules/BFXM_to_XMesh.cpp
@@ -2,11 +2,10 @@
  * BFXM_to_XMesh.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/Convert.cpp
+++ b/engine/objconv/mesher/Modules/Convert.cpp
@@ -2,11 +2,10 @@
  * Convert.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/Dims.cpp
+++ b/engine/objconv/mesher/Modules/Dims.cpp
@@ -2,11 +2,10 @@
  * Dims.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/OldSyntax.cpp
+++ b/engine/objconv/mesher/Modules/OldSyntax.cpp
@@ -2,11 +2,10 @@
  * OldSyntax.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/Wavefront_to_BFXM.cpp
+++ b/engine/objconv/mesher/Modules/Wavefront_to_BFXM.cpp
@@ -2,11 +2,10 @@
  * Wavefront_to_BFXM.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/XMesh_to_BFXM.cpp
+++ b/engine/objconv/mesher/Modules/XMesh_to_BFXM.cpp
@@ -2,11 +2,10 @@
  * XMesh_to_BFXM.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/Modules/XMesh_to_Ogre.cpp
+++ b/engine/objconv/mesher/Modules/XMesh_to_Ogre.cpp
@@ -2,11 +2,10 @@
  * XMesh_to_Ogre.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/PrecompiledHeaders/Converter.cpp
+++ b/engine/objconv/mesher/PrecompiledHeaders/Converter.cpp
@@ -2,11 +2,10 @@
  * Converter.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/PrecompiledHeaders/Converter.h
+++ b/engine/objconv/mesher/PrecompiledHeaders/Converter.h
@@ -2,11 +2,10 @@
  * Converter.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/PrecompiledHeaders/Standard.h
+++ b/engine/objconv/mesher/PrecompiledHeaders/Standard.h
@@ -2,11 +2,10 @@
  * Standard.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/from_BFXM.cpp
+++ b/engine/objconv/mesher/from_BFXM.cpp
@@ -2,11 +2,10 @@
  * from_BFXM.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/from_BFXM.h
+++ b/engine/objconv/mesher/from_BFXM.h
@@ -2,11 +2,10 @@
  * from_BFXM.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/from_obj.cpp
+++ b/engine/objconv/mesher/from_obj.cpp
@@ -2,11 +2,10 @@
  * from_obj.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/from_obj.h
+++ b/engine/objconv/mesher/from_obj.h
@@ -2,11 +2,10 @@
  * from_obj.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/mesh.h
+++ b/engine/objconv/mesher/mesh.h
@@ -2,11 +2,10 @@
  * mesh.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/mesh_io.h
+++ b/engine/objconv/mesher/mesh_io.h
@@ -2,11 +2,10 @@
  * mesh_io.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/to_BFXM.cpp
+++ b/engine/objconv/mesher/to_BFXM.cpp
@@ -2,11 +2,10 @@
  * to_BFXM.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/to_BFXM.h
+++ b/engine/objconv/mesher/to_BFXM.h
@@ -2,11 +2,10 @@
  * to_BFXM.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/to_OgreMesh.cpp
+++ b/engine/objconv/mesher/to_OgreMesh.cpp
@@ -2,11 +2,10 @@
  * to_OgreMesh.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/to_OgreMesh.h
+++ b/engine/objconv/mesher/to_OgreMesh.h
@@ -2,11 +2,10 @@
  * to_OgreMesh.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/to_obj.cpp
+++ b/engine/objconv/mesher/to_obj.cpp
@@ -2,11 +2,10 @@
  * to_obj.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mesher/to_obj.h
+++ b/engine/objconv/mesher/to_obj.h
@@ -2,11 +2,10 @@
  * to_obj.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/missionpriceadj.cpp
+++ b/engine/objconv/missionpriceadj.cpp
@@ -2,11 +2,10 @@
  * missionpriceadj.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/mplconvert.py
+++ b/engine/objconv/mplconvert.py
@@ -2,11 +2,10 @@
 # mplconvert.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/objscale.cpp
+++ b/engine/objconv/objscale.cpp
@@ -2,11 +2,10 @@
  * objscale.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/planetMakerHelper.py
+++ b/engine/objconv/planetMakerHelper.py
@@ -2,11 +2,10 @@
 # planetMakerHelper.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/replace.cpp
+++ b/engine/objconv/replace.cpp
@@ -2,11 +2,10 @@
  * replace.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/scramble.cpp
+++ b/engine/objconv/scramble.cpp
@@ -2,11 +2,10 @@
  * scramble.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/starCodes.py
+++ b/engine/objconv/starCodes.py
@@ -2,11 +2,10 @@
 # starCodes.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/starSystemPlanetMaker.py
+++ b/engine/objconv/starSystemPlanetMaker.py
@@ -2,11 +2,10 @@
 # starSystemPlanetMaker.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/starsystemgen/starsysgen.cpp
+++ b/engine/objconv/starsystemgen/starsysgen.cpp
@@ -2,11 +2,10 @@
  * starsysgen.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/starsystemreader/readstarsystem.cpp
+++ b/engine/objconv/starsystemreader/readstarsystem.cpp
@@ -2,11 +2,10 @@
  * readstarsystem.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/trisort.cpp
+++ b/engine/objconv/trisort.cpp
@@ -2,11 +2,10 @@
  * trisort.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/trisort.h
+++ b/engine/objconv/trisort.h
@@ -2,11 +2,10 @@
  * trisort.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/ucsv.py
+++ b/engine/objconv/ucsv.py
@@ -2,11 +2,10 @@
 # ucsv.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/objconv/varray.cpp
+++ b/engine/objconv/varray.cpp
@@ -2,11 +2,10 @@
  * varray.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/objconv/wcSystemReader.py
+++ b/engine/objconv/wcSystemReader.py
@@ -3,11 +3,10 @@
 # wcSystemReader.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/saveinterface/autoupdater.cpp
+++ b/engine/saveinterface/autoupdater.cpp
@@ -2,11 +2,10 @@
  * autoupdater.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/saveinterface/build
+++ b/engine/saveinterface/build
@@ -3,8 +3,10 @@
 ##
 # build
 #
+# Vega Strike - Space Simulation, Combat and Trading
 # Copyright (c) 2001-2022 Daniel Horn, pyramid3d, Stephen G. Tuggy, 
 # and other Vega Strike Contributors
+# Copyright (C) 2026 The Vega Strike Contributors
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #
@@ -12,7 +14,7 @@
 #
 # Vega Strike is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # Vega Strike is distributed in the hope that it will be useful,
@@ -21,7 +23,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 #thank you Thunderbird@#nvidia

--- a/engine/setup/CMakeLists.txt
+++ b/engine/setup/CMakeLists.txt
@@ -2,11 +2,10 @@
 # CMakeLists.txt
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/setup/resource.h
+++ b/engine/setup/resource.h
@@ -2,11 +2,10 @@
  * resource.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/c/setup.cpp
+++ b/engine/setup/src/c/setup.cpp
@@ -2,11 +2,10 @@
  * setup.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/central.cpp
+++ b/engine/setup/src/include/central.cpp
@@ -2,11 +2,10 @@
  * central.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/central.h
+++ b/engine/setup/src/include/central.h
@@ -2,11 +2,10 @@
  * central.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/display.h
+++ b/engine/setup/src/include/display.h
@@ -2,11 +2,10 @@
  * display.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/display_dialog.cpp
+++ b/engine/setup/src/include/display_dialog.cpp
@@ -2,11 +2,10 @@
  * display_dialog.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/display_gtk.cpp
+++ b/engine/setup/src/include/display_gtk.cpp
@@ -2,11 +2,10 @@
  * display_gtk.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/dont_link/display_console.cpp
+++ b/engine/setup/src/include/dont_link/display_console.cpp
@@ -2,11 +2,10 @@
  * display_console.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/dont_link/display_console.h
+++ b/engine/setup/src/include/dont_link/display_console.h
@@ -2,11 +2,10 @@
  * display_console.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/file.cpp
+++ b/engine/setup/src/include/file.cpp
@@ -2,11 +2,10 @@
  * file.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/file.h
+++ b/engine/setup/src/include/file.h
@@ -2,11 +2,10 @@
  * file.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/general.cpp
+++ b/engine/setup/src/include/general.cpp
@@ -2,11 +2,10 @@
  * general.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/include/general.h
+++ b/engine/setup/src/include/general.h
@@ -2,11 +2,10 @@
  * general.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/setup/src/macbuild.sh
+++ b/engine/setup/src/macbuild.sh
@@ -2,11 +2,10 @@
 # macbuild.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/SharedPool.cpp
+++ b/engine/src/SharedPool.cpp
@@ -2,11 +2,10 @@
  * SharedPool.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/SharedPool.h
+++ b/engine/src/SharedPool.h
@@ -2,11 +2,10 @@
  * SharedPool.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/Singleton.h
+++ b/engine/src/Singleton.h
@@ -2,11 +2,10 @@
  * Singleton.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/accountserver.cpp
+++ b/engine/src/accountserver.cpp
@@ -2,11 +2,10 @@
  * accountserver.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/audiolib.h
+++ b/engine/src/audiolib.h
@@ -2,11 +2,10 @@
  * audiolib.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/buildlin.sh
+++ b/engine/src/buildlin.sh
@@ -2,11 +2,10 @@
 # buildlin.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/buildlin32.sh
+++ b/engine/src/buildlin32.sh
@@ -2,11 +2,10 @@
 # buildlin32.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/buildlin64.sh
+++ b/engine/src/buildlin64.sh
@@ -2,11 +2,10 @@
 # buildlin64.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/buildmac.sh
+++ b/engine/src/buildmac.sh
@@ -2,11 +2,10 @@
 # buildmac.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/buildmac.x11.sh
+++ b/engine/src/buildmac.x11.sh
@@ -1,9 +1,11 @@
 ##
 # buildmac.x11.sh
 #
+# Vega Strike - Space Simulation, Combat and Trading
 # Copyright (c) 2001-2002 Daniel Horn
 # Copyright (c) 2002-2019 pyramid3d and other Vega Strike Contributors
 # Copyright (c) 2019-2021 Stephen G. Tuggy, and other Vega Strike Contributors
+# Copyright (C) 2026 The Vega Strike Contributors
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #
@@ -11,7 +13,7 @@
 #
 # Vega Strike is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # Vega Strike is distributed in the hope that it will be useful,
@@ -20,7 +22,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Vega Strike. If not, see <https://www.gnu.org/licenses/>.
+# along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 g++    -pipe -O2  -Wall  -ffast-math -fomit-frame-pointer -fexpensive-optimizations    -o vegastrike star_system_generic.o universe_generic.o universe_util_generic.o galaxy.o galaxy_xml.o galaxy_gen.o faction_generic.o hashtable.o configxml.o easydom.o xml_serializer.o xml_support.o lin_time.o endianness.o faction_util.o load_mission.o savegame.o vs_path.o debug_vs.o gfxlib_struct.o in_joystick.o faction.o force_feedback.o in_kb.o in_sdl.o in_mouse.o in_main.o in_handler.o main_loop.o physics.o star_system_jump.o star_system_xml.o star_system.o universe.o universe_util.o config_xml.o macosx_math.o vs_globals.o main.o aldrv/libaldrv.a common/libvscommon.a networking/libnetclient.a cmd/script/script_call_briefing.o cmd/script/libscript.a cmd/script/c_alike/libc_alike.a python/briefing_wrapper.o cmd/libcmd.a cmd/base_init.o python/libpython.a gfx/libgfx.a cmd/ai/libai.a gldrv/libgldrv.a gui/libgui.a networking/libnet.a cmd/collide/libcollide.a boost129/libboost_python.a boost/libboost_python.a -lpthread  -lobjc /Users/daniel/Install/glut-3.7/lib/glut/glut_8x13.o /Users/daniel/Install/glut-3.7/lib/glut/glut_9x15.o /Users/daniel/Install/glut-3.7/lib/glut/glut_bitmap.o /Users/daniel/Install/glut-3.7/lib/glut/glut_bwidth.o /Users/daniel/Install/glut-3.7/lib/glut/glut_cindex.o /Users/daniel/Install/glut-3.7/lib/glut/glut_cmap.o /Users/daniel/Install/glut-3.7/lib/glut/glut_cursor.o /Users/daniel/Install/glut-3.7/lib/glut/glut_dials.o /Users/daniel/Install/glut-3.7/lib/glut/glut_dstr.o /Users/daniel/Install/glut-3.7/lib/glut/glut_event.o /Users/daniel/Install/glut-3.7/lib/glut/glut_ext.o /Users/daniel/Install/glut-3.7/lib/glut/glut_fullscrn.o /Users/daniel/Install/glut-3.7/lib/glut/glut_gamemode.o /Users/daniel/Install/glut-3.7/lib/glut/glut_get.o /Users/daniel/Install/glut-3.7/lib/glut/glut_glxext.o /Users/daniel/Install/glut-3.7/lib/glut/glut_hel10.o /Users/daniel/Install/glut-3.7/lib/glut/glut_hel12.o /Users/daniel/Install/glut-3.7/lib/glut/glut_hel18.o /Users/daniel/Install/glut-3.7/lib/glut/glut_init.o /Users/daniel/Install/glut-3.7/lib/glut/glut_input.o /Users/daniel/Install/glut-3.7/lib/glut/glut_joy.o /Users/daniel/Install/glut-3.7/lib/glut/glut_key.o /Users/daniel/Install/glut-3.7/lib/glut/glut_keyctrl.o /Users/daniel/Install/glut-3.7/lib/glut/glut_keyup.o /Users/daniel/Install/glut-3.7/lib/glut/glut_menu.o /Users/daniel/Install/glut-3.7/lib/glut/glut_menu2.o /Users/daniel/Install/glut-3.7/lib/glut/glut_mesa.o /Users/daniel/Install/glut-3.7/lib/glut/glut_modifier.o /Users/daniel/Install/glut-3.7/lib/glut/glut_mroman.o /Users/daniel/Install/glut-3.7/lib/glut/glut_overlay.o /Users/daniel/Install/glut-3.7/lib/glut/glut_roman.o /Users/daniel/Install/glut-3.7/lib/glut/glut_shapes.o /Users/daniel/Install/glut-3.7/lib/glut/glut_space.o /Users/daniel/Install/glut-3.7/lib/glut/glut_stroke.o /Users/daniel/Install/glut-3.7/lib/glut/glut_swap.o /Users/daniel/Install/glut-3.7/lib/glut/glut_swidth.o /Users/daniel/Install/glut-3.7/lib/glut/glut_tablet.o /Users/daniel/Install/glut-3.7/lib/glut/glut_teapot.o /Users/daniel/Install/glut-3.7/lib/glut/glut_tr10.o /Users/daniel/Install/glut-3.7/lib/glut/glut_tr24.o /Users/daniel/Install/glut-3.7/lib/glut/glut_util.o /Users/daniel/Install/glut-3.7/lib/glut/glut_vidresize.o /Users/daniel/Install/glut-3.7/lib/glut/glut_warp.o /Users/daniel/Install/glut-3.7/lib/glut/glut_win.o /Users/daniel/Install/glut-3.7/lib/glut/glut_winmisc.o /Users/daniel/Install/glut-3.7/lib/glut/layerutil.o  -L/usr/X11R6/lib/ -l GL -l GLU -lX11 -lXmu -lXi  /sw/lib/libexpat.a /sw/lib/libjpeg.a /sw/lib/python2.2/config/libpython2.2.a   /Users/daniel/Install/libpng-1.2.5/libpng.a /users/daniel/install/zlib/libz.a

--- a/engine/src/cg_global.cpp
+++ b/engine/src/cg_global.cpp
@@ -2,11 +2,10 @@
  * cg_global.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/cg_global.h
+++ b/engine/src/cg_global.h
@@ -2,11 +2,10 @@
  * cg_global.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/components/player_ship.cpp
+++ b/engine/src/components/player_ship.cpp
@@ -2,11 +2,10 @@
  * player_ship.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/components/player_ship.h
+++ b/engine/src/components/player_ship.h
@@ -2,11 +2,10 @@
  * player_ship.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/config_xml.cpp
+++ b/engine/src/config_xml.cpp
@@ -2,11 +2,10 @@
  * config_xml.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alexander Rawass
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/config_xml.h
+++ b/engine/src/config_xml.h
@@ -2,11 +2,10 @@
  * config_xml.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alexander Rawass
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/configuration/tests/configuration_tests.cpp
+++ b/engine/src/configuration/tests/configuration_tests.cpp
@@ -7,7 +7,6 @@
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy, David Wales
  *
- *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *
  * This file is part of Vega Strike.

--- a/engine/src/debug_vs.cpp
+++ b/engine/src/debug_vs.cpp
@@ -2,11 +2,10 @@
  * debug_vs.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/debug_vs.h
+++ b/engine/src/debug_vs.h
@@ -2,11 +2,10 @@
  * debug_vs.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/endianness.h
+++ b/engine/src/endianness.h
@@ -2,11 +2,10 @@
  * endianness.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/exit_unit_tests.cpp
+++ b/engine/src/exit_unit_tests.cpp
@@ -2,11 +2,10 @@
  * exit_unit_tests.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/faction_util.cpp
+++ b/engine/src/faction_util.cpp
@@ -2,11 +2,10 @@
  * faction_util.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/faction_util_server.cpp
+++ b/engine/src/faction_util_server.cpp
@@ -2,11 +2,10 @@
  * faction_util_server.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/fastmath.cpp
+++ b/engine/src/fastmath.cpp
@@ -2,11 +2,10 @@
  * fastmath.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/ffmpeg_init.cpp
+++ b/engine/src/ffmpeg_init.cpp
@@ -2,11 +2,10 @@
  * ffmpeg_init.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/ffmpeg_init.h
+++ b/engine/src/ffmpeg_init.h
@@ -2,11 +2,10 @@
  * ffmpeg_init.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/file_main.h
+++ b/engine/src/file_main.h
@@ -2,11 +2,10 @@
  * file_main.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/force_feedback.cpp
+++ b/engine/src/force_feedback.cpp
@@ -2,11 +2,10 @@
  * force_feedback.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alexander Rawass
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/force_feedback.h
+++ b/engine/src/force_feedback.h
@@ -2,11 +2,10 @@
  * force_feedback.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alexander Rawass
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/force_feedback_server.cpp
+++ b/engine/src/force_feedback_server.cpp
@@ -2,11 +2,10 @@
  * force_feedback_server.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/functors.h
+++ b/engine/src/functors.h
@@ -2,11 +2,10 @@
  * functors.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Matthew Adams
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/gfxlib.h
+++ b/engine/src/gfxlib.h
@@ -2,11 +2,10 @@
  * gfxlib.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/gfxlib_struct.cpp
+++ b/engine/src/gfxlib_struct.cpp
@@ -2,11 +2,10 @@
  * gfxlib_struct.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/gfxlib_struct.h
+++ b/engine/src/gfxlib_struct.h
@@ -2,11 +2,10 @@
  * gfxlib_struct.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/gfxlib_struct_server.cpp
+++ b/engine/src/gfxlib_struct_server.cpp
@@ -2,11 +2,10 @@
  * gfxlib_struct_server.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/gnuhash.h
+++ b/engine/src/gnuhash.h
@@ -2,11 +2,10 @@
  * gnuhash.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/hashtable.h
+++ b/engine/src/hashtable.h
@@ -2,11 +2,10 @@
  * hashtable.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alan Shieh
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/heap.h
+++ b/engine/src/heap.h
@@ -2,11 +2,10 @@
  * heap.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Claudio Freire
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in.h
+++ b/engine/src/in.h
@@ -2,11 +2,10 @@
  * in.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_handler.h
+++ b/engine/src/in_handler.h
@@ -2,11 +2,10 @@
  * in_handler.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alan Shieh
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -2,11 +2,10 @@
  * in_joystick.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alexander Rawass
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -2,11 +2,10 @@
  * in_joystick.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Alexander Rawass
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_kb.cpp
+++ b/engine/src/in_kb.cpp
@@ -2,11 +2,10 @@
  * in_kb.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_kb.h
+++ b/engine/src/in_kb.h
@@ -2,11 +2,10 @@
  * in_kb.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_kb_data.h
+++ b/engine/src/in_kb_data.h
@@ -2,11 +2,10 @@
  * in_kb_data.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_main.cpp
+++ b/engine/src/in_main.cpp
@@ -2,11 +2,10 @@
  * in_main.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_main.h
+++ b/engine/src/in_main.h
@@ -2,11 +2,10 @@
  * in_main.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_mouse.cpp
+++ b/engine/src/in_mouse.cpp
@@ -2,11 +2,10 @@
  * in_mouse.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_mouse.h
+++ b/engine/src/in_mouse.h
@@ -2,11 +2,10 @@
  * in_mouse.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/in_sdl.cpp
+++ b/engine/src/in_sdl.cpp
@@ -2,11 +2,10 @@
  * in_sdl.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/intel-mac-link.sh
+++ b/engine/src/intel-mac-link.sh
@@ -2,11 +2,10 @@
 # intel-mac-link.sh
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/junk.c
+++ b/engine/src/junk.c
@@ -2,11 +2,10 @@
  * junk.c
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/libaudioserver.cpp
+++ b/engine/src/libaudioserver.cpp
@@ -2,11 +2,10 @@
  * libaudioserver.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/libserver.cpp
+++ b/engine/src/libserver.cpp
@@ -2,11 +2,10 @@
  * libserver.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/linecollide.h
+++ b/engine/src/linecollide.h
@@ -2,11 +2,10 @@
  * linecollide.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/macquartz.cpp
+++ b/engine/src/macquartz.cpp
@@ -2,11 +2,10 @@
  * macquartz.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/main_loop.cpp
+++ b/engine/src/main_loop.cpp
@@ -2,11 +2,10 @@
  * main_loop.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/main_loop.h
+++ b/engine/src/main_loop.h
@@ -2,11 +2,10 @@
  * main_loop.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/physics.cpp
+++ b/engine/src/physics.cpp
@@ -2,11 +2,10 @@
  * physics.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/physics.h
+++ b/engine/src/physics.h
@@ -2,11 +2,10 @@
  * physics.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/profile.h
+++ b/engine/src/profile.h
@@ -2,11 +2,10 @@
  * profile.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/rendertext.cpp
+++ b/engine/src/rendertext.cpp
@@ -2,11 +2,10 @@
  * rendertext.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/rendertext.h
+++ b/engine/src/rendertext.h
@@ -2,11 +2,10 @@
  * rendertext.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/replaceall.py
+++ b/engine/src/replaceall.py
@@ -2,11 +2,10 @@
 # replaceall.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/src/resizable.h
+++ b/engine/src/resizable.h
@@ -2,11 +2,10 @@
  * resizable.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/save_util.h
+++ b/engine/src/save_util.h
@@ -2,11 +2,10 @@
  * save_util.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/sdl_key_converter.cpp
+++ b/engine/src/sdl_key_converter.cpp
@@ -2,11 +2,10 @@
  * sdl_key_converter.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/sdl_key_converter.h
+++ b/engine/src/sdl_key_converter.h
@@ -2,11 +2,10 @@
  * sdl_key_converter.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/star_system.cpp
+++ b/engine/src/star_system.cpp
@@ -2,11 +2,10 @@
  * star_system.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/star_system.h
+++ b/engine/src/star_system.h
@@ -2,11 +2,10 @@
  * star_system.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/star_system_jump.cpp
+++ b/engine/src/star_system_jump.cpp
@@ -2,11 +2,10 @@
  * star_system_jump.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/star_xml.h
+++ b/engine/src/star_xml.h
@@ -2,11 +2,10 @@
  * star_xml.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -2,11 +2,10 @@
  * universe.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -2,11 +2,10 @@
  * universe.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/universe_util.cpp
+++ b/engine/src/universe_util.cpp
@@ -2,11 +2,10 @@
  * universe_util.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/universe_util.h
+++ b/engine/src/universe_util.h
@@ -2,11 +2,10 @@
  * universe_util.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/universe_util_server.cpp
+++ b/engine/src/universe_util_server.cpp
@@ -2,11 +2,10 @@
  * universe_util_server.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vega_cast_utils.h
+++ b/engine/src/vega_cast_utils.h
@@ -2,11 +2,10 @@
  * vega_cast_utils.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vega_string_utils.h
+++ b/engine/src/vega_string_utils.h
@@ -2,11 +2,10 @@
  * vega_string_utils.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vegaserver.cpp
+++ b/engine/src/vegaserver.cpp
@@ -2,11 +2,10 @@
  * vegaserver.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file. Specifically: Stephane Vaxelaire
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vegastrike.h
+++ b/engine/src/vegastrike.h
@@ -2,11 +2,10 @@
  * vegastrike.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/version.h.in
+++ b/engine/src/version.h.in
@@ -2,11 +2,10 @@
  * version.h.in
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vs_exit.h
+++ b/engine/src/vs_exit.h
@@ -2,11 +2,10 @@
  * vs_exit.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vs_logging.cpp
+++ b/engine/src/vs_logging.cpp
@@ -2,11 +2,10 @@
  * vs_logging.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vs_logging.h
+++ b/engine/src/vs_logging.h
@@ -2,11 +2,10 @@
  * vs_logging.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/src/vs_math.h
+++ b/engine/src/vs_math.h
@@ -2,11 +2,10 @@
  * vs_math.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/stringsort.cpp
+++ b/engine/stringsort.cpp
@@ -2,11 +2,10 @@
  * stringsort.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/tools/cinemut-nm-decode.py
+++ b/engine/tools/cinemut-nm-decode.py
@@ -3,11 +3,10 @@
 # cinemut-nm-decode.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/tools/cinemut-nm-encode.py
+++ b/engine/tools/cinemut-nm-encode.py
@@ -3,11 +3,10 @@
 # cinemut-nm-encode.py
 #
 # Vega Strike - Space Simulation, Combat and Trading
-# Copyright (C) 2001-2025 The Vega Strike Contributors:
+# Copyright (C) 2001-2026 The Vega Strike Contributors:
 # Project creator: Daniel Horn
 # Original development team: As listed in the AUTHORS file
 # Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
-#
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #

--- a/engine/tools/common.cpp
+++ b/engine/tools/common.cpp
@@ -2,12 +2,10 @@
  * common.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically:
- * Konstantinos Arvanitis
+ * Original development team: As listed in the AUTHORS file. Specifically: Konstantinos Arvanitis
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/tools/common.h
+++ b/engine/tools/common.h
@@ -2,12 +2,10 @@
  * common.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically:
- * Konstantinos Arvanitis
+ * Original development team: As listed in the AUTHORS file. Specifically: Konstantinos Arvanitis
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/tools/vsrextract.cpp
+++ b/engine/tools/vsrextract.cpp
@@ -2,12 +2,10 @@
  * vsrextract.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically:
- * Konstantinos Arvanitis
+ * Original development team: As listed in the AUTHORS file. Specifically: Konstantinos Arvanitis
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/tools/vsrmake.cpp
+++ b/engine/tools/vsrmake.cpp
@@ -2,12 +2,10 @@
  * vsrmake.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically:
- * Konstantinos Arvanitis
+ * Original development team: As listed in the AUTHORS file. Specifically: Konstantinos Arvanitis
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/tools/vsrtools.h
+++ b/engine/tools/vsrtools.h
@@ -2,12 +2,10 @@
  * vsrtools.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically:
- * Konstantinos Arvanitis
+ * Original development team: As listed in the AUTHORS file. Specifically: Konstantinos Arvanitis
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/color/color.h
+++ b/engine/vs_cubemap_gen/src/color/color.h
@@ -2,11 +2,10 @@
  * color.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/command/command.h
+++ b/engine/vs_cubemap_gen/src/command/command.h
@@ -2,11 +2,10 @@
  * command.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/command/command_impl/command.cpp
+++ b/engine/vs_cubemap_gen/src/command/command_impl/command.cpp
@@ -2,11 +2,10 @@
  * command.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/errors/errors.h
+++ b/engine/vs_cubemap_gen/src/errors/errors.h
@@ -2,11 +2,10 @@
  * errors.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/file_io/file_io.h
+++ b/engine/vs_cubemap_gen/src/file_io/file_io.h
@@ -2,11 +2,10 @@
  * file_io.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/file_io/file_io_impl/file_io.cpp
+++ b/engine/vs_cubemap_gen/src/file_io/file_io_impl/file_io.cpp
@@ -2,11 +2,10 @@
  * file_io.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter.h
+++ b/engine/vs_cubemap_gen/src/filter/filter.h
@@ -2,11 +2,10 @@
  * filter.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter_impl/filter.cpp
+++ b/engine/vs_cubemap_gen/src/filter/filter_impl/filter.cpp
@@ -2,11 +2,10 @@
  * filter.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter_impl/filter_math.h
+++ b/engine/vs_cubemap_gen/src/filter/filter_impl/filter_math.h
@@ -2,11 +2,10 @@
  * filter_math.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter_impl/filter_one_texel.cpp
+++ b/engine/vs_cubemap_gen/src/filter/filter_impl/filter_one_texel.cpp
@@ -2,11 +2,10 @@
  * filter_one_texel.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter_impl/filter_one_texel.h
+++ b/engine/vs_cubemap_gen/src/filter/filter_impl/filter_one_texel.h
@@ -2,11 +2,10 @@
  * filter_one_texel.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter_impl/filter_settings.cpp
+++ b/engine/vs_cubemap_gen/src/filter/filter_impl/filter_settings.cpp
@@ -2,11 +2,10 @@
  * filter_settings.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/filter/filter_settings.h
+++ b/engine/vs_cubemap_gen/src/filter/filter_settings.h
@@ -2,11 +2,10 @@
  * filter_settings.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/first.h
+++ b/engine/vs_cubemap_gen/src/first.h
@@ -2,11 +2,10 @@
  * first.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/fvector/fvector.h
+++ b/engine/vs_cubemap_gen/src/fvector/fvector.h
@@ -2,11 +2,10 @@
  * fvector.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/fvector/fvector_impl/fvector.cpp
+++ b/engine/vs_cubemap_gen/src/fvector/fvector_impl/fvector.cpp
@@ -2,11 +2,10 @@
  * fvector.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/process/process.h
+++ b/engine/vs_cubemap_gen/src/process/process.h
@@ -2,11 +2,10 @@
  * process.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/settings/settings.h
+++ b/engine/vs_cubemap_gen/src/settings/settings.h
@@ -2,11 +2,10 @@
  * settings.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/mem_texture.h
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture.h
@@ -2,11 +2,10 @@
  * mem_texture.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/mem_texture_impl/coords.cpp
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture_impl/coords.cpp
@@ -2,11 +2,10 @@
  * coords.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/mem_texture_impl/coords.h
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture_impl/coords.h
@@ -2,11 +2,10 @@
  * coords.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/mem_texture_impl/mem_texture.cpp
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture_impl/mem_texture.cpp
@@ -2,11 +2,10 @@
  * mem_texture.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/mem_texture_impl/side.cpp
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture_impl/side.cpp
@@ -2,11 +2,10 @@
  * side.cpp
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/mem_texture_impl/side.h
+++ b/engine/vs_cubemap_gen/src/texture/mem_texture_impl/side.h
@@ -2,11 +2,10 @@
  * side.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/texture/texture_settings.h
+++ b/engine/vs_cubemap_gen/src/texture/texture_settings.h
@@ -2,11 +2,10 @@
  * texture_settings.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/engine/vs_cubemap_gen/src/units/units.h
+++ b/engine/vs_cubemap_gen/src/units/units.h
@@ -2,11 +2,10 @@
  * units.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
- * Copyright (C) 2001-2025 The Vega Strike Contributors:
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
  * Original development team: As listed in the AUTHORS file
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
- *
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *

--- a/script/add_gpl_license.py
+++ b/script/add_gpl_license.py
@@ -130,7 +130,7 @@ SCRIPT_LIKE_COMMENT_REGEX = re.compile(r'^ *#+( *)(.*)$')
 SHEBANG_REGEX = re.compile(r'^#!(.*)$')
 
 C_LIKE_COMMENTS = ['.c', '.cpp', '.h', '.hpp', '.h.in', '.yacc', '.lex']
-SCRIPT_LIKE_COMMENTS = ['.py', '.cmake', '.deprecated.cmake', '.txt', '.sh', '.ps1', '.yml', '.yaml']
+SCRIPT_LIKE_COMMENTS = ['.py', '.cmake', '.deprecated.cmake', '.txt', '.sh', '.ps1', '.yml', '.yaml', '.x11.sh']
 
 ROW_OF_EQUALS_SIGNS_REGEX = re.compile(r'^={5,200}$')
 ROW_OF_ASTERISKS_REGEX = re.compile(r'^\*{5,200}$')


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] This is a documentation change only

Issues:
- Finishes implementing #1512 for 0.11.x

Purpose:
- What is this pull request trying to do? Update the copyright headers in the rest of the source files
- What release is this for? 0.11.x
- Is there a project or milestone we should apply this to? 0.11.x
