### PR TITLE
Fix 0.10.0 alpha installers

### DIFF
--- a/.github/workflows/Windows-Release.yml
+++ b/.github/workflows/Windows-Release.yml
@@ -28,11 +28,13 @@ jobs:
             preset-name:     VS2022Win64-pie-enabled-RelWithDebInfo
             python-version:  3.13.13
             is-release:      1
+            install-nsis:    0
           - os:              windows-2025-vs2026
             triplet:         x64-win10
             preset-name:     VS2026Win64-pie-enabled-RelWithDebInfo
             python-version:  3.13.13
             is-release:      1
+            install-nsis:    1
 
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -96,6 +98,12 @@ jobs:
 
       - name: Install CMake
         uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
+
+      - name: Install NSIS
+        if: ${{ matrix.install-nsis }}
+        uses: repolevedavaj/install-nsis@1ab2f7ba2fe9408db612029be0bb3c0088b0d3e9 # v1.2.1
+        with:
+          nsis-version: '3.12'
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -77,11 +77,11 @@ jobs:
           PYTHONHOME: ""
           PYTHONPATH: ""
           IS_RELEASE: 1
-        run: script/cibuild --preset-name=${{ matrix.preset-name }}
+        run: script/cibuild --preset-name=${{ matrix.preset-name }} --build-type=${{ matrix.build-type }}
 
       - name: Package it
         working-directory: ${{github.workspace}}
-        run: cpack -V --preset-name="package-${{ matrix.preset-name }}"
+        run: cpack -V --preset-name="package-${{ matrix.preset-name }}" -G DragNDrop
 
       - name: Upload the artifacts
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1

--- a/script/build
+++ b/script/build
@@ -107,6 +107,6 @@ for i in "${directories_to_copy_if_they_exist[@]}"
 do
     if [ -d "$i" ]
     then
-        cp -v "$i" "${BIN_DIR}"/
+        cp -rv "$i" "${BIN_DIR}"/
     fi
 done

--- a/script/build
+++ b/script/build
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 #====================================
 # @file   : build
-# @brief  : build VegaStrike
-# @usage  : ./script/build --preset-name=VS2022Win64-pie-enabled-RelWithDebInfo
+# @brief  : build Vega Strike
+# @usage  : ./script/build --preset-name=linux-unix-makefiles-pie-enabled-glvnd-RelWithDebInfo
 # @param  : preset-name=, build-type=
 #====================================
 
 #============ DESCRIPTION ===========
-# This script builds VegaStrike.
+# This script builds Vega Strike.
 # After this, it copies the relevant files to the 'bin' directory.
 # The steps for creating this script were taken from the projects wiki:
 # https://github.com/Taose/Vegastrike-taose/wiki/How-to-Build
 #====================================
 
-# Copyright (C) 2020-2025 Stephen G. Tuggy and other Vega Strike contributors.
+# Copyright (C) 2020-2026 Stephen G. Tuggy and other Vega Strike contributors.
 #
 # https://github.com/vegastrike/Vega-Strike-Engine-Source
 #
@@ -36,7 +36,7 @@
 set -e
 
 echo "--------------------------"
-echo "--- build | 2025-11-27 ---"
+echo "--- build | 2026-07-12 ---"
 echo "--------------------------"
 
 #----------------------------------
@@ -69,7 +69,7 @@ done
 
 ROOT_DIR=$(pwd)
 echo "ROOT_DIR: ${ROOT_DIR}"
-BUILD_DIR="${ROOT_DIR}/build"
+BUILD_DIR="${ROOT_DIR}/build/${preset_name}"
 echo "BUILD_DIR: ${BUILD_DIR}"
 BIN_DIR="${ROOT_DIR}/bin"
 COMMAND=""

--- a/script/package
+++ b/script/package
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 ##
-# package
+#====================================
+# @file   : package
+# @brief  : package Vega Strike installer
+# @usage  : ./script/package --preset-name=linux-unix-makefiles-pie-enabled-glvnd-RelWithDebInfo
+# @param  : preset-name=, build-type=
+#====================================
 #
 # Vega Strike - Space Simulation, Combat and Trading
 # Copyright (C) 2001-2026 The Vega Strike Contributors:
@@ -37,14 +42,44 @@
 # ====================================
 #
 
+echo "----------------------------"
+echo "--- package | 2026-07-12 ---"
+echo "----------------------------"
 
 #----------------------------------
 # validate parameters
 #----------------------------------
 
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --preset_name=*)
+      preset_name="${1#*=}"
+      ;;
+    --preset-name=*)
+      preset_name="${1#*=}"
+      ;;
+    --build_type=*)
+      build_type="${1#*=}"
+      ;;
+    --build-type=*)
+      build_type="${1#*=}"
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 ROOT_DIR=$(pwd)
-BUILD_DIR=$ROOT_DIR/build
+echo "ROOT_DIR: ${ROOT_DIR}"
+BUILD_DIR="${ROOT_DIR}/build/${preset_name}"
+echo "BUILD_DIR: ${BUILD_DIR}"
 BIN_DIR=$ROOT_DIR/bin
+echo "BIN_DIR: ${BIN_DIR}"
 PACKAGE_DIR=$ROOT_DIR/packages
 VS_EXECUTABLE=${BUILD_DIR}/vegastrike-engine
 VS_CONFIG_EXECUTABLE=${BUILD_DIR}/vegasettings
@@ -175,7 +210,7 @@ function copyTarballs()
 function copyFiles()
 {
 	# Ensure the package output directory exists
-	mkdir -p ${PACKAGE_DIR}
+	mkdir -p "${PACKAGE_DIR}"
 
 	copyDebFiles
 	copyRpmFiles
@@ -184,28 +219,24 @@ function copyFiles()
 
 function buildPackages()
 {
-	# before running make package regen the Cmake data so that
-	# it picks up the dependencies just generated
-	cmake "${ROOT_DIR}"
-	make package
-	make package_source
+	# before running the package step, regen the CMake data so that it picks up the dependencies just generated
+	cmake --preset "$preset_name"
+
+	# Run the actual package step
+	cpack -V --preset "package-$preset_name"
 }
 
-echo "----------------------------"
-echo "--- package | 2020-12-13 ---"
-echo "----------------------------"
-
-if [ ! -f ${VS_EXECUTABLE} ]; then
+if [ ! -f "${VS_EXECUTABLE}" ]; then
 	echo "***************************************"
 	echo "*** Please build Vega Strike first. ***"
 	echo "***************************************"
 	exit 1
 fi
 
-cd $BUILD_DIR
+pushd "$BUILD_DIR" || exit 2
 
 buildDependencies
 buildPackages
 copyFiles
 
-cd $ROOT_DIR
+popd || exit 2

--- a/script/package
+++ b/script/package
@@ -233,10 +233,6 @@ if [ ! -f "${VS_EXECUTABLE}" ]; then
 	exit 1
 fi
 
-pushd "$BUILD_DIR" || exit 2
-
 buildDependencies
 buildPackages
 copyFiles
-
-popd || exit 2

--- a/script/package
+++ b/script/package
@@ -235,4 +235,7 @@ fi
 
 buildDependencies
 buildPackages
+
+pushd "$BUILD_DIR" || exit 2
 copyFiles
+popd || exit 2


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] This is a CI/build system change only, and will require cutting an installer to test

Issues:
- Fixes #1640 for 0.10.x (hopefully)

Purpose:
- What is this pull request trying to do? Fix the Windows 2025 build failure due to NSIS not being installed on the GitHub runner image. Make other changes as necessary to fix the installer builds.
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
