### PR TITLE
Fix legacy base highlight: stop doubling hover mouse coords

### DIFF
--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -979,7 +979,11 @@ void BaseInterface::ClickWin(int button, int state, int x, int y) {
 }
 
 void BaseInterface::PassiveMouseOverWin(int x, int y) {
-    ModifyMouseSensitivity(x, y);
+    // Do NOT apply ModifyMouseSensitivity here. It doubles the mouse position
+    // (a low-res workaround) and clamps at the screen edges, which corrupts
+    // coordinates near the border. The click path (ClickWin) uses raw pixels,
+    // and the computer path applies its own sensitivity handling in
+    // EventManager. Passing raw pixels keeps hover consistent with clicks.
     SetSoftwareMousePosition(x, y);
     if (CurrentBase) {
         if (CurrentBase->CallComp) {
@@ -998,7 +1002,7 @@ void BaseInterface::PassiveMouseOverWin(int x, int y) {
 }
 
 void BaseInterface::ActiveMouseOverWin(int x, int y) {
-    ModifyMouseSensitivity(x, y);
+    // See PassiveMouseOverWin: do NOT apply ModifyMouseSensitivity here.
     SetSoftwareMousePosition(x, y);
     if (CurrentBase) {
         if (CurrentBase->CallComp) {


### PR DESCRIPTION
The hover path applied ModifyMouseSensitivity, which doubles the mouse position relative to screen center when resolution_x >= double_mouse_position (a low-res-screen workaround active on all modern displays). The click path (ClickWin) never applied it — it uses raw pixels. This made the highlight respond to a 2x-scaled mouse (peaking at halfway to each hotspot) while clicks were correct.

Fix: Remove ModifyMouseSensitivity from the hover handlers entirely, so hover uses raw pixels consistent with clicks. The computer path applies its own sensitivity handling in EventManager, so this also fixes a double-application there. Scoped to the legacy base path only; the main menu is unaffected.

Note: an earlier approach inverted the doubling inside MouseOver, but that transform clamps at the screen edges, making the inverse lossy near the border (edge hotspots never reached full brightness). Removing the doubling at the source is the correct fix.


Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

This only affects the text highlighting in the bases. This has been tested on the various base locations on Atlantis. 

Issues:
- Issue #1347

Purpose:
- What is this pull request trying to do?
- - Fix base text highlighting. 
- What release is this for?
- -Whichever. :)
- Is there a project or milestone we should apply this to?
- -Nope. 