### PR TITLE
0.10.x -- README: Enclose PowerShell commands in code blocks

### DIFF
--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           submodules: false

--- a/.github/workflows/Windows-CI.yml
+++ b/.github/workflows/Windows-CI.yml
@@ -83,7 +83,7 @@ jobs:
           update-environment: false
 
       - name: Install CMake
-        uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
+        uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "${SHORT_SHA}"
 
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           submodules: false
@@ -95,7 +95,7 @@ jobs:
           update-environment: false
 
       - name: Install CMake
-        uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
+        uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -133,7 +133,7 @@ jobs:
         if: steps.cache-vcpkg-restore.outputs.cache-hit != 'true'
 
       - name: Upload the artifacts
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -95,7 +95,7 @@ jobs:
           update-environment: false
 
       - name: Install CMake
-        uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
+        uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:
           fetch-depth: 2
 

--- a/.github/workflows/fortify-on-demand-scan.yml
+++ b/.github/workflows/fortify-on-demand-scan.yml
@@ -19,7 +19,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Fortify on Demand Scan
         # You may pin to the exact commit or the version.

--- a/.github/workflows/linux-pr.yml
+++ b/.github/workflows/linux-pr.yml
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           submodules: false

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           submodules: false

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: brew install bash
 
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           submodules: false

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -49,7 +49,7 @@ jobs:
         run: brew install bash
 
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           submodules: false

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -84,7 +84,7 @@ jobs:
         run: cpack -V --preset-name="package-${{ matrix.preset-name }}"
 
       - name: Upload the artifacts
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Check out code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ By default, the full clone will download over 800 MB of data. There are several 
 3. Do a shallow clone using the following:
 
 ```bash
-$ git clone git@github.com:vegastrike/Vega-Strike-Engine-Source.git --shallow-since=2023-09-27
+git clone git@github.com:vegastrike/Vega-Strike-Engine-Source.git --shallow-since=2023-09-27
 ```
 
 This will produce a significantly smaller download - in the order of 22-30 MB; well over a 10x reduction.
@@ -276,7 +276,25 @@ Vega Strike is now compiling on Windows! There are also installers available for
 
 To compile Vega Strike on Windows, start by installing either Visual Studio 2026 or just the Visual Studio 2026 Developer Tools. When selecting the Workloads and Components to install, include at least "C++ for Desktop" and a recent build of the Windows SDK. Probably Git and the GitHub for Windows extension also. Install the latest Visual Studio updates as well.
 
-Once the Visual Studio Installer finishes, reboot your computer. Then, find `Developer PowerShell for VS 2026` on the Start menu; alt-click it ("right-click"); and choose "Run as Administrator." Run `Set-ExecutionPolicy RemoteSigned` (or another suitable PowerShell Execution Policy of your choice). Type `Y` and press Enter to confirm. Exit PowerShell. Now reopen `Developer PowerShell for VS 2026`, this time without Admin privileges, and run `script/bootstrap.ps1`. Once that finishes, reboot your computer again. Finally, open `Developer PowerShell for VS 2026` one more time, and run `script/build.ps1 -PresetName VS2026Win64-pie-enabled-RelWithDebInfo -BuildType RelWithDebInfo`. (The build type can also be `Debug` or `Release`. Just make sure that it matches the build type stanza at the end of the preset name.)
+Once the Visual Studio Installer finishes, reboot your computer. Then, find `Developer PowerShell for VS 2026` on the Start menu; alt-click it ("right-click"); and choose "Run as Administrator." Run:
+
+```pwsh
+Set-ExecutionPolicy RemoteSigned
+```
+
+(or another suitable PowerShell Execution Policy of your choice). Type `Y` and press Enter to confirm. Exit PowerShell. Now reopen `Developer PowerShell for VS 2026`, this time without Admin privileges, and run:
+
+```pwsh
+script/bootstrap.ps1
+```
+
+Once that finishes, reboot your computer again. Finally, open `Developer PowerShell for VS 2026` one more time, and run:
+
+```pwsh
+script/build.ps1 -PresetName VS2026Win64-pie-enabled-RelWithDebInfo -BuildType RelWithDebInfo
+```
+
+(The build type can also be `Debug` or `Release`. Just make sure that it matches the build type stanza at the end of the preset name.)
 
 Assuming all the above steps succeed, you are now ready to run Vega Strike. Note that `vegasettings` is not currently building on Windows, so you will need to edit `vegastrike.config` manually as needed.
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] This is a documentation change only

Issues:
- ([peer review](https://github.com/vegastrike/Vega-Strike-Engine-Source/pull/1617#discussion_r3452300361))

Purpose:
- What is this pull request trying to do? Enclose PowerShell commands in the README in code blocks for readability, as per peer review on #1617 
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
