### PR TITLE
Fixed font point config and migrated base computer to ImGUI

### DIFF
--- a/engine/src/cmd/base_util.cpp
+++ b/engine/src/cmd/base_util.cpp
@@ -888,12 +888,13 @@ const Dictionary &GetEventData() {
     return _GetEventData();
 }
 
-
+//  Python accessor, not used in cpp
 float GetTextHeight(std::string text, Vector widheimult) {
     const float font_point = configuration().graphics.font_point_flt;
     return font_point * 2 / configuration().graphics.resolution_y;
 }
 
+//  Python accessor, not used in cpp
 float GetTextWidth(std::string text, Vector widheimult) {
     //Unsupported for now
     return 0;

--- a/engine/src/cmd/base_util.cpp
+++ b/engine/src/cmd/base_util.cpp
@@ -888,11 +888,10 @@ const Dictionary &GetEventData() {
     return _GetEventData();
 }
 
+
 float GetTextHeight(std::string text, Vector widheimult) {
-    static constexpr bool force_highquality = true;
-    constexpr bool use_bit = force_highquality ||  configuration().graphics.high_quality_font;
     const float font_point = configuration().graphics.font_point_flt;
-    return use_bit ? getFontHeight() : (font_point * 2 / configuration().graphics.resolution_y);
+    return font_point * 2 / configuration().graphics.resolution_y;
 }
 
 float GetTextWidth(std::string text, Vector widheimult) {

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -559,7 +559,7 @@ static bool setup_sdl_video_mode() {
     get_screen_measurements();
 
     // Initialize imgui
-    InitGui(window, &context);
+    InitGui(window, &context, configuration().graphics.font_point_dbl);
 
     return true;
 }

--- a/engine/src/gui/font.cpp
+++ b/engine/src/gui/font.cpp
@@ -4,8 +4,8 @@
  * Vega Strike - Space Simulation, Combat and Trading
  * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically: Mike Byron
- * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+ * Original development team: As listed in the AUTHORS file
+ * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy, Danny Gehl
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *
@@ -24,159 +24,147 @@
  * You should have received a copy of the GNU General Public License
  * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#include "src/vegastrike.h"
-
 #include "font.h"
-
-#include "guidefs.h"
-#include "root_generic/vs_globals.h"
-#include "src/config_xml.h"
+#include "src/vs_logging.h"
+#include "gldrv/gl_globals.h"
+#include "src/gfxlib.h"
+#include <imgui.h>
+#include <imgui_internal.h> // For access to ImFont metrics
 #include "configuration/configuration.h"
 
-//For some reason, the cumulative width of GLUT strings is smaller than the
-//actual width when they are painted.  If we add this factor to the reference
-//length of every GLUT character, things work a lot better.
-//It looks like the reason is that the return type for getting GLUT reference lengths
-//is int, and the lengths are not int.  The character drawing code lets GLUT move the
-//origin for each character, and it looks like that movement is not integer in the
-//reference char space (it's clearly not going to be integer in the scaled space).
-static const double GLUT_WIDTH_HACK = 0.6;
-
-//The width of the space character in the outline font is too big, so we make it a special case.
-static const char SPACE_CHAR = ' ';
-
-bool useStroke() {
-    const bool tmp = configuration().graphics.high_quality_font_computer;
-    return !tmp;
-}
-
-static double GetGlobalUIScale() {
-    // You could pull this from your config file or a new GUIState variable
-    return configuration().graphics.gui_font_scale_flt;
-}
-
-//Calculate the metrics for this font.
-//This does the real work, and doesn't check whether it needs to be done.
-void Font::calcMetrics(void) {
-    //This is a hack to adjust the font stroke width as the font size goes up.
-    //Since the stroke width is in pixels, we scale the width up as the screen resolution gets
-    //higher.  (Currently, this is linear, which doesn't work well at small sizes.)
-    //We also make sure the stroke width is at least 1.0.  Otherwise antialiasing causes
-    //some font features to fade out.
-    //My OpenGL (Windows XP) has a max line width of 10.  So we get stroke width truncation for font
-    //size over 0.5.  This is OK because the curves look really ugly that big anyway.
-    const double referenceStrokeWidth = 20.0;                          //Best width for a font size of 1.0 (big).
-    const double referenceStrokeWidthResolution = 800;          //X-resolution stroke width measured in.
-    const double minimumStrokeWidth = 1.0;
-
-    const double nonClippedStrokeWidth = size() * referenceStrokeWidth * strokeWeight()
-            * (configuration().graphics.resolution_x / referenceStrokeWidthResolution);
-
-    m_strokeWidth = guiMax(minimumStrokeWidth, nonClippedStrokeWidth);
-    m_needMetrics = false;
-
-    //Vertical scaling factor:
-    m_verticalScaling = (size() * GetGlobalUIScale()) / REFERENCE_LINE_SPACING;
-    //Horizontal scaling factor.  Same as vertical, except we need to make the coord system
-    //the same distance in all directions, so we need to apply the ratio of vert / horiz
-    //resolution.  Otherwise the fonts are slightly stretched horizontally -- there
-    //are more pixels horizontally than vertically per unit in the identity coord space.
-    if (useStroke()) {
-        m_horizontalScaling = (m_verticalScaling * configuration().graphics.resolution_y) / configuration().graphics.resolution_x;
-    } else {
-        //Calculation above seems broken... this seems to work for most sizes with bitmap.
-        m_horizontalScaling = m_verticalScaling / (1.6 * configuration().graphics.resolution_x / 1000);
-    }
-    //The size of a horizontal pixel in reference space.
-    const double horizPixelInRefSpace = REFERENCE_LINE_SPACING / (configuration().graphics.resolution_x / 2) / size();
-
-    //Recalculate the extra char width.
-    m_extraCharWidth = horizPixelInRefSpace * m_strokeWidth;
-
-    //Space character width should be the same as a number.
-    //Numbers are generally all the same width so you can assume they will go into columns.
-    //We use '8' because if the numbers aren't all the same width, '8' is a good, wide number.
-    //What we calculate here is the horizontal translation to get from the actual outline font
-    //space char width to the space char width we want.
-    const double eightWidth = glutStrokeWidth(GLUT_STROKE_ROMAN, '8') + m_extraCharWidth;
-    m_spaceCharFixup = eightWidth - glutStrokeWidth(GLUT_STROKE_ROMAN, SPACE_CHAR);
-}
-
-//Check whether we need to recalc the metrics, and do it in const object.
 void Font::calcMetricsIfNeeded(void) const {
     if (m_needMetrics) {
-        //calcmetrics is a cache.  Doesn't change the "real" state of the object.
-        Font *s = const_cast< Font * > (this);
-        s->calcMetrics();
+        const_cast<Font*>(this)->calcMetrics();
     }
 }
 
-//Draw a character.
-float Font::drawChar(char c) const {
+// Calculates the metrics for this font.
+// This does the real work, and doesn't check whether it needs to be done.
+void Font::calcMetrics(void) {
+    m_needMetrics = false;
+
+    // Determine how much we need to scale the font 
+    // to reach the desired 'm_size' (0.1 = 10% of the screen height).
+    double scale_factor = static_cast<double>(m_size) / configuration().graphics.font_point_dbl;
+
+    // Vertical Scaling: 
+    // We adjust by the configured GUI scale factor.
+    m_verticalScaling = scale_factor * configuration().graphics.gui_font_scale_dbl; 
+
+    // Horizontal Scaling:
+    // Correct for the aspect ratio so characters aren't squashed.
+    double aspect_ratio = static_cast<double>(configuration().graphics.resolution_y) / static_cast<double>(configuration().graphics.resolution_x);
+    m_horizontalScaling = m_verticalScaling * aspect_ratio;
+
+    // printf("Vertical Scaling: %f, Horizontal Scaling: %f,\n", 
+    //     m_verticalScaling, m_horizontalScaling);
+}
+
+float Font::drawChar(char c, float xOffset) const {
+    ImGuiContext* ctx = ImGui::GetCurrentContext();
+    if (!ctx) return 0.0f;
+
+    // Get the texture ID first
+    ImTextureID tex_id = ctx->IO.Fonts->TexRef.GetTexID();
+
+    // If tex_id is 0, the font atlas is not initialized or has been destroyed
+    if (!tex_id || tex_id == (ImTextureID)(intptr_t)-1) {
+        return 0.0f;
+    }
+
     calcMetricsIfNeeded();
-    if (useStroke()) {
-        glutStrokeCharacter(GLUT_STROKE_ROMAN, c);
-        if (c == SPACE_CHAR) {
-            //Need to translate back a bit -- the width of the space is too big.
-            glTranslated(m_spaceCharFixup, 0.0, 0.0);
-        } else {
-            glTranslated(m_extraCharWidth, 0.0, 0.0);
-        }
-        return 0;
-    } else {
-        glutBitmapCharacter(GLUT_BITMAP_HELVETICA_12, c);
-        return glutBitmapWidth(GLUT_BITMAP_HELVETICA_12, c);
+    
+    // Access the baked font data instead of the raw ImFont object
+    ImFontBaked* font_baked = ImGui::GetFontBaked(); 
+    if (!font_baked) return 0.0f;
+    
+    // Use the new FindGlyph method on the baked font
+    const ImFontGlyph* glyph = font_baked->FindGlyph((ImWchar)c);
+    if (!glyph) return 0.0f;
+
+    // IMPORTANT: Tell OpenGL which unit we are binding to
+    GFXActiveTexture(GL_TEXTURE0); 
+    glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)tex_id);
+
+    const float unit_scale = 1;//2.5f;
+    // move up one line
+    const float yOffset = -font_baked->Ascent;//-50.0f;
+
+    float x0 = (glyph->X0 + xOffset) * unit_scale;
+    float y0 = (glyph->Y0 + yOffset) * unit_scale;
+    float x1 = (glyph->X1 + xOffset) * unit_scale;
+    float y1 = (glyph->Y1 + yOffset) * unit_scale;
+
+    // Define interleaved data: [x, y, z, u, v]
+    const float verts[] = {
+        x0, -y0, 0.0f, glyph->U0, glyph->V0,
+        x1, -y0, 0.0f, glyph->U1, glyph->V0,
+        x1, -y1, 0.0f, glyph->U1, glyph->V1,
+        x0, -y1, 0.0f, glyph->U0, glyph->V1
+    };
+
+    // poor man's bold
+    if(m_strokeWeight == BOLD_STROKE) {
+        // Draw it again with a slight offset to make it look "thicker"
+        const float boldOffset = 2.0f; // Tweak this for thickness
+        const float boldVerts[] = {
+            x0 + boldOffset, -y0, 0.0f, glyph->U0, glyph->V0,
+            x1 + boldOffset, -y0, 0.0f, glyph->U1, glyph->V0,
+            x1 + boldOffset, -y1, 0.0f, glyph->U1, glyph->V1,
+            x0 + boldOffset, -y1, 0.0f, glyph->U0, glyph->V1
+        };
+        GFXDraw(GFXQUAD, boldVerts, 4, 3, 0, 2, 0);
     }
+
+    // Draw using the GFXDraw signature: 
+    // Type: GFXQUAD, Data: verts, vnum: 4, vsize: 3, csize: 0, tsize0: 2, tsize1: 0
+    GFXDraw(GFXQUAD, verts, 4, 3, 0, 2, 0);
+
+    // Return the advance value
+    return (float)glyph->AdvanceX;
 }
 
-//The width of a character in reference units.
 double Font::charWidth(char c) const {
     calcMetricsIfNeeded();
-    if (useStroke()) {
-        if (c == SPACE_CHAR) {
-            //Spaces have a special width.
-            const double spaceCharWidth =
-                    glutStrokeWidth(GLUT_STROKE_ROMAN, SPACE_CHAR) + m_spaceCharFixup;
-            return spaceCharWidth + GLUT_WIDTH_HACK;
-        }
-        const double charWidth = glutStrokeWidth(GLUT_STROKE_ROMAN, c);
-        return charWidth + m_extraCharWidth + GLUT_WIDTH_HACK;
-    } else {
-        return glutBitmapWidth(GLUT_BITMAP_HELVETICA_12, c) / (size() * 2);
-    }
+    ImFontBaked* font_baked = ImGui::GetFontBaked();
+    if (!font_baked) return 0.0f;
+    const ImFontGlyph* glyph = font_baked->FindGlyph((ImWchar)c);
+    return glyph ? (double)(glyph->AdvanceX) : 0.0;
 }
 
-//The width of a string in reference units.
 double Font::stringWidth(const std::string &str) const {
     calcMetricsIfNeeded();
-
-    double result = 0.0;
-    for (string::const_iterator i = str.begin(); i != str.end(); i++) {
-        result += charWidth(*i);
+    double width = 0.0;
+    for (char c : str) {
+        width += charWidth(c);
     }
-    return result;
+    return width;
 }
 
-//Calculate the OpenGL stroke width for a font size+weight.
-//This value is cached in the font object.
-double Font::strokeWidth(void) const {
-    calcMetricsIfNeeded();
-
-    return m_strokeWidth;
-}
-
-//Vertical scaling factor to be used to image this font.
 double Font::verticalScaling(void) const {
     calcMetricsIfNeeded();
-
     return m_verticalScaling;
 }
 
-//Horizontal scaling factor to be used to image this font.
 double Font::horizontalScaling(void) const {
     calcMetricsIfNeeded();
-
     return m_horizontalScaling;
 }
 
+double Font::strokeWidth(void) const {
+    return m_strokeWidth;
+}
+
+double Font::ascent(void) const {
+    ImFontBaked* font_baked = ImGui::GetFontBaked();
+    return font_baked ? font_baked->Ascent : 0.0f;
+}
+
+double Font::descent(void) const {
+    ImFontBaked* font_baked = ImGui::GetFontBaked();
+    return font_baked ? font_baked->Descent : 0.0f;
+}
+
+bool useStroke(void) {
+    return true;
+}

--- a/engine/src/gui/font.cpp
+++ b/engine/src/gui/font.cpp
@@ -4,7 +4,7 @@
  * Vega Strike - Space Simulation, Combat and Trading
  * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file
+ * Original development team: As listed in the AUTHORS file. Specifically: Mike Byron
  * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy, Danny Gehl
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
@@ -41,7 +41,6 @@ void Font::calcMetricsIfNeeded(void) const {
 // Calculates the metrics for this font.
 // This does the real work, and doesn't check whether it needs to be done.
 void Font::calcMetrics(void) {
-    m_needMetrics = false;
 
     // Determine how much we need to scale the font 
     // to reach the desired 'm_size' (0.1 = 10% of the screen height).
@@ -56,6 +55,7 @@ void Font::calcMetrics(void) {
     double aspect_ratio = static_cast<double>(configuration().graphics.resolution_y) / static_cast<double>(configuration().graphics.resolution_x);
     m_horizontalScaling = m_verticalScaling * aspect_ratio;
 
+    m_needMetrics = false;
     // printf("Vertical Scaling: %f, Horizontal Scaling: %f,\n", 
     //     m_verticalScaling, m_horizontalScaling);
 }

--- a/engine/src/gui/font.cpp
+++ b/engine/src/gui/font.cpp
@@ -51,6 +51,11 @@ bool useStroke() {
     return !tmp;
 }
 
+static double GetGlobalUIScale() {
+    // You could pull this from your config file or a new GUIState variable
+    return configuration().graphics.gui_font_scale_flt;
+}
+
 //Calculate the metrics for this font.
 //This does the real work, and doesn't check whether it needs to be done.
 void Font::calcMetrics(void) {
@@ -72,7 +77,7 @@ void Font::calcMetrics(void) {
     m_needMetrics = false;
 
     //Vertical scaling factor:
-    m_verticalScaling = size() / REFERENCE_LINE_SPACING;
+    m_verticalScaling = (size() * GetGlobalUIScale()) / REFERENCE_LINE_SPACING;
     //Horizontal scaling factor.  Same as vertical, except we need to make the coord system
     //the same distance in all directions, so we need to apply the ratio of vert / horiz
     //resolution.  Otherwise the fonts are slightly stretched horizontally -- there

--- a/engine/src/gui/font.h
+++ b/engine/src/gui/font.h
@@ -34,17 +34,6 @@ static const float LIGHT_STROKE = 0.6;
 static const float NORMAL_STROKE = 1.0;
 static const float BOLD_STROKE = 1.5;
 
-//The GLUT outline font (GLUT_STROKE_ROMAN) has a maximum ascender over the baseline of
-//119.05, and a max descender under the baseline of 33.33.
-//We add a bit of extra space to make sure the characters don't run into each other vertically.
-//Not too much, because the max ascender almost never runs into the max descender, and
-//we don't want too much white space between lines.  (This spacing is a guess -- tweak
-//it if necessary.)
-//These constants describe the reference vertical spacing of the font:
-static const double REFERENCE_BASELINE_POS = 33.33;
-static const double REFERENCE_FONT_ASCENDER = 119.05;
-static const double REFERENCE_LINE_SPACING = REFERENCE_FONT_ASCENDER + REFERENCE_BASELINE_POS;
-
 //Font object.
 //Right now, this only supports the GLUT outline font.
 //We try to choose the best options for a given Font size.  May or may not do
@@ -74,7 +63,7 @@ public:
     }
 
 //Draw a character.  Assumes scaling is done, current color set, etc.
-    float drawChar(char c) const;
+    float drawChar(char c, float xOffset = 0) const;
 
 //The width of a character in reference units.
     double charWidth(char c) const;
@@ -82,11 +71,17 @@ public:
 //The width of a string in reference units.
     double stringWidth(const std::string &str) const;
 
-//Vertical scaling factor to be used to image this font.
+//Vertical scaling factor from char reference space to identity space to be used to image this font.
     double verticalScaling(void) const;
 
-//Horizontal scaling factor to be used to image this font.
+//Horizontal scaling factor from char reference space to identity space to be used to image this font.
     double horizontalScaling(void) const;
+
+// Returns the font ascent
+    double ascent(void) const;
+
+// Returns the font descent
+    double descent(void) const;
 
 //CONSTRUCTION
     Font(float newsize = .1, float weight = NORMAL_STROKE) :
@@ -119,7 +114,7 @@ protected:
 //This does the real work, and doesn't check whether it needs to be done.
     void calcMetrics(void);
 
-//Check whether we need to recalc the metrics, and do it in const object.
+    // Check whether we need to recalc the metrics, and do it in const object.
     void calcMetricsIfNeeded(void) const;
 
 protected:

--- a/engine/src/gui/painttext.cpp
+++ b/engine/src/gui/painttext.cpp
@@ -209,7 +209,9 @@ static float drawChars(const string &str,
     glLineWidth(font.strokeWidth());
     //Draw all the characters.
     for (int charPos = start; charPos <= end; charPos++) {
-        inRasterPos += font.drawChar(str[charPos], inRasterPos);
+        if(str[charPos] != '\0') {
+            inRasterPos += font.drawChar(str[charPos], inRasterPos);
+        }
     }
     return inRasterPos;
 }

--- a/engine/src/gui/painttext.cpp
+++ b/engine/src/gui/painttext.cpp
@@ -205,17 +205,11 @@ static float drawChars(const string &str,
         float inRasterPos) {
     //Make sure the graphics state is right.
     GFXColorf(color);
-    if (useStroke()) {
-        glLineWidth(font.strokeWidth());
-    } else {
-        const bool setRasterPos = configuration().graphics.set_raster_text_color;
-        if (setRasterPos) {
-            glRasterPos2f(inRasterPos / (configuration().graphics.resolution_x / 2), 0);
-        }
-    }
+    GFXEnable(TEXTURE0);
+    glLineWidth(font.strokeWidth());
     //Draw all the characters.
     for (int charPos = start; charPos <= end; charPos++) {
-        inRasterPos += font.drawChar(str[charPos]);
+        inRasterPos += font.drawChar(str[charPos], inRasterPos);
     }
     return inRasterPos;
 }
@@ -228,8 +222,16 @@ void PaintText::drawLines(size_t start, size_t count) const {
     if (m_lines.empty()) {
         return;
     }
+    // Save current textures
+    GLint saved_texture;
+    GLint saved_active_texture;
+
+    // Get which texture unit is currently active
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &saved_active_texture);
+    // Get the binding for the currently active unit (usually GL_TEXTURE0)
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &saved_texture);
     //Initialize the graphics state.
-    GFXToggleTexture(false, 0);
+    GFXToggleTexture(true, 0);
     if (configuration().graphics.smooth_lines) {
         glEnable(GL_LINE_SMOOTH);
     }
@@ -280,6 +282,9 @@ void PaintText::drawLines(size_t start, size_t count) const {
     }
     glPopMatrix();
     GFXToggleTexture(true, 0);
+    // restore previous texture
+    GFXActiveTexture(saved_active_texture);
+    glBindTexture(GL_TEXTURE_2D, saved_texture);
 }
 
 //Get a floating-point argument for a PaintText format command.
@@ -733,7 +738,7 @@ void PaintText::calcLayout(void) {
         //SINGLE LINE.
         currentLine->height = m_rect.size.height;
         currentLine->baseLine = (currentLine->height - m_font.size()) / 2.0
-                + m_verticalScaling * REFERENCE_FONT_ASCENDER;
+                + m_verticalScaling * m_font.ascent();
 
         string::size_type ignorePos = 0;
         bool ellipsis = (m_widthExceeded == ELLIPSIS);
@@ -751,7 +756,8 @@ void PaintText::calcLayout(void) {
         while (true) {
             //Figure vertical measurements before we parse the line.
             currentLine->height = m_layout.fontStack.back().size() * m_layout.currentLineSpacing;
-            currentLine->baseLine = currentLine->height - m_verticalScaling * REFERENCE_BASELINE_POS;
+            currentLine->baseLine = (currentLine->height - m_font.size()) / 2.0f 
+                                        + m_verticalScaling * m_font.ascent();
 
             //Get the first line of chars, including the length.
             string::size_type endNextLinePos = 0;

--- a/libraries/gui/gui.cpp
+++ b/libraries/gui/gui.cpp
@@ -45,7 +45,7 @@ bool gui_initialized = false;
 SDL_Window* current_window = nullptr;
 ImFont* roboto_18_font;
 
-void InitGui(SDL_Window *window, const SDL_GLContext *context, float fontSize) {
+void InitGui(SDL_Window *window, const SDL_GLContext *context, const float fontSize) {
     current_window = window;
     SDL_GLContext gl_context = *context;
 

--- a/libraries/gui/gui.cpp
+++ b/libraries/gui/gui.cpp
@@ -45,7 +45,7 @@ bool gui_initialized = false;
 SDL_Window* current_window = nullptr;
 ImFont* roboto_18_font;
 
-void InitGui(SDL_Window *window, const SDL_GLContext *context) {
+void InitGui(SDL_Window *window, const SDL_GLContext *context, float fontSize) {
     current_window = window;
     SDL_GLContext gl_context = *context;
 
@@ -60,7 +60,7 @@ void InitGui(SDL_Window *window, const SDL_GLContext *context) {
     ImGuiIO& io = ImGui::GetIO();
     io.Fonts->Clear();
     ImFontConfig cfg;
-    cfg.SizePixels = 18.0f;
+    cfg.SizePixels = fontSize;
     io.FontDefault = io.Fonts->AddFontDefault(&cfg);
 
     gui_initialized = true;

--- a/libraries/gui/gui.h
+++ b/libraries/gui/gui.h
@@ -35,7 +35,7 @@ class SDL_Window;
 extern bool gui_initialized;
 extern SDL_Window* current_window;
 
-void InitGui(SDL_Window *window, const SDL_GLContext *context);
+void InitGui(SDL_Window *window, const SDL_GLContext *context, float fontSize);
 void CleanupGui();
 
 #endif // VEGA_STRIKE_LIBRARIES_GUI_GUI_H


### PR DESCRIPTION
Code Changes:
- [x] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

Issues:
This re-enables the possibility to configure font_point in the config. I tested with 32 (up from 16 which was hard-coded) and it looked much better.

I now managed to find a solution for the base computer as well. In principle we should probably rewrite it from scratch using ImGUI components, this is a larger untertaking however.

possibly addresses #671 