### PR TITLE
Nav screen migrated to Dear ImGUI drawing routines and mouse cursor restored

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -247,6 +247,7 @@ SET(LIBGUI_SOURCES
     src/gui/eventresponder.cpp
     src/gui/font.cpp
     src/gui/glut_support.cpp
+    src/gui/imgui_support.cpp
     src/gui/groupcontrol.cpp
     src/gui/guidefs.cpp
     src/gui/guitexture.cpp

--- a/engine/src/cmd/base.h
+++ b/engine/src/cmd/base.h
@@ -33,7 +33,7 @@
 #include "gfx/hud.h"
 #include "gfx/sprite.h"
 #include <cstdio>
-#include "gui/glut_support.h"
+#include "gui/imgui_support.h"
 
 #include "audio/Types.h"
 #include "audio/Source.h"

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -70,7 +70,6 @@
 #include "libraries/gui/gui.h"
 #include "backends/imgui_impl_sdl3.h"
 #include "backends/imgui_impl_opengl3.h"
-#include "backends/imgui_impl_sdlrenderer3.h"
 
 VegaRandom base_interface_random{};
 
@@ -117,7 +116,8 @@ static bool createdbase = false;
 static int createdmusic = -1;
 
 void ModifyMouseSensitivity(int &x, int &y) {
-    biModifyMouseSensitivity(x, y, false);
+    // FIXME enabling this breaks mouse over events in the main menu
+    // biModifyMouseSensitivity(x, y, false);
 }
 
 #ifdef BASE_MAKER
@@ -744,6 +744,9 @@ void base_main_loop() {
                              configuration().graphics.resolution_y);
     ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
     ImGui::Begin("main_window", nullptr, window_flags);
+
+    // hide the mouse cursor, we got a cooler one!
+    ImGui::SetMouseCursor(ImGuiMouseCursor_None);
     
     bool refresh_result = RefreshGUI();
 
@@ -957,6 +960,8 @@ void BaseInterface::Click(int xint, int yint, int button, int state) {
 }
 
 void BaseInterface::ClickWin(int button, int state, int x, int y) {
+    ModifyMouseSensitivity(x, y);
+    SetSoftwareMousePosition(x, y);
     if (state == WS_MOUSE_DOWN) {
         getMouseButtonMask() |= (1 << (button - 1));
     } else if (state == WS_MOUSE_UP) {
@@ -1533,7 +1538,7 @@ void BaseInterface::Draw() {
 
     GFXColor(0, 0, 0, 0);
     SetupViewport();
-    StartGUIFrame(GFXTRUE);
+    StartGUIFrame();
     if (GetElapsedTime() < 1) {
         AnimatedTexture::UpdateAllFrame();
     }

--- a/engine/src/gfx/hud.cpp
+++ b/engine/src/gfx/hud.cpp
@@ -264,7 +264,7 @@ int TextPlane::Draw(const string &newText, int offset, bool start_lower, bool fo
 
     std::vector<TextLine> lines = ParseText(newText, color);
     ImVec2 text_size;
-    ImDrawList* draw_list = ImGui::GetForegroundDrawList();
+    ImDrawList* draw_list = ImGui::GetBackgroundDrawList();
     const ImVec2 pad(4.0f, 2.0f); // TODO: make this variable
     
     // Move one line up if not start_lower 

--- a/engine/src/gfx/hud.cpp
+++ b/engine/src/gfx/hud.cpp
@@ -25,76 +25,23 @@
  * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <cmath>
+#include <cstddef>
 #include <vector>
 #include <string>
 #include <utility>
 
-#include <ctype.h>
-#include "src/gfxlib.h"
-#include "cmd/unit_generic.h"
+#include "configuration/configuration.h"
 #include "gfx/hud.h"
-#include "src/file_main.h"
-#include "root_generic/vs_globals.h"
 #include "src/config_xml.h"
-#include "cmd/base.h"
-//#include "glut.h"
-#include "src/universe.h"
 #include "gldrv/mouse_cursor.h"
 
-#include "gldrv/gl_globals.h"
-
-#include "libraries/gui/gui.h"
 #include "imgui.h"
-
-
-static bool isInside() {
-    if (BaseInterface::CurrentBase) {
-        return true;
-    }
-    return false;
-}
-
-
-
-const std::string &getStringFontForHeight(bool &changed) {
-    const bool inside = isInside();
-    static bool lastinside = inside;
-    if (lastinside != inside) {
-        changed = true;
-        lastinside = inside;
-    } else {
-        changed = false;
-    }
-    return inside ? configuration().graphics.bases.font : configuration().graphics.font;
-}
-
+#include "gui/guidefs.h"
 
 
 float getFontHeight() {
-    bool changed = false;
-    std::string whichfont = getStringFontForHeight(changed);
-    static float point = 0;
-    if (changed) {
-        point = 0;
-    }
-    if (point == 0) {
-        if (whichfont == "helvetica10") {
-            point = 22;
-        } else if (whichfont == "helvetica18") {
-            point = 40;
-        } else if (whichfont == "times24") {
-            point = 50;
-        } else if (whichfont == "times10") {
-            point = 22;
-        } else if (whichfont == "fixed13") {
-            point = 30;
-        } else if (whichfont == "fixed15") {
-            point = 34;
-        } else {
-            point = 26;
-        }
-    }
-    return point / configuration().graphics.resolution_y;
+    return configuration().graphics.font_point_flt / configuration().graphics.resolution_y;
 }
 
 TextPlane::TextPlane(const GFXColor &c, const GFXColor &bgcol) {
@@ -132,18 +79,6 @@ static float TwoCharToFloat(char a, char b) {
     return TwoCharToByte(a, b) / 255.;
 }
 
-
-// Text in a specific color
-struct TextSegment {
-    std::string text;
-    ImU32 color;
-};
-
-struct TextLine {
-    float width;
-    std::vector<TextSegment> segments;
-};
-
 static ImU32 MakeColorU32(float r, float g, float b, float a) {
     return IM_COL32(
         int(r * 255.0f),
@@ -163,21 +98,34 @@ static void FlushBuffer(std::vector<TextSegment>& segments, std::string& buffer,
 }
 
 
-static std::vector<TextLine> ParseText(const std::string& text, ImU32 default_color) {
+std::vector<TextLine> TextPlane::ParseText(const std::string& text, ImU32 default_color) {
     std::vector<TextLine> lines;
     std::vector<TextSegment> segments;
 
     ImU32 current_color = default_color;
     std::string buffer;
     std::string current_line;
+    size_t lastWordSeparator = 0;
+    size_t lastWordSeparatorInBuffer = 0;
+    // we need a slight margin as otherwise some texts won't fit
+    float widthInPixels = Coordinates::normToPixelW(myDims.i) * 1.05f;
+    if(widthInPixels < 0) {
+        widthInPixels = INFINITY;
+    }
 
     // Can't use for-each because we need i to move forward and back
     for (size_t i = 0; i < text.size(); ++i) {
         char c = text[i];
 
         // '_' is rendered as space
-        if (c == '_')
+        if (c == '_') {
             c = ' ';
+        }
+
+        if (c == ' ') {
+            lastWordSeparator = i;
+            lastWordSeparatorInBuffer = buffer.size();
+        }
 
         // Color tag: #RRGGBB
         if (c == '#' && i + 6 < text.size()) {
@@ -193,19 +141,45 @@ static std::vector<TextLine> ParseText(const std::string& text, ImU32 default_co
                 current_color = MakeColorU32(r, g, b, 1.0);
 
             i += 6;
+            lastWordSeparator = i;
+            lastWordSeparatorInBuffer = 0;
             continue;
         }
 
-        // Newline
-        if(c=='\n') {
-            FlushBuffer(segments, buffer, current_color);
-            current_color = default_color;
+        // Newline - either because of a newline char or because we are out of space
+        const float currentSize = ImGui::CalcTextSize(current_line.c_str()).x;
+        if(c=='\n' || currentSize > widthInPixels) {
+            // if line is too wide and word not too long for the line
+            if( currentSize > widthInPixels && lastWordSeparatorInBuffer > 0 ) {
+                // clear the current incomplete word
+                buffer.resize(lastWordSeparatorInBuffer);
+                FlushBuffer(segments, buffer, current_color);
+            } else if (c=='\n') {
+                FlushBuffer(segments, buffer, current_color);
+            }
+            // keep color when we need to break the line becaus of length, otherwise reset
+            if(c=='\n') {
+                current_color = default_color;
+            }
 
             TextLine line;
-            line.width = ImGui::CalcTextSize(current_line.c_str()).x;
+            line.width = currentSize;
             line.segments = segments;
             lines.emplace_back(line);
             segments.clear();
+            current_line = "";
+
+            if( currentSize > widthInPixels) {
+                // we go one back to the last word separator to preserve the chars
+                if( lastWordSeparatorInBuffer > 0 ) {
+                    i = lastWordSeparator;
+                } else {
+                    i--;
+                }
+                
+            }
+            lastWordSeparator = i;
+            lastWordSeparatorInBuffer = 0;
 
             continue;
         }
@@ -247,7 +221,7 @@ bool isTransparent(ImU32 color) {
 
 void drawBackground(ImDrawList* draw_list, ImU32 background_color, 
                     ImVec2 position, ImVec2 size, bool automatte) {
-    const ImVec2 pad(4.0f, 2.0f); // TODO: make this variable
+    //const ImVec2 pad(4.0f, 2.0f); // TODO: make this variable
 }
 
 void drawBackgroundAroundText(ImDrawList* draw_list, ImU32 background_color, 
@@ -274,6 +248,11 @@ int TextPlane::Draw(const string &newText, int offset, bool start_lower, bool fo
         position.y -= text_size.y;
     }
 
+    // Clipping coords to avoid overrunning text
+    // ImVec4 clipRect(position.x, position.y - 5, position.x + Coordinates::normToPixelW(myDims.i), position.y + Coordinates::normToPixelH(myDims.y) + 10);
+    // debug rectangle for clipping
+    // ImGui::GetForegroundDrawList()->AddRect(ImVec2(clipRect.x, clipRect.y), ImVec2(clipRect.z, clipRect.w), IM_COL32(255, 0, 0, 255));
+
     for (TextLine& line : lines) {
         for(TextSegment& segment : line.segments) {
             text_size = ImGui::CalcTextSize(segment.text.c_str());
@@ -295,7 +274,8 @@ int TextPlane::Draw(const string &newText, int offset, bool start_lower, bool fo
 
             }
 
-            draw_list->AddText(position, segment.color, segment.text.c_str());
+            // FIXME last param should be proper cliprect
+            draw_list->AddText(nullptr, 0.0f, position, segment.color, segment.text.c_str(), nullptr, 0.0f, nullptr);
              
             position.x += text_size.x;
         }

--- a/engine/src/gfx/hud.h
+++ b/engine/src/gfx/hud.h
@@ -28,13 +28,23 @@
 #define VEGA_STRIKE_ENGINE_GFX_HUD_H
 
 #include <string>
-#include "gfx_generic/vec.h"
 #include "src/gfxlib_struct.h"
 
 #include <cstdint>
 using ImU32 = std::uint32_t;
 
 class Texture;
+
+// Text in a specific color
+struct TextSegment {
+    std::string text;
+    ImU32 color;
+};
+
+struct TextLine {
+    float width;
+    std::vector<TextSegment> segments;
+};
 
 class TextPlane {
     std::string myText;
@@ -48,6 +58,8 @@ class TextPlane {
  *       float left, right, top, bottom;
  *  } myGlyphPos[256];
  */
+    std::vector<TextLine> ParseText(const std::string& text, ImU32 default_color);
+
 public:
     ImU32 color, background_color;
     TextPlane(const struct GFXColor &col = GFXColor(1, 1, 1, 1), const struct GFXColor &bgcol = GFXColor(0, 0, 0, 0));

--- a/engine/src/gfx/nav/navigation_system.cpp
+++ b/engine/src/gfx/nav/navigation_system.cpp
@@ -406,14 +406,6 @@ NavigationSystem::CachedSectorIterator NavigationSystem::CachedSectorIterator::o
 }
 
 void NavigationSystem::DrawGalaxy() {
-    // Obscure cockpit almost completely.
-    const ImVec2 start_position(0,0);
-    const ImVec2 end_position(configuration().graphics.resolution_x,
-                              configuration().graphics.resolution_y);
-    const ImU32 background_color = IM_COL32(0,0,0,224);
-    ImGui::GetForegroundDrawList()->AddRectFilled(start_position, end_position, background_color,
-                    0.0f // No rounded borders
-    );
 
     // (1, screenoccupation, factioncolours);	//	lists of items to draw that are in mouse range
     std::vector<SystemDrawNode> mouselist;     
@@ -666,11 +658,11 @@ void NavigationSystem::DrawGalaxy() {
         }
         unsigned destsize = systemIter->GetDestinationSize();
         if (destsize != 0) {
-            GFXDisable(LIGHTING);
-            GFXDisable(TEXTURE0);
-            const int vsize = 3 + 4;
-            std::vector<float> verts(2 * destsize * vsize);
-            std::vector<float>::iterator v = verts.begin();
+            ImDrawList* drawList = ImGui::GetForegroundDrawList();
+
+            // Line thickness constant (adjust as needed, e.g., 1.5f or 2.0f)
+            const float line_thickness = 2.0f;
+
             for (unsigned i = 0; i < destsize; ++i) {
                 CachedSystemIterator::SystemInfo &oth = systemIter[systemIter->GetDestinationIndex(i)];
                 if (oth.isDrawable()) {
@@ -678,7 +670,7 @@ void NavigationSystem::DrawGalaxy() {
                     ReplaceAxes(posoth);
 
                     float the_new_x, the_new_y, new_system_item_scale_temp, the_new_x_flat, the_new_y_flat;
-                    //WARNING: SOME VARIABLES FOR ORIGINAL SYSTEM MAY BE MODIFIED HERE!!!
+                    // WARNING: SOME VARIABLES FOR ORIGINAL SYSTEM MAY BE MODIFIED HERE!!!
                     TranslateCoordinates(posoth,
                             pos_flat,
                             center_nav_x,
@@ -692,11 +684,11 @@ void NavigationSystem::DrawGalaxy() {
                             the_new_y_flat,
                             new_system_item_scale_temp,
                             0);
+
                     GFXColor othcol = oth.GetColor();
-                    othcol.a =
-                            (new_system_item_scale_temp
-                                    - minimumitemscaledown) / (maximumitemscaleup - minimumitemscaledown) + alphaadd;
-                    //GetAlpha(oldposoth,center_x,center_y,center_z,zdistance);
+                    othcol.a = (new_system_item_scale_temp - minimumitemscaledown) / 
+                            (maximumitemscaleup - minimumitemscaledown) + alphaadd;
+
                     IntersectBorder(the_new_x, the_new_y, the_x, the_y);
 
                     bool isConnectionPath = false;
@@ -708,43 +700,48 @@ void NavigationSystem::DrawGalaxy() {
                                     && (*paths)->isNeighborPath(temp, systemIter->GetDestinationIndex(i));
                         }
                     }
+
+                    // Screen pixel coordinate projection
+                    ImVec2 p1(
+                        static_cast<float>(Coordinates::normToPixelX(the_x)),
+                        static_cast<float>(Coordinates::normToPixelY(the_y))
+                    );
+                    ImVec2 p2(
+                        static_cast<float>(Coordinates::normToPixelX(the_new_x)),
+                        static_cast<float>(Coordinates::normToPixelY(the_new_y))
+                    );
+
                     if (isConnectionPath) {
-                        *v++ = the_x;
-                        *v++ = the_y;
-                        *v++ = 0;
-                        *v++ = pathcol.r;
-                        *v++ = pathcol.g;
-                        *v++ = pathcol.b;
-                        *v++ = pathcol.a;
-                        *v++ = the_new_x;
-                        *v++ = the_new_y;
-                        *v++ = 0;
-                        *v++ = pathcol.r;
-                        *v++ = pathcol.g;
-                        *v++ = pathcol.b;
-                        *v++ = pathcol.a;
+                        // Connection path line with uniform path color
+                        ImU32 cPath = IM_COL32(
+                            static_cast<int>(pathcol.r * 255.0f),
+                            static_cast<int>(pathcol.g * 255.0f),
+                            static_cast<int>(pathcol.b * 255.0f),
+                            static_cast<int>(pathcol.a * 255.0f)
+                        );
+
+                        drawList->AddLine(p1, p2, cPath, line_thickness);
+
                     } else if (path_view != PATH_ONLY) {
-                        *v++ = the_x;
-                        *v++ = the_y;
-                        *v++ = 0;
-                        *v++ = col.r;
-                        *v++ = col.g;
-                        *v++ = col.b;
-                        *v++ = col.a;
-                        *v++ = the_new_x;
-                        *v++ = the_new_y;
-                        *v++ = 0;
-                        *v++ = othcol.r;
-                        *v++ = othcol.g;
-                        *v++ = othcol.b;
-                        *v++ = othcol.a;
+                        // Standard system link (Gouraud shaded line between origin color and target color)
+                        ImU32 cStart = IM_COL32(
+                            static_cast<int>(col.r * 255.0f),
+                            static_cast<int>(col.g * 255.0f),
+                            static_cast<int>(col.b * 255.0f),
+                            static_cast<int>(col.a * 255.0f)
+                        );
+                        ImU32 cEnd = IM_COL32(
+                            static_cast<int>(othcol.r * 255.0f),
+                            static_cast<int>(othcol.g * 255.0f),
+                            static_cast<int>(othcol.b * 255.0f),
+                            static_cast<int>(othcol.a * 255.0f)
+                        );
+
+                        //  Multi-color line segment with gradient transition across the line
+                        drawList->AddLine(p1, p2, cStart, line_thickness); // Primary line
                     }
                 }
             }
-            if (v != verts.end()) {
-                verts.erase(v, verts.end());
-            }
-            GFXDraw(GFXLINE, &verts[0], verts.size() / vsize, 3, 4);
         }
         ++systemIter;
     }

--- a/engine/src/gfx/nav/navitemstodraw.h
+++ b/engine/src/gfx/nav/navitemstodraw.h
@@ -70,21 +70,13 @@ void NavigationSystem::DrawGrid(float &x1, float &x2, float &y1, float &y2, cons
     // Vertical grid lines
     for (int i = 1; i < 10; i++) {
         float x = x1 + i * deltax;
-        drawList->AddLine(
-            NormToPixel(x, y1),
-            NormToPixel(x, y2),
-            color, 1.0f
-        );
+        drawList->AddLine(NormToPixel(x, y1), NormToPixel(x, y2), color, 1.0f);
     }
 
     // Horizontal grid lines
     for (int i = 1; i < 10; i++) {
         float y = y1 + i * deltay;
-        drawList->AddLine(
-            NormToPixel(x1, y),
-            NormToPixel(x2, y),
-            color, 1.0f
-        );
+        drawList->AddLine(NormToPixel(x1, y), NormToPixel(x2, y), color, 1.0f);
     }
 }
 
@@ -107,17 +99,14 @@ void NavigationSystem::DrawHalfCircleTop(float x, float y, float size, const GFX
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    const int segments = 10;
-    float radius = 0.5f * size;
-    float yOffset = y - 0.25f * size;
+    float radiusPx = Coordinates::normToPixelW(0.5f * size);
+    ImVec2 center = NormToPixel(x, y);
+    center.y -= radiusPx * 0.5f; // Offset in pixel space
 
     drawList->PathClear();
-    for (int i = 0; i <= segments; ++i) {
-        float angle = i * (static_cast<float>(M_PI) / segments);
-        float px = x + radius * std::cos(angle);
-        float py = yOffset + radius * std::sin(angle);
-        drawList->PathLineTo(NormToPixel(px, py));
-    }
+    // PathArcTo(center, radius, a_min, a_max, num_segments)
+    // 0 to PI draws the arc
+    drawList->PathArcTo(center, radiusPx, 0.0f, static_cast<float>(M_PI), 16);
     drawList->PathStroke(color, 0, NAV_LINE_WEIGHT);
 }
 
@@ -128,17 +117,13 @@ void NavigationSystem::DrawHalfCircleBottom(float x, float y, float size, const 
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    const int segments = 10;
-    float radius = 0.5f * size;
-    float yOffset = y + 0.25f * size;
+    float radiusPx = Coordinates::normToPixelW(0.5f * size);
+    ImVec2 center = NormToPixel(x, y);
+    center.y += radiusPx * 0.5f; // Offset in pixel space
 
     drawList->PathClear();
-    for (int i = 0; i <= segments; ++i) {
-        float angle = static_cast<float>(M_PI) + i * (static_cast<float>(M_PI) / segments);
-        float px = x + radius * std::cos(angle);
-        float py = yOffset + radius * std::sin(angle);
-        drawList->PathLineTo(NormToPixel(px, py));
-    }
+    // PI to 2*PI draws the opposite arc
+    drawList->PathArcTo(center, radiusPx, static_cast<float>(M_PI), static_cast<float>(M_PI * 2.0), 16);
     drawList->PathStroke(color, 0, NAV_LINE_WEIGHT);
 }
 
@@ -149,39 +134,44 @@ void NavigationSystem::DrawPlanet(float x, float y, float size, const GFXColor &
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    // Outer circle
-    float radius = 0.5f * size;
-    DrawCircle(x ,y, size, col);
+    ImVec2 c = NormToPixel(x, y);
+    float r = Coordinates::normToPixelW(0.5f * size);
 
-    // Planet interior lines
-    drawList->AddLine(NormToPixel(x - radius, y), NormToPixel(x, y + 0.2f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x, y + 0.2f * size), NormToPixel(x, y - 0.2f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x, y - 0.2f * size), NormToPixel(x + radius, y), color, NAV_LINE_WEIGHT);
+    // Outer circle
+    drawList->AddCircle(c, r, color, 0, NAV_LINE_WEIGHT);
+
+    // Planet interior lines (all calculated in pure pixel space relative to center)
+    drawList->AddLine(ImVec2(c.x - r, c.y), ImVec2(c.x, c.y + r * 0.4f), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x, c.y + r * 0.4f), ImVec2(c.x, c.y - r * 0.4f), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x, c.y - r * 0.4f), ImVec2(c.x + r, c.y), color, NAV_LINE_WEIGHT);
 }
 
 //**********************************
-// Draws a station icon (3x3 grid pattern)
+// Draws a station icon (Square 3x3 grid pattern)
 //**********************************
 void NavigationSystem::DrawStation(float x, float y, float size, const GFXColor &col) {
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    float segment = size / 3.0f;
-    float startX = x - 0.5f * size;
-    float startY = y - 0.5f * size;
-    float endX = x + 0.5f * size;
-    float endY = y + 0.5f * size;
+    ImVec2 c = NormToPixel(x, y);
+    float halfSizePx = Coordinates::normToPixelW(0.5f * size);
+    float segmentPx = (halfSizePx * 2.0f) / 3.0f;
 
-    // Horizontal lines
+    float startX = c.x - halfSizePx;
+    float startY = c.y - halfSizePx;
+    float endX   = c.x + halfSizePx;
+    float endY   = c.y + halfSizePx;
+
+    // Horizontal grid lines
     for (int i = 0; i < 4; i++) {
-        float currentY = startY + i * segment;
-        drawList->AddLine(NormToPixel(startX, currentY), NormToPixel(endX, currentY), color, NAV_LINE_WEIGHT);
+        float curY = startY + i * segmentPx;
+        drawList->AddLine(ImVec2(startX, curY), ImVec2(endX, curY), color, NAV_LINE_WEIGHT);
     }
 
-    // Vertical lines
+    // Vertical grid lines
     for (int i = 0; i < 4; i++) {
-        float currentX = startX + i * segment;
-        drawList->AddLine(NormToPixel(currentX, startY), NormToPixel(currentX, endY), color, NAV_LINE_WEIGHT);
+        float curX = startX + i * segmentPx;
+        drawList->AddLine(ImVec2(curX, startY), ImVec2(curX, endY), color, NAV_LINE_WEIGHT);
     }
 }
 
@@ -192,24 +182,26 @@ void NavigationSystem::DrawJump(float x, float y, float size, const GFXColor &co
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    float radius = 0.5f * size;
-    float offset = 0.125f * size;
+    ImVec2 c = NormToPixel(x, y);
+    float r = Coordinates::normToPixelW(0.5f * size);
+    float off = r * 0.25f; // Offset relative to radius in pixel space
 
     // Outer circle
-    DrawCircle(x ,y, size, col);
+    drawList->AddCircle(c, r, color, 0, NAV_LINE_WEIGHT);
 
-    // Cardinal arrows
-    drawList->AddLine(NormToPixel(x, y + radius), NormToPixel(x + offset, y + offset), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x, y + radius), NormToPixel(x - offset, y + offset), color, NAV_LINE_WEIGHT);
-
-    drawList->AddLine(NormToPixel(x, y - radius), NormToPixel(x + offset, y - offset), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x, y - radius), NormToPixel(x - offset, y - offset), color, NAV_LINE_WEIGHT);
-
-    drawList->AddLine(NormToPixel(x - radius, y), NormToPixel(x - offset, y + offset), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x - radius, y), NormToPixel(x - offset, y - offset), color, NAV_LINE_WEIGHT);
-
-    drawList->AddLine(NormToPixel(x + radius, y), NormToPixel(x + offset, y + offset), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x + radius, y), NormToPixel(x + offset, y - offset), color, NAV_LINE_WEIGHT);
+    // Cardinal arrows in pixel space
+    // Top
+    drawList->AddLine(ImVec2(c.x, c.y - r), ImVec2(c.x + off, c.y - off), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x, c.y - r), ImVec2(c.x - off, c.y - off), color, NAV_LINE_WEIGHT);
+    // Bottom
+    drawList->AddLine(ImVec2(c.x, c.y + r), ImVec2(c.x + off, c.y + off), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x, c.y + r), ImVec2(c.x - off, c.y + off), color, NAV_LINE_WEIGHT);
+    // Left
+    drawList->AddLine(ImVec2(c.x - r, c.y), ImVec2(c.x - off, c.y + off), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x - r, c.y), ImVec2(c.x - off, c.y - off), color, NAV_LINE_WEIGHT);
+    // Right
+    drawList->AddLine(ImVec2(c.x + r, c.y), ImVec2(c.x + off, c.y + off), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x + r, c.y), ImVec2(c.x + off, c.y - off), color, NAV_LINE_WEIGHT);
 }
 
 //**********************************
@@ -219,12 +211,15 @@ void NavigationSystem::DrawMissile(float x, float y, float size, const GFXColor 
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    drawList->AddLine(NormToPixel(x - 0.5f * size, y - 0.125f * size), NormToPixel(x, y + 0.375f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x + 0.5f * size, y - 0.125f * size), NormToPixel(x, y + 0.375f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x - 0.25f * size, y - 0.125f * size), NormToPixel(x - 0.25f * size, y + 0.125f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x + 0.25f * size, y - 0.125f * size), NormToPixel(x + 0.25f * size, y + 0.125f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x - 0.25f * size, y + 0.125f * size), NormToPixel(x, y - 0.125f * size), color, NAV_LINE_WEIGHT);
-    drawList->AddLine(NormToPixel(x + 0.25f * size, y + 0.125f * size), NormToPixel(x, y - 0.125f * size), color, NAV_LINE_WEIGHT);
+    ImVec2 c = NormToPixel(x, y);
+    float s = Coordinates::normToPixelW(size);
+
+    drawList->AddLine(ImVec2(c.x - 0.5f * s, c.y + 0.125f * s), ImVec2(c.x, c.y - 0.375f * s), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x + 0.5f * s, c.y + 0.125f * s), ImVec2(c.x, c.y - 0.375f * s), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x - 0.25f * s, c.y + 0.125f * s), ImVec2(c.x - 0.25f * s, c.y - 0.125f * s), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x + 0.25f * s, c.y + 0.125f * s), ImVec2(c.x + 0.25f * s, c.y - 0.125f * s), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x - 0.25f * s, c.y - 0.125f * s), ImVec2(c.x, c.y + 0.125f * s), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(ImVec2(c.x + 0.25f * s, c.y - 0.125f * s), ImVec2(c.x, c.y + 0.125f * s), color, NAV_LINE_WEIGHT);
 }
 
 //**********************************
@@ -234,107 +229,109 @@ void NavigationSystem::DrawTargetCorners(float x, float y, float size, const GFX
     ImDrawList* drawList = GetNavDrawList();
     ImU32 color = ToImColor(col);
 
-    float half = 0.5f * size;
-    float inner = 0.3f * size;
+    ImVec2 c = NormToPixel(x, y);
+    float half  = Coordinates::normToPixelW(0.5f * size);
+    float inner = Coordinates::normToPixelW(0.3f * size);
 
     // Top-Left corner
-    drawList->AddLine(NormToPixel(x - half, y + half), NormToPixel(x - inner, y + half), color, NAV_LINE_WEIGHT*2);
-    drawList->AddLine(NormToPixel(x - half, y + half), NormToPixel(x - half, y + inner), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(ImVec2(c.x - half, c.y - half), ImVec2(c.x - inner, c.y - half), color, NAV_LINE_WEIGHT * 2);
+    drawList->AddLine(ImVec2(c.x - half, c.y - half), ImVec2(c.x - half, c.y - inner), color, NAV_LINE_WEIGHT * 2);
 
     // Top-Right corner
-    drawList->AddLine(NormToPixel(x + half, y + half), NormToPixel(x + inner, y + half), color, NAV_LINE_WEIGHT*2);
-    drawList->AddLine(NormToPixel(x + half, y + half), NormToPixel(x + half, y + inner), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(ImVec2(c.x + half, c.y - half), ImVec2(c.x + inner, c.y - half), color, NAV_LINE_WEIGHT * 2);
+    drawList->AddLine(ImVec2(c.x + half, c.y - half), ImVec2(c.x + half, c.y - inner), color, NAV_LINE_WEIGHT * 2);
 
     // Bottom-Left corner
-    drawList->AddLine(NormToPixel(x - half, y - half), NormToPixel(x - inner, y - half), color, NAV_LINE_WEIGHT*2);
-    drawList->AddLine(NormToPixel(x - half, y - half), NormToPixel(x - half, y - inner), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(ImVec2(c.x - half, c.y + half), ImVec2(c.x - inner, c.y + half), color, NAV_LINE_WEIGHT * 2);
+    drawList->AddLine(ImVec2(c.x - half, c.y + half), ImVec2(c.x - half, c.y + inner), color, NAV_LINE_WEIGHT * 2);
 
     // Bottom-Right corner
-    drawList->AddLine(NormToPixel(x + half, y - half), NormToPixel(x + inner, y - half), color, NAV_LINE_WEIGHT*2);
-    drawList->AddLine(NormToPixel(x + half, y - half), NormToPixel(x + half, y - inner), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(ImVec2(c.x + half, c.y + half), ImVec2(c.x + inner, c.y + half), color, NAV_LINE_WEIGHT * 2);
+    drawList->AddLine(ImVec2(c.x + half, c.y + half), ImVec2(c.x + half, c.y + inner), color, NAV_LINE_WEIGHT * 2);
 }
 
 //**********************************
-// Draws a 3D projected navigation disc using smooth ImGui Ellipses
+// Draws a 3D projected/oriented navigation circle grid (Accurate 3D perspective)
 //**********************************
 void NavigationSystem::DrawNavCircle(float x, float y, float size, float rot_x, float rot_y, const GFXColor &col) {
     ImDrawList* drawList = GetNavDrawList();
 
     constexpr int circles = 4;
+    constexpr int segments = 20;
     constexpr int segments2 = 12;
     constexpr float TWO_PI = 2.0f * static_cast<float>(M_PI);
 
-    // Compute pixel radii based on 3D tilt
-    ImVec2 center = NormToPixel(x, y);
-    float baseRadiusPx = Coordinates::normToPixelW(0.6f * size);
-    
-    // Minor axis compresses based on pitch tilt (rot_x)
-    float radiusX = baseRadiusPx;
-    float radiusY = baseRadiusPx * std::fabs(std::cos(rot_x));
+    // 1. Concentric web circles in true 3D projection
+    for (int i = 0; i < segments; ++i) {
+        float angle1 = i * (TWO_PI / segments);
+        float angle2 = (i + 1) * (TWO_PI / segments);
 
-    // -------------------------------------------------------------------------
-    // 1. Smooth Concentric Web Ellipses
-    // -------------------------------------------------------------------------
-    for (int j = circles; j > 0; --j) {
-        float scale = static_cast<float>(j) / static_cast<float>(circles);
-        float rx = radiusX * scale;
-        float ry = radiusY * scale;
+        GFXColor ci(col.r, col.g, col.b * std::fabs(std::sin(angle1 / 2.0f)), col.a);
+        ImU32 segmentColor = ToImColor(ci);
 
-        // Draw rotated ellipse path
-        drawList->PathClear();
-        constexpr int ellipseSegments = 32; // Smooth auto-tessellated curve
-        
-        for (int i = 0; i < ellipseSegments; ++i) {
-            float a = i * (TWO_PI / ellipseSegments);
-            
-            // Unrotated ellipse point
-            float ex = rx * std::cos(a);
-            float ey = ry * std::sin(a);
+        QVector pos1(0.6 * size * std::cos(angle1), 0.6 * size * std::sin(angle1), 0.0);
+        QVector pos2(0.6 * size * std::cos(angle2), 0.6 * size * std::sin(angle2), 0.0);
 
-            // Apply yaw rotation (rot_y) on screen plane
-            float rotX = ex * std::cos(rot_y) - ey * std::sin(rot_y);
-            float rotY = ex * std::sin(rot_y) + ey * std::cos(rot_y);
+        pos1 = dxyz(pos1, 0, 0, rot_y);
+        pos1 = dxyz(pos1, rot_x, 0, 0);
+        pos2 = dxyz(pos2, 0, 0, rot_y);
+        pos2 = dxyz(pos2, rot_x, 0, 0);
 
-            drawList->PathLineTo(ImVec2(center.x + rotX, center.y + rotY));
+        float standard_unit = 0.25f * 1.2f * size;
+        float zdistance1 = (1.2f * size) - pos1.k;
+        float zdistance2 = (1.2f * size) - pos2.k;
+        float zscale1 = standard_unit / zdistance1;
+        float zscale2 = standard_unit / zdistance2;
+
+        pos1 *= (zscale1 * 5.0f);
+        pos2 *= (zscale2 * 5.0f);
+
+        for (int j = circles; j > 0; j--) {
+            float scale = static_cast<float>(j) / static_cast<float>(circles);
+            QVector p1 = pos1 * scale;
+            QVector p2 = pos2 * scale;
+
+            drawList->AddLine(
+                NormToPixel(x + p1.i, y + p1.j),
+                NormToPixel(x + p2.i, y + p2.j),
+                segmentColor, NAV_LINE_WEIGHT
+            );
         }
-
-        // Color with standard alpha
-        ImU32 ringColor = ToImColor(col);
-        drawList->PathStroke(ringColor, ImDrawFlags_Closed, NAV_LINE_WEIGHT);
     }
 
-    // -------------------------------------------------------------------------
-    // 2. Radial Spoke Lines (12 Rays from center outward)
-    // -------------------------------------------------------------------------
-    constexpr float angleStepSpoke = TWO_PI / static_cast<float>(segments2);
-    constexpr float innerScale = 1.0f / static_cast<float>(circles * 2);
-
+    // 2. Radial spoke lines in true 3D projection
     for (int i = 0; i < segments2; ++i) {
-        float angle = i * angleStepSpoke;
+        float angle = i * (TWO_PI / segments2);
 
-        // Fading blue channel gradient along the radial direction
-        GFXColor ci(col.r, col.g, col.b * std::fabs(std::sin(angle * 0.5f)), col.a);
+        GFXColor ci(col.r, col.g, col.b * std::fabs(std::sin(angle / 2.0f)), col.a);
         ImU32 spokeColor = ToImColor(ci);
 
-        bool isCardinal = (std::fabs(angle - 1.57f) < 0.01f) || 
-                         (std::fabs(angle - 3.14f) < 0.01f) || 
-                         (std::fabs(angle - 4.71f) < 0.01f) || 
-                         (angle < 0.01f);
+        QVector pos1(0.6 * size * std::cos(angle) / (circles * 2), 0.6 * size * std::sin(angle) / (circles * 2), 0.0);
+        QVector pos2(0.6 * size * std::cos(angle), 0.6 * size * std::sin(angle), 0.0);
 
-        float outerScale = isCardinal ? 1.1f : 1.0f;
+        if ((std::fabs(angle - 1.57f) < 0.01f) || (std::fabs(angle - 3.14f) < 0.01f) || 
+            (std::fabs(angle - 4.71f) < 0.01f) || (angle < 0.01f)) {
+            pos2 *= 1.1f;
+        }
 
-        // Radial start and end points along ellipse boundary
-        auto GetEllipsePoint = [&](float a, float scaleFactor) -> ImVec2 {
-            float ex = radiusX * scaleFactor * std::cos(a);
-            float ey = radiusY * scaleFactor * std::sin(a);
-            float rotX = ex * std::cos(rot_y) - ey * std::sin(rot_y);
-            float rotY = ex * std::sin(rot_y) + ey * std::cos(rot_y);
-            return ImVec2(center.x + rotX, center.y + rotY);
-        };
+        pos1 = dxyz(pos1, 0, 0, rot_y);
+        pos1 = dxyz(pos1, rot_x, 0, 0);
+        pos2 = dxyz(pos2, 0, 0, rot_y);
+        pos2 = dxyz(pos2, rot_x, 0, 0);
 
-        ImVec2 pInner = GetEllipsePoint(angle, innerScale);
-        ImVec2 pOuter = GetEllipsePoint(angle, outerScale);
+        float standard_unit = 0.25f * 1.2f * size;
+        float zdistance1 = (1.2f * size) - pos1.k;
+        float zdistance2 = (1.2f * size) - pos2.k;
+        float zscale1 = standard_unit / zdistance1;
+        float zscale2 = standard_unit / zdistance2;
 
-        drawList->AddLine(pInner, pOuter, spokeColor, NAV_LINE_WEIGHT);
+        pos1 *= (zscale1 * 5.0f);
+        pos2 *= (zscale2 * 5.0f);
+
+        drawList->AddLine(
+            NormToPixel(x + pos1.i, y + pos1.j),
+            NormToPixel(x + pos2.i, y + pos2.j),
+            spokeColor, NAV_LINE_WEIGHT
+        );
     }
 }

--- a/engine/src/gfx/nav/navitemstodraw.h
+++ b/engine/src/gfx/nav/navitemstodraw.h
@@ -25,409 +25,316 @@
  * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
  */
 // NO HEADER GUARD
+#include "imgui/imgui.h"
+#include <cmath>
 
-//This draws the mouse cursor
-//**********************************
-void NavigationSystem::DrawCursor(float x, float y, float wid, float hei, const GFXColor &col) {
-    float sizex, sizey;
-    const bool modern_nav_cursor = configuration().graphics.nav.modern_mouse_cursor;
-    if (modern_nav_cursor) {
-        const std::string mouse_cursor_sprite = configuration().graphics.nav.mouse_cursor_sprite;
-        static VSSprite MouseVSSprite(mouse_cursor_sprite.c_str(), BILINEAR, GFXTRUE);
-        GFXBlendMode(SRCALPHA, INVSRCALPHA);
-        GFXColorf(GUI_OPAQUE_WHITE());
+static constexpr float NAV_LINE_WEIGHT = 2.0f; // Adjust as needed
 
-        //Draw the cursor sprite.
-        GFXEnable(TEXTURE0);
-        GFXDisable(DEPTHTEST);
-        GFXDisable(TEXTURE1);
-        MouseVSSprite.GetSize(sizex, sizey);
-        MouseVSSprite.SetPosition(x + sizex / 2, y + sizey / 2);
-        MouseVSSprite.Draw();
-    } else {
-        GFXColorf(col);
-        GFXDisable(TEXTURE0);
-        GFXDisable(LIGHTING);
-        GFXBlendMode(SRCALPHA, INVSRCALPHA);
-
-        const float verts[8 * 3] = {
-                x, y, 0,
-                x, y - hei, 0,
-                x, y, 0,
-                x + wid, y - 0.75f * hei, 0,
-                x, y - hei, 0,
-                x + 0.35f * wid, y - 0.6f * hei, 0,
-                x + 0.35f * wid, y - 0.6f * hei, 0,
-                x + wid, y - 0.75f * hei, 0,
-        };
-        GFXDraw(GFXLINE, verts, 8);
-
-        GFXEnable(TEXTURE0);
-    }
+// Helper to convert GFXColor/GFXColorf to ImU32 packed color
+static inline ImU32 ToImColor(const GFXColor &col) {
+    return IM_COL32(
+        static_cast<int>(col.r * 255.0f),
+        static_cast<int>(col.g * 255.0f),
+        static_cast<int>(col.b * 255.0f),
+        static_cast<int>(col.a * 255.0f)
+    );
 }
-//**********************************
 
-//This draws the grid over the nav screen area
+// Converts normalized screen coordinates to ImGui pixel screen coordinates
+static inline ImVec2 NormToPixel(float x, float y) {
+    return ImVec2(
+        static_cast<float>(Coordinates::normToPixelX(x)),
+        static_cast<float>(Coordinates::normToPixelY(y))
+    );
+}
+
+// Helper to retrieve current ImGui draw list (Background layer)
+static inline ImDrawList* GetNavDrawList() {
+    return ImGui::GetBackgroundDrawList();
+}
+
+//**********************************
+// Draws a 10x10 coordinate grid over the nav screen area
 //**********************************
 void NavigationSystem::DrawGrid(float &x1, float &x2, float &y1, float &y2, const GFXColor &col) {
     if (!configuration().graphics.hud.draw_nav_grid) {
         return;
     }
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
 
-    float deltax = x2 - x1;
-    deltax = deltax / 10;
-    float deltay = y2 - y1;
-    deltay = deltay / 10;
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    static VertexBuilder<> verts;
-    verts.clear();
+    float deltax = (x2 - x1) / 10.0f;
+    float deltay = (y2 - y1) / 10.0f;
+
+    // Vertical grid lines
     for (int i = 1; i < 10; i++) {
-        verts.insert(x1 + i * deltax, y1, 0);
-        verts.insert(x1 + i * deltax, y2, 0);
+        float x = x1 + i * deltax;
+        drawList->AddLine(
+            NormToPixel(x, y1),
+            NormToPixel(x, y2),
+            color, 1.0f
+        );
     }
-    for (int i = 1; i < 10; i++) {
-        verts.insert(x1, y1 + i * deltay, 0);
-        verts.insert(x2, y1 + i * deltay, 0);
-    }
-    GFXDraw(GFXLINE, verts);
 
-    GFXEnable(TEXTURE0);
+    // Horizontal grid lines
+    for (int i = 1; i < 10; i++) {
+        float y = y1 + i * deltay;
+        drawList->AddLine(
+            NormToPixel(x1, y),
+            NormToPixel(x2, y),
+            color, 1.0f
+        );
+    }
 }
-//**********************************
 
-//This will draw a circle over the screen
+//**********************************
+// Draws a circle icon centered at (x, y)
 //**********************************
 void NavigationSystem::DrawCircle(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    // 20 segments
-    static VertexBuilder<> verts;
-    verts.clear();
-    for (float i = 0; i < 2 * M_PI + M_PI / 10; i += M_PI / 10) {
-        verts.insert(
-                x + 0.5 * size * cos(i),
-                y + 0.5 * size * sin(i),
-                0
-        );
-    }
-    GFXDraw(GFXLINESTRIP, verts);
+    float pixelRadius = Coordinates::normToPixelW(0.5f * size);
 
-    GFXEnable(TEXTURE0);
+    drawList->AddCircle(NormToPixel(x, y), pixelRadius, color, 0, NAV_LINE_WEIGHT);
 }
-//**********************************
 
-//This will draw a half circle, centered at the top 1/4 center
+//**********************************
+// Draws a half circle centered at top 1/4 center
 //**********************************
 void NavigationSystem::DrawHalfCircleTop(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    // 10 segments
-    static VertexBuilder<> verts;
-    verts.clear();
-    for (float i = 0; i < M_PI + M_PI / 10; i += M_PI / 10) {
-        verts.insert(
-                x + 0.5 * size * cos(i),
-                y + 0.5 * size * sin(i) - 0.25 * size,
-                0
-        );
+    const int segments = 10;
+    float radius = 0.5f * size;
+    float yOffset = y - 0.25f * size;
+
+    drawList->PathClear();
+    for (int i = 0; i <= segments; ++i) {
+        float angle = i * (static_cast<float>(M_PI) / segments);
+        float px = x + radius * std::cos(angle);
+        float py = yOffset + radius * std::sin(angle);
+        drawList->PathLineTo(NormToPixel(px, py));
     }
-    GFXDraw(GFXLINESTRIP, verts);
-
-    GFXEnable(TEXTURE0);
+    drawList->PathStroke(color, 0, NAV_LINE_WEIGHT);
 }
-//**********************************
 
-//This will draw a half circle, centered at the bottom 1/4 center
+//**********************************
+// Draws a half circle centered at bottom 1/4 center
 //**********************************
 void NavigationSystem::DrawHalfCircleBottom(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    // 10 segments
-    static VertexBuilder<> verts;
-    verts.clear();
-    for (float i = M_PI; i < 2 * M_PI + M_PI / 10; i += M_PI / 10) {
-        verts.insert(
-                x + 0.5 * size * cos(i),
-                y + 0.5 * size * sin(i) + 0.25 * size,
-                0
-        );
+    const int segments = 10;
+    float radius = 0.5f * size;
+    float yOffset = y + 0.25f * size;
+
+    drawList->PathClear();
+    for (int i = 0; i <= segments; ++i) {
+        float angle = static_cast<float>(M_PI) + i * (static_cast<float>(M_PI) / segments);
+        float px = x + radius * std::cos(angle);
+        float py = yOffset + radius * std::sin(angle);
+        drawList->PathLineTo(NormToPixel(px, py));
     }
-    GFXDraw(GFXLINESTRIP, verts);
-
-    GFXEnable(TEXTURE0);
+    drawList->PathStroke(color, 0, NAV_LINE_WEIGHT);
 }
-//**********************************
 
-//This will draw a planet icon. circle + lightning thingy
+//**********************************
+// Draws a planet icon (Circle with central axis lines)
 //**********************************
 void NavigationSystem::DrawPlanet(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    static VertexBuilder<> verts;
-    verts.clear();
-    for (float i = 0; i < 2 * M_PI; i += M_PI / 10) {
-        verts.insert(
-                x + 0.5 * size * cos(i),
-                y + 0.5 * size * sin(i),
-                0
-        );
-        verts.insert(
-                x + 0.5 * size * cos(i + M_PI / 10),
-                y + 0.5 * size * sin(i + M_PI / 10),
-                0
-        );
-    }
-    verts.insert(x - 0.5 * size, y, 0);
-    verts.insert(x, y + 0.2 * size, 0);
-    verts.insert(x, y + 0.2 * size, 0);
-    verts.insert(x, y - 0.2 * size, 0);
-    verts.insert(x, y - 0.2 * size, 0);
-    verts.insert(x + 0.5 * size, y, 0);
-    GFXDraw(GFXLINE, verts);
+    // Outer circle
+    float radius = 0.5f * size;
+    DrawCircle(x ,y, size, col);
 
-    GFXEnable(TEXTURE0);
+    // Planet interior lines
+    drawList->AddLine(NormToPixel(x - radius, y), NormToPixel(x, y + 0.2f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x, y + 0.2f * size), NormToPixel(x, y - 0.2f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x, y - 0.2f * size), NormToPixel(x + radius, y), color, NAV_LINE_WEIGHT);
 }
-//**********************************
 
-//This will draw a station icon. 3x3 grid
+//**********************************
+// Draws a station icon (3x3 grid pattern)
 //**********************************
 void NavigationSystem::DrawStation(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    float segment = size / 3;
-    static VertexBuilder<> verts;
-    verts.clear();
-    for (int i = 0; i < 4; i++) {
-        verts.insert(
-                x - 0.5 * size,
-                y - 0.5 * size + i * segment,
-                0
-        );
-        verts.insert(
-                x + 0.5 * size,
-                y - 0.5 * size + i * segment,
-                0
-        );
-    }
-    for (int i = 0; i < 4; i++) {
-        verts.insert(
-                x - 0.5 * size + i * segment,
-                y - 0.5 * size,
-                0
-        );
-        verts.insert(
-                x - 0.5 * size + i * segment,
-                y + 0.5 * size,
-                0
-        );
-    }
-    GFXDraw(GFXLINE, verts);
+    float segment = size / 3.0f;
+    float startX = x - 0.5f * size;
+    float startY = y - 0.5f * size;
+    float endX = x + 0.5f * size;
+    float endY = y + 0.5f * size;
 
-    GFXEnable(TEXTURE0);
+    // Horizontal lines
+    for (int i = 0; i < 4; i++) {
+        float currentY = startY + i * segment;
+        drawList->AddLine(NormToPixel(startX, currentY), NormToPixel(endX, currentY), color, NAV_LINE_WEIGHT);
+    }
+
+    // Vertical lines
+    for (int i = 0; i < 4; i++) {
+        float currentX = startX + i * segment;
+        drawList->AddLine(NormToPixel(currentX, startY), NormToPixel(currentX, endY), color, NAV_LINE_WEIGHT);
+    }
 }
-//**********************************
 
-//This will draw a jump node icon
+//**********************************
+// Draws a jump node icon (Circle with cardinal arrow indicators)
 //**********************************
 void NavigationSystem::DrawJump(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    static VertexBuilder<> verts;
-    verts.clear();
-    for (float i = 0; i < 2 * M_PI; i += M_PI / 10) {
-        verts.insert(
-                x + 0.5 * size * cos(i),
-                y + 0.5 * size * sin(i),
-                0
-        );
-        verts.insert(
-                x + 0.5 * size * cos(i + M_PI / 10),
-                y + 0.5 * size * sin(i + M_PI / 10),
-                0
-        );
-    }
-    verts.insert(x, y + 0.5 * size, 0);
-    verts.insert(x + 0.125 * size, y + 0.125 * size, 0);
-    verts.insert(x, y + 0.5 * size, 0);
-    verts.insert(x - 0.125 * size, y + 0.125 * size, 0);
-    verts.insert(x, y - 0.5 * size, 0);
-    verts.insert(x + 0.125 * size, y - 0.125 * size, 0);
-    verts.insert(x, y - 0.5 * size, 0);
-    verts.insert(x - 0.125 * size, y - 0.125 * size, 0);
-    verts.insert(x - 0.5 * size, y, 0);
-    verts.insert(x - 0.125 * size, y + 0.125 * size, 0);
-    verts.insert(x - 0.5 * size, y, 0);
-    verts.insert(x - 0.125 * size, y - 0.125 * size, 0);
-    verts.insert(x + 0.5 * size, y, 0);
-    verts.insert(x + 0.125 * size, y + 0.125 * size, 0);
-    verts.insert(x + 0.5 * size, y, 0);
-    verts.insert(x + 0.125 * size, y - 0.125 * size, 0);
-    GFXDraw(GFXLINE, verts);
+    float radius = 0.5f * size;
+    float offset = 0.125f * size;
 
-    GFXEnable(TEXTURE0);
+    // Outer circle
+    DrawCircle(x ,y, size, col);
+
+    // Cardinal arrows
+    drawList->AddLine(NormToPixel(x, y + radius), NormToPixel(x + offset, y + offset), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x, y + radius), NormToPixel(x - offset, y + offset), color, NAV_LINE_WEIGHT);
+
+    drawList->AddLine(NormToPixel(x, y - radius), NormToPixel(x + offset, y - offset), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x, y - radius), NormToPixel(x - offset, y - offset), color, NAV_LINE_WEIGHT);
+
+    drawList->AddLine(NormToPixel(x - radius, y), NormToPixel(x - offset, y + offset), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x - radius, y), NormToPixel(x - offset, y - offset), color, NAV_LINE_WEIGHT);
+
+    drawList->AddLine(NormToPixel(x + radius, y), NormToPixel(x + offset, y + offset), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x + radius, y), NormToPixel(x + offset, y - offset), color, NAV_LINE_WEIGHT);
 }
 
 //**********************************
-
-//This will draw a missile icon
+// Draws a missile warning/target icon
 //**********************************
 void NavigationSystem::DrawMissile(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    const float verts[12 * 3] = {
-            x - 0.5f * size, y - 0.125f * size, 0,
-            x, y + 0.375f * size, 0,
-            x + 0.5f * size, y - 0.125f * size, 0,
-            x, y + 0.375f * size, 0,
-            x - 0.25f * size, y - 0.125f * size, 0,
-            x - 0.25f * size, y + 0.125f * size, 0,
-            x + 0.25f * size, y - 0.125f * size, 0,
-            x + 0.25f * size, y + 0.125f * size, 0,
-            x - 0.25f * size, y + 0.125f * size, 0,
-            x, y - 0.125f * size, 0,
-            x + 0.25f * size, y + 0.125f * size, 0,
-            x, y - 0.125f * size, 0,
-    };
-    GFXDraw(GFXLINE, verts, 12);
-
-    GFXEnable(TEXTURE0);
+    drawList->AddLine(NormToPixel(x - 0.5f * size, y - 0.125f * size), NormToPixel(x, y + 0.375f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x + 0.5f * size, y - 0.125f * size), NormToPixel(x, y + 0.375f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x - 0.25f * size, y - 0.125f * size), NormToPixel(x - 0.25f * size, y + 0.125f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x + 0.25f * size, y - 0.125f * size), NormToPixel(x + 0.25f * size, y + 0.125f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x - 0.25f * size, y + 0.125f * size), NormToPixel(x, y - 0.125f * size), color, NAV_LINE_WEIGHT);
+    drawList->AddLine(NormToPixel(x + 0.25f * size, y + 0.125f * size), NormToPixel(x, y - 0.125f * size), color, NAV_LINE_WEIGHT);
 }
-//**********************************
 
-//This will draw a square set of corners
+//**********************************
+// Draws corner brackets for targeting frames
 //**********************************
 void NavigationSystem::DrawTargetCorners(float x, float y, float size, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
+    ImU32 color = ToImColor(col);
 
-    const float verts[16 * 3] = {
-            x - 0.5f * size, y + 0.5f * size, 0,
-            x - 0.3f * size, y + 0.5f * size, 0,
-            x - 0.5f * size, y + 0.5f * size, 0,
-            x - 0.5f * size, y + 0.3f * size, 0,
-            x + 0.5f * size, y + 0.5f * size, 0,
-            x + 0.3f * size, y + 0.5f * size, 0,
-            x + 0.5f * size, y + 0.5f * size, 0,
-            x + 0.5f * size, y + 0.3f * size, 0,
-            x - 0.5f * size, y - 0.5f * size, 0,
-            x - 0.3f * size, y - 0.5f * size, 0,
-            x - 0.5f * size, y - 0.5f * size, 0,
-            x - 0.5f * size, y - 0.3f * size, 0,
-            x + 0.5f * size, y - 0.5f * size, 0,
-            x + 0.3f * size, y - 0.5f * size, 0,
-            x + 0.5f * size, y - 0.5f * size, 0,
-            x + 0.5f * size, y - 0.3f * size, 0,
-    };
-    GFXDraw(GFXLINE, verts, 16);
+    float half = 0.5f * size;
+    float inner = 0.3f * size;
 
-    GFXEnable(TEXTURE0);
+    // Top-Left corner
+    drawList->AddLine(NormToPixel(x - half, y + half), NormToPixel(x - inner, y + half), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(NormToPixel(x - half, y + half), NormToPixel(x - half, y + inner), color, NAV_LINE_WEIGHT*2);
+
+    // Top-Right corner
+    drawList->AddLine(NormToPixel(x + half, y + half), NormToPixel(x + inner, y + half), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(NormToPixel(x + half, y + half), NormToPixel(x + half, y + inner), color, NAV_LINE_WEIGHT*2);
+
+    // Bottom-Left corner
+    drawList->AddLine(NormToPixel(x - half, y - half), NormToPixel(x - inner, y - half), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(NormToPixel(x - half, y - half), NormToPixel(x - half, y - inner), color, NAV_LINE_WEIGHT*2);
+
+    // Bottom-Right corner
+    drawList->AddLine(NormToPixel(x + half, y - half), NormToPixel(x + inner, y - half), color, NAV_LINE_WEIGHT*2);
+    drawList->AddLine(NormToPixel(x + half, y - half), NormToPixel(x + half, y - inner), color, NAV_LINE_WEIGHT*2);
 }
-//**********************************
 
-//This will draw an oriented circle
+//**********************************
+// Draws a 3D projected navigation disc using smooth ImGui Ellipses
 //**********************************
 void NavigationSystem::DrawNavCircle(float x, float y, float size, float rot_x, float rot_y, const GFXColor &col) {
-    GFXColorf(col);
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
+    ImDrawList* drawList = GetNavDrawList();
 
-    const int circles = 4;
-    const int segments = 20;
-    const int segments2 = 12;
-    const int vnum = 2 * (circles * segments + segments2);
-    static VertexBuilder<float, 3, 0, 4> verts;
-    verts.clear();
-    verts.reserve(vnum);
-    for (float i = 0; i < 2 * M_PI; i += (2 * M_PI / segments)) {
-        GFXColor ci(col.r, col.g, col.b * fabs(sin(i / 2.0)), col.a);
-        QVector pos1((0.6 * size * cos(i)), (0.6 * size * sin(i)), 0);
-        QVector pos2((0.6 * size * cos(i + (2 * M_PI / segments))), (0.6 * size * sin(i + (6.28 / segments))), 0);
+    constexpr int circles = 4;
+    constexpr int segments2 = 12;
+    constexpr float TWO_PI = 2.0f * static_cast<float>(M_PI);
 
-        pos1 = dxyz(pos1, 0, 0, rot_y);
-        pos1 = dxyz(pos1, rot_x, 0, 0);
-        pos2 = dxyz(pos2, 0, 0, rot_y);
-        pos2 = dxyz(pos2, rot_x, 0, 0);
+    // Compute pixel radii based on 3D tilt
+    ImVec2 center = NormToPixel(x, y);
+    float baseRadiusPx = Coordinates::normToPixelW(0.6f * size);
+    
+    // Minor axis compresses based on pitch tilt (rot_x)
+    float radiusX = baseRadiusPx;
+    float radiusY = baseRadiusPx * std::fabs(std::cos(rot_x));
 
-        float standard_unit = 0.25 * 1.2 * size;
-        float zdistance1 = ((1.2 * size) - pos1.k);
-        float zdistance2 = ((1.2 * size) - pos2.k);
-        float zscale1 = standard_unit / zdistance1;
-        float zscale2 = standard_unit / zdistance2;
-        pos1 *= (zscale1 * 5.0);
-        pos2 *= (zscale2 * 5.0);
+    // -------------------------------------------------------------------------
+    // 1. Smooth Concentric Web Ellipses
+    // -------------------------------------------------------------------------
+    for (int j = circles; j > 0; --j) {
+        float scale = static_cast<float>(j) / static_cast<float>(circles);
+        float rx = radiusX * scale;
+        float ry = radiusY * scale;
 
-        for (int j = circles; j > 0; j--) {
-            pos1 *= (float(j) / float(circles));
-            pos2 *= (float(j) / float(circles));
+        // Draw rotated ellipse path
+        drawList->PathClear();
+        constexpr int ellipseSegments = 32; // Smooth auto-tessellated curve
+        
+        for (int i = 0; i < ellipseSegments; ++i) {
+            float a = i * (TWO_PI / ellipseSegments);
+            
+            // Unrotated ellipse point
+            float ex = rx * std::cos(a);
+            float ey = ry * std::sin(a);
 
-            Vector pos1t((x + pos1.i), (y + (pos1.j)), 0);
-            Vector pos2t((x + pos2.i), (y + (pos2.j)), 0);
+            // Apply yaw rotation (rot_y) on screen plane
+            float rotX = ex * std::cos(rot_y) - ey * std::sin(rot_y);
+            float rotY = ex * std::sin(rot_y) + ey * std::cos(rot_y);
 
-            verts.insert(GFXColorVertex(pos1t, ci));
-            verts.insert(GFXColorVertex(pos2t, ci));
+            drawList->PathLineTo(ImVec2(center.x + rotX, center.y + rotY));
         }
+
+        // Color with standard alpha
+        ImU32 ringColor = ToImColor(col);
+        drawList->PathStroke(ringColor, ImDrawFlags_Closed, NAV_LINE_WEIGHT);
     }
-    for (float i = 0; i < 2 * M_PI; i += (2 * M_PI / segments2)) {
-        GFXColor ci(col.r, col.g, col.b * fabs(sin(i / 2.0)), col.a);
-        QVector pos1((0.6 * size * cos(i) / float(circles * 2)), (0.6 * size * sin(i) / float(circles * 2)), 0);
-        QVector pos2((0.6 * size * cos(i)), (0.6 * size * sin(i)), 0);
 
-        if ((fabs(i - 1.57) < 0.01) || (fabs(i - 3.14) < 0.01) || (fabs(i - 4.71) < 0.01) || (i < 0.01)) {
-            pos2 *= 1.1;
-        }
-        pos1 = dxyz(pos1, 0, 0, rot_y);
-        pos1 = dxyz(pos1, rot_x, 0, 0);
-        pos2 = dxyz(pos2, 0, 0, rot_y);
-        pos2 = dxyz(pos2, rot_x, 0, 0);
+    // -------------------------------------------------------------------------
+    // 2. Radial Spoke Lines (12 Rays from center outward)
+    // -------------------------------------------------------------------------
+    constexpr float angleStepSpoke = TWO_PI / static_cast<float>(segments2);
+    constexpr float innerScale = 1.0f / static_cast<float>(circles * 2);
 
-        float standard_unit = 0.25 * 1.2 * size;
-        float zdistance1 = ((1.2 * size) - pos1.k);
-        float zdistance2 = ((1.2 * size) - pos2.k);
-        float zscale1 = standard_unit / zdistance1;
-        float zscale2 = standard_unit / zdistance2;
-        pos1 *= (zscale1 * 5.0);
-        pos2 *= (zscale2 * 5.0);
+    for (int i = 0; i < segments2; ++i) {
+        float angle = i * angleStepSpoke;
 
-        pos1.i += x;
-        pos1.j += y;
-        pos2.i += x;
-        pos2.j += y;
+        // Fading blue channel gradient along the radial direction
+        GFXColor ci(col.r, col.g, col.b * std::fabs(std::sin(angle * 0.5f)), col.a);
+        ImU32 spokeColor = ToImColor(ci);
 
-        // pos, col
-        verts.insert(GFXColorVertex(pos1.Cast(), ci));
-        verts.insert(GFXColorVertex(pos2.Cast(), ci));
+        bool isCardinal = (std::fabs(angle - 1.57f) < 0.01f) || 
+                         (std::fabs(angle - 3.14f) < 0.01f) || 
+                         (std::fabs(angle - 4.71f) < 0.01f) || 
+                         (angle < 0.01f);
+
+        float outerScale = isCardinal ? 1.1f : 1.0f;
+
+        // Radial start and end points along ellipse boundary
+        auto GetEllipsePoint = [&](float a, float scaleFactor) -> ImVec2 {
+            float ex = radiusX * scaleFactor * std::cos(a);
+            float ey = radiusY * scaleFactor * std::sin(a);
+            float rotX = ex * std::cos(rot_y) - ey * std::sin(rot_y);
+            float rotY = ex * std::sin(rot_y) + ey * std::cos(rot_y);
+            return ImVec2(center.x + rotX, center.y + rotY);
+        };
+
+        ImVec2 pInner = GetEllipsePoint(angle, innerScale);
+        ImVec2 pOuter = GetEllipsePoint(angle, outerScale);
+
+        drawList->AddLine(pInner, pOuter, spokeColor, NAV_LINE_WEIGHT);
     }
-    GFXDraw(GFXLINE, verts);
-
-    GFXEnable(TEXTURE0);
 }
-//**********************************
-

--- a/engine/src/gfx/nav/navscreen.cpp
+++ b/engine/src/gfx/nav/navscreen.cpp
@@ -65,6 +65,7 @@
 #include "gfx/nav/navcomputer.h"
 #include "gfx/nav/navpath.h"
 #include "gldrv/winsys.h"
+#include "gui/imgui_support.h"
 
 //This sets up the items in the navscreen
 //**********************************
@@ -456,6 +457,8 @@ void NavigationSystem::Draw() {
     GFXHudMode(true);
     GFXDisable(DEPTHTEST);
     GFXDisable(DEPTHWRITE);
+    StartGUIFrame();
+    
     //**********************************
 
     screenoccupation->reset();
@@ -543,6 +546,7 @@ void NavigationSystem::Draw() {
     //**********************************
 
     GFXEnable(TEXTURE0);
+    EndGUIFrame(MOUSE_POINTER_NORMAL);
     GFXHudMode(false);
 }
 //**********************************

--- a/engine/src/gfx/nav/navscreen.cpp
+++ b/engine/src/gfx/nav/navscreen.cpp
@@ -458,7 +458,16 @@ void NavigationSystem::Draw() {
     GFXDisable(DEPTHTEST);
     GFXDisable(DEPTHWRITE);
     StartGUIFrame();
-    
+ 
+    // Obscure cockpit almost completely.
+    const ImVec2 start_position(0,0);
+    const ImVec2 end_position(configuration().graphics.resolution_x,
+                              configuration().graphics.resolution_y);
+    const ImU32 background_color = IM_COL32(0,0,0,224);
+    ImGui::GetBackgroundDrawList()->AddRectFilled(start_position, end_position, background_color,
+                    0.0f // No rounded borders
+    );
+
     //**********************************
 
     screenoccupation->reset();
@@ -672,7 +681,7 @@ void NavigationSystem::DrawMission() {
         text += "\n";
     }
     text +=
-            "#FFA000     PRESS SHIFT-M TO TOGGLE THIS MENU    \n\n\n\n#000000*******#00a6FFVega Strike 0.7#000000*********\nWelcome to VS. Your ship undocks stopped; #8080FFArrow keys/mouse/joystick#000000 steer your ship. Use #8080FF+#000000 & #8080FF-#000000 to adjust cruise control, or #8080FF/#000000 & #8080FF[backspace]#000000 to go to max governor setting or full-stop, respectively. Use #8080FFy#000000 to toggle between maneuver and travel settings for your relative velocity governors. Use #8080ff[home]#000000 & #8080FF[end]#000000 to set and unset velocity reference point to the current target (non-hostile targets only). Use #8080FFTab#000000 to activate Overdrive(if present).\n\nPress #8080FFn#000000 to cycle nav points, #8080FFt#000000 to cycle targets, and #8080FFp#000000 to target objects in front of you.\n\n#8080FF[space]#000000 fires guns, and #8080ff[Enter]#000000 fires missiles.\n\nThe #8080FFa#000000 key activates SPEC drive for insystem FTL.\nInterstellar Travel requires a #FFBB11 jump drive#000000 and #FFBB11FTL Capacitors#000000 to be installed. To jump, fly into the green wireframe nav-marker; hit #8080FFj#000000 to jump to the linked system.\n\nTo dock, target a base, planet or large vessel and hail with #8080FF0#000000 to request docking clearance. When you get close, a green box will appear. Fly to the box. When inside the box, #8080FFd#000000 will dock.\n\n#FF0000If Vega Strike halts or acts oddly,#000000\n#FFFF00immediately#000000 post the latest log\nfile from $HOME/.vegastrike/logs/\nto https://forums.vega-strike.org/\nbefore you restart Vega Strike.\n";
+            "#FFA000     PRESS SHIFT-M TO TOGGLE THIS MENU    \n\n\n\n#000000*******#00a6FFVega Strike 0.10.0#000000*********\nWelcome to VS. Your ship undocks stopped; #8080FFArrow keys/mouse/joystick#000000 steer your ship. Use #8080FF+#000000 & #8080FF-#000000 to adjust cruise control, or #8080FF/#000000 & #8080FF[backspace]#000000 to go to max governor setting or full-stop, respectively. Use #8080FFy#000000 to toggle between maneuver and travel settings for your relative velocity governors. Use #8080ff[home]#000000 & #8080FF[end]#000000 to set and unset velocity reference point to the current target (non-hostile targets only). Use #8080FFTab#000000 to activate Overdrive(if present).\n\nPress #8080FFn#000000 to cycle nav points, #8080FFt#000000 to cycle targets, and #8080FFp#000000 to target objects in front of you.\n\n#8080FF[space]#000000 fires guns, and #8080ff[Enter]#000000 fires missiles.\n\nThe #8080FFa#000000 key activates SPEC drive for insystem FTL.\nInterstellar Travel requires a #FFBB11 jump drive#000000 and #FFBB11FTL Capacitors#000000 to be installed. To jump, fly into the green wireframe nav-marker; hit #8080FFj#000000 to jump to the linked system.\n\nTo dock, target a base, planet or large vessel and hail with #8080FF0#000000 to request docking clearance. When you get close, a green box will appear. Fly to the box. When inside the box, #8080FFd#000000 will dock.\n\n#FF0000If Vega Strike halts or acts oddly,#000000\n#FFFF00immediately#000000 post the latest log\nfile from $HOME/.vegastrike/logs/\nto https://forums.vega-strike.org/\nbefore you restart Vega Strike.\n";
     displayname.SetText(text);
     displayname.SetCharSize(1, 1);
     displayname.Draw();
@@ -1249,7 +1258,7 @@ void NavigationSystem::DrawButton(float &x1, float &x2, float &y1, float &y2, in
             } else {
                 //if in mission mode
 
-                navcomp->run();
+                flipbit(whattodraw, 1);
             }
         }
         //******************************************************
@@ -1699,50 +1708,30 @@ void NavigationSystem::RecordMinAndMax(const QVector &pos,
     //**********************************
 }
 
+/*
+ * Draws the origin orientation triad (X, Y, Z axes widget) using ImGui DrawList
+ * and normalized-to-pixel coordinate conversion.
+ */
 void NavigationSystem::DrawOriginOrientationTri(float center_nav_x, float center_nav_y, bool system_not_galaxy) {
-    //Draw Origin Orientation Tri
-    //**********************************
-    QVector directionx;
-    QVector directiony;
-    QVector directionz;
+    // Determine basis vectors based on active axis alignment
+    QVector directionx, directiony, directionz;
+
     if (axis == 2) {
-        directionx.i = 0.1;
-        directionx.j = 0.0;
-        directionx.k = 0.0;
-
-        directionz.i = 0.0;
-        directionz.j = 0.1;
-        directionz.k = 0.0;
-
-        directiony.i = 0.0;
-        directiony.j = 0.0;
-        directiony.k = 0.1;
+        directionx = QVector(0.1f, 0.0f, 0.0f);
+        directionz = QVector(0.0f, 0.1f, 0.0f);
+        directiony = QVector(0.0f, 0.0f, 0.1f);
     } else if (axis == 1) {
-        directiony.i = 0.1;
-        directiony.j = 0.0;
-        directiony.k = 0.0;
-
-        directionz.i = 0.0;
-        directionz.j = 0.1;
-        directionz.k = 0.0;
-
-        directionx.i = 0.0;
-        directionx.j = 0.0;
-        directionx.k = 0.1;
+        directiony = QVector(0.1f, 0.0f, 0.0f);
+        directionz = QVector(0.0f, 0.1f, 0.0f);
+        directionx = QVector(0.0f, 0.0f, 0.1f);
     } else {
-        //(axis == 3)
-        directionx.i = 0.1;
-        directionx.j = 0.0;
-        directionx.k = 0.0;
-
-        directiony.i = 0.0;
-        directiony.j = 0.1;
-        directiony.k = 0.0;
-
-        directionz.i = 0.0;
-        directionz.j = 0.0;
-        directionz.k = 0.1;
+        // (axis == 3)
+        directionx = QVector(0.1f, 0.0f, 0.0f);
+        directiony = QVector(0.0f, 0.1f, 0.0f);
+        directionz = QVector(0.0f, 0.0f, 0.1f);
     }
+
+    // Apply 3D rotation matrix transformations if in 3D view mode
     if (system_not_galaxy) {
         if (system_view == VIEW_3D) {
             directionx = dxyz(directionx, 0, 0, ry_s);
@@ -1764,31 +1753,37 @@ void NavigationSystem::DrawOriginOrientationTri(float center_nav_x, float center
         directionz = dxyz(directionz, 0, 0, ry);
         directionz = dxyz(directionz, rx, 0, 0);
     }
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
 
-    float x0 = center_nav_x - 0.8 * ((screenskipby4[1] - screenskipby4[0]) / 2);
-    float y0 = center_nav_y - 0.8 * ((screenskipby4[3] - screenskipby4[2]) / 2);
-    float x1 = x0 + (directionx.i * (0.3 / (0.3 - directionx.k)));
-    float y1 = y0 + (directionx.j * (0.3 / (0.3 - directionx.k)));
-    float x2 = x0 + (directiony.i * (0.3 / (0.3 - directiony.k)));
-    float y2 = y0 + (directiony.j * (0.3 / (0.3 - directiony.k)));
-    float x3 = x0 + (directionz.i * (0.3 / (0.3 - directionz.k)));
-    float y3 = y0 + (directionz.j * (0.3 / (0.3 - directionz.k)));
+    // Compute normalized origin and axis endpoint coordinates
+    float x0 = center_nav_x - 0.8f * ((screenskipby4[1] - screenskipby4[0]) / 2.0f);
+    float y0 = center_nav_y - 0.8f * ((screenskipby4[3] - screenskipby4[2]) / 2.0f);
 
-    const float verts[6 * (3 + 4)] = {
-            x0, y0, 0, 1, 0, 0, 0.5,
-            x1, y1, 0, 1, 0, 0, 0.5,
-            x0, y0, 0, 0, 1, 0, 0.5,
-            x2, y2, 0, 0, 1, 0, 0.5,
-            x0, y0, 0, 0, 0, 1, 0.5,
-            x3, y3, 0, 0, 0, 1, 0.5,
-    };
-    GFXDraw(GFXLINE, verts, 6, 3, 4);
+    float x1 = x0 + (directionx.i * (0.3f / (0.3f - directionx.k)));
+    float y1 = y0 + (directionx.j * (0.3f / (0.3f - directionx.k)));
 
-    GFXEnable(TEXTURE0);
-    //**********************************
+    float x2 = x0 + (directiony.i * (0.3f / (0.3f - directiony.k)));
+    float y2 = y0 + (directiony.j * (0.3f / (0.3f - directiony.k)));
+
+    float x3 = x0 + (directionz.i * (0.3f / (0.3f - directionz.k)));
+    float y3 = y0 + (directionz.j * (0.3f / (0.3f - directionz.k)));
+
+    // Convert normalized coordinates to screen pixels
+    ImVec2 p0(static_cast<float>(Coordinates::normToPixelX(x0)), static_cast<float>(Coordinates::normToPixelY(y0)));
+    ImVec2 p1(static_cast<float>(Coordinates::normToPixelX(x1)), static_cast<float>(Coordinates::normToPixelY(y1)));
+    ImVec2 p2(static_cast<float>(Coordinates::normToPixelX(x2)), static_cast<float>(Coordinates::normToPixelY(y2)));
+    ImVec2 p3(static_cast<float>(Coordinates::normToPixelX(x3)), static_cast<float>(Coordinates::normToPixelY(y3)));
+
+    ImDrawList* drawList = ImGui::GetForegroundDrawList();
+
+    // Packed RGB colors with 0.5 (128) Alpha
+    const ImU32 red   = IM_COL32(255,   0,   0, 128); // X Axis
+    const ImU32 green = IM_COL32(  0, 255,   0, 128); // Y Axis
+    const ImU32 blue  = IM_COL32(  0,   0, 255, 128); // Z Axis
+
+    // Draw origin triad lines
+    drawList->AddLine(p0, p1, red,   2.0f);
+    drawList->AddLine(p0, p2, green, 2.0f);
+    drawList->AddLine(p0, p3, blue,  2.0f);
 }
 
 float NavigationSystem::CalculatePerspectiveAdjustment(float &zscale,
@@ -1979,6 +1974,9 @@ void NavigationSystem::TranslateAndDisplay(QVector &pos,
     DisplayOrientationLines(the_x, the_y, the_x_flat, the_y_flat, system_not_galaxy);
 }
 
+/*
+ * Display orientation projection lines using ImGui DrawList and pixel projection.
+ */
 void NavigationSystem::DisplayOrientationLines(float the_x,
         float the_y,
         float the_x_flat,
@@ -1987,43 +1985,58 @@ void NavigationSystem::DisplayOrientationLines(float the_x,
     if ((system_not_galaxy ? system_view : galaxy_view) == VIEW_ORTHO) {
         return;
     }
-    //Draw orientation lines
-    //**********************************
-    GFXDisable(TEXTURE0);
-    GFXDisable(LIGHTING);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
-    GFXColorf(GFXColor(0.5, 0.5, 0.5, .15));
+
+    ImDrawList* drawList = ImGui::GetBackgroundDrawList();
+
+    // Default line color: Grey with ~15% Alpha
+    GFXColor lineCol(0.5f, 0.5f, 0.5f, 0.15f);
 
     bool display_flat_circle = true;
     if ((the_y_flat > screenskipby4[3])
             || (the_y_flat < screenskipby4[2])
             || (the_x_flat > screenskipby4[1])
             || (the_x_flat < screenskipby4[0])) {
-        GFXColorf(GFXColor(0, 1, 1, .05));
+        // Cyan tint with 5% Alpha if flat point is out of screen bounds
+        lineCol = GFXColor(0.0f, 1.0f, 1.0f, 0.05f);
         display_flat_circle = false;
     }
+
     bool display_flat = true;
     if ((the_x > screenskipby4[1])
             || (the_x < screenskipby4[0])
             || (the_y > screenskipby4[3])
             || (the_y < screenskipby4[2])) {
-        GFXColorf(GFXColor(1, 1, 0, .05));
+        // Yellow tint with 5% Alpha if main point is out of screen bounds
+        lineCol = GFXColor(1.0f, 1.0f, 0.0f, 0.05f);
         display_flat = false;
     }
+
     if (display_flat) {
         IntersectBorder(the_x_flat, the_y_flat, the_x, the_y);
-        const float verts[2 * 3] = {
-                the_x_flat, the_y_flat, 0,
-                the_x, the_y, 0,
-        };
-        GFXDraw(GFXLINE, verts, 2);
+
+        // Draw the orientation vector line
+        ImVec2 p1 = ImVec2(
+            static_cast<float>(Coordinates::normToPixelX(the_x_flat)),
+            static_cast<float>(Coordinates::normToPixelY(the_y_flat))
+        );
+        ImVec2 p2 = ImVec2(
+            static_cast<float>(Coordinates::normToPixelX(the_x)),
+            static_cast<float>(Coordinates::normToPixelY(the_y))
+        );
+
+        ImU32 colPacked = IM_COL32(
+            static_cast<int>(lineCol.r * 255.0f),
+            static_cast<int>(lineCol.g * 255.0f),
+            static_cast<int>(lineCol.b * 255.0f),
+            static_cast<int>(lineCol.a * 255.0f)
+        );
+
+        drawList->AddLine(p1, p2, colPacked, 1.0f);
+
         if (display_flat_circle) {
-            DrawCircle(the_x_flat, the_y_flat, (.005 * system_item_scale), GFXColor(1, 1, 1, .2));
+            DrawCircle(the_x_flat, the_y_flat, (0.005f * system_item_scale), GFXColor(1.0f, 1.0f, 1.0f, 0.2f));
         }
     }
-
-    GFXEnable(TEXTURE0);
-    //**********************************
 }
 
 void Beautify(string systemfile, string &sector, string &system) {

--- a/engine/src/gfx/nav/navscreen.cpp
+++ b/engine/src/gfx/nav/navscreen.cpp
@@ -667,7 +667,7 @@ void NavigationSystem::DrawMission() {
     TextPlane displayname;
     GFXColor temp_color(1, 1, 1, 1);
     displayname.color = static_cast<ImU32>(temp_color);
-    displayname.SetSize(.42, -.7);
+    displayname.SetSize(.62, -.7);
     displayname.SetPos(originx + (.1 * deltax) + .37, originy /*+(1*deltay)*/ );
     std::string text;
     if (active_missions.size() > 1) {

--- a/engine/src/gfx/nav/navscreen.h
+++ b/engine/src/gfx/nav/navscreen.h
@@ -27,7 +27,6 @@
 #ifndef VEGA_STRIKE_ENGINE_GFX_NAV_NAV_SCREEN_H
 #define VEGA_STRIKE_ENGINE_GFX_NAV_NAV_SCREEN_H
 
-#include "gui/glut_support.h"
 #include "gfx/nav/navscreenoccupied.h"
 #include "gfx/nav/drawlist.h"
 #include "gfx/nav/navitemtypes.h"

--- a/engine/src/gfx/sprite.cpp
+++ b/engine/src/gfx/sprite.cpp
@@ -34,14 +34,14 @@
 #include "gfx/aux_texture.h"
 #include "gfx/ani_texture.h"
 #include "gfx/sprite.h"
-#include "gfx_generic/matrix.h"
 #include "src/gfxlib.h"
-#include "src/vegastrike.h"
 #include "root_generic/vs_globals.h"
 #include "gldrv/gl_globals.h"
 #include <assert.h>
 #include <math.h>
 #include "src/gnuhash.h"
+#include "imgui/imgui.h"
+#include "gui/guidefs.h"
 
 #ifdef _WIN32
 #include <direct.h>
@@ -297,6 +297,43 @@ void VSSprite::Draw() {
         }
         GFXEnable(CULLFACE);
     }
+}
+
+// draws a sprite at its position with ImGUI
+void VSSprite::DrawWithImGui(ImDrawList *drawList = ImGui::GetBackgroundDrawList()) {
+    if (!surface) {
+        return;
+    }
+
+    // FIXME - support multi-texture, rotation, passes and layers
+
+    // Make the sprite's texture active and fetch its GL ID
+    surface->MakeActive(0, 0);
+    
+    GLint actual_gl_id = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &actual_gl_id);
+    if (actual_gl_id <= 0) return;
+
+    ImTextureID texID = static_cast<ImTextureID>(static_cast<uintptr_t>(actual_gl_id));
+
+    // Get current sprite position, we draw from top left, thus adjust Y
+    ImVec2 topLeft(
+    Coordinates::normToPixelX(xcenter),
+    Coordinates::normToPixelY(ycenter + heighto2 * 2)
+    );
+    // Get the size of the sprite in pixels
+    ImVec2 spriteSize(Coordinates::normToPixelW(widtho2 * 2), Coordinates::normToPixelH(heighto2 * 2)); 
+
+    // Draw directly to ImGui's top-level overlay
+    // Note: (0,0) to (1,1) UVs work cleanly here. If flipped vertically, swap 0.0f and 1.0f on Y.
+    drawList->AddImage(
+        texID,
+        topLeft,                                             // Top-left (Hotspot)
+        ImVec2(topLeft.x + spriteSize.x, topLeft.y + spriteSize.y), // Bottom-right
+        ImVec2(0.0f, 1.0f),                                   // UV Top-Left
+        ImVec2(1.0f, 0.0f),                                   // UV Bottom-Right
+        IM_COL32(255, 255, 255, 255)
+    );
 }
 
 void VSSprite::SetPosition(const float &x1, const float &y1) {

--- a/engine/src/gfx/sprite.h
+++ b/engine/src/gfx/sprite.h
@@ -27,9 +27,8 @@
 #ifndef VEGA_STRIKE_ENGINE_GFX_SPRITE_H
 #define VEGA_STRIKE_ENGINE_GFX_SPRITE_H
 
+#include "imgui/imgui.h"
 #include "src/gfxlib.h"
-
-#include "gfx_generic/quaternion.h"
 
 #include "audio/Types.h"
 #include "audio/Source.h"
@@ -73,6 +72,7 @@ public:
 //Return true if sprite was loaded successfully
     bool LoadSuccess() const;
     void Draw();
+    void DrawWithImGui(ImDrawList *drawList);
 /**
  * Draw at specified coordinates given by 4 endpoints.
  *

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -57,7 +57,7 @@
 #include <SDL3/SDL_video.h>
 
 #include "gldrv/mouse_cursor.h"
-
+#include "backends/imgui_impl_sdl3.h"
 /*
  * Windowing System Abstraction Layer
  * Abstracts creation of windows, handling of events, etc.
@@ -687,7 +687,10 @@ void winsys_process_events() {
     }
     while (keepRunning) {
         while (SDL_PollEvent(&event)) {
+            // forward all events to ImGUI
+            ImGui_ImplSDL3_ProcessEvent(&event);
 
+            // now the VS processing of events
             state = false;
             switch (event.type) {
                 case SDL_EVENT_KEY_UP:

--- a/engine/src/gui/glut_support.cpp
+++ b/engine/src/gui/glut_support.cpp
@@ -27,18 +27,10 @@
 
 #include <png.h>
 #include "glut_support.h"
-#include "gfx/sprite.h"
-#include "root_generic/vs_globals.h"
-#include "gfx/aux_texture.h"
-#include "root_generic/vs_globals.h"
-#include "src/config_xml.h"
-#include "gfx/vsimage.h"
-#include "vegadisk/vsfilesystem.h"
 #include "src/vs_logging.h"
 #include "gldrv/gl_globals.h"
 #include "configuration/configuration.h"
 
-using namespace VSFileSystem;
 
 #define isspAce(chr)                                                                  \
     ( (chr == '\t') || (chr == '\n') || (chr == '\v') || (chr == '\f') || (chr == '\r') \
@@ -151,80 +143,3 @@ float WidthOfChar(char chr) {
     width /= 2500;
     return width;
 }
-
-static int mmx = 0;
-static int mmy = 0;
-
-void SetSoftwareMousePosition(int x, int y) {
-    mmx = x;
-    mmy = y;
-}
-
-/** Starts a Frame of OpenGL with proper parameters and mouse
- */
-void StartGUIFrame(GFXBOOL clr) {
-    //glutSetCursor(GLUT_CURSOR_INHERIT);
-    //GFXViewPort (0,0,configuration().graphics.resolution_x,configuration().graphics.resolution_y);
-    GFXHudMode(true);
-    GFXColor4f(1, 1, 1, 1);
-
-    GFXDisable(DEPTHTEST);
-    GFXEnable(DEPTHWRITE);
-    GFXDisable(LIGHTING);
-    GFXDisable(CULLFACE);
-    GFXClear(clr);
-    GFXDisable(DEPTHWRITE);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
-    GFXDisable(TEXTURE1);
-    GFXEnable(TEXTURE0);
-}
-
-void DrawGlutMouse(int mousex, int mousey, VSSprite *spr) {
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
-    GFXColor4f(1, 1, 1, 1);
-    GFXDisable(TEXTURE1);
-    GFXEnable(TEXTURE0);
-    GFXDisable(DEPTHTEST);
-    GFXDisable(LIGHTING);
-    float sizex = 0, sizey = 0;
-    spr->GetSize(sizex, sizey);
-    float tempx = 0, tempy = 0;
-    spr->GetPosition(tempx, tempy);
-    spr->SetPosition(tempx + -1 + .5 * sizex + float(mousex)
-            / (.5 * configuration().graphics.resolution_x), tempy + 1 + .5 * sizey - float(mousey) / (.5 * configuration().graphics.resolution_y));
-    spr->Draw();
-    GFXDisable(TEXTURE0);
-    GFXEnable(TEXTURE0);
-    spr->SetPosition(tempx, tempy);
-}
-
-extern void ConditionalCursorDraw(bool);
-
-void EndGUIFrame(MousePointerStyle pointerStyle) {
-    static VSSprite MouseOverVSSprite("mouseover.spr", BILINEAR, GFXTRUE);
-    static VSSprite MouseVSSprite("mouse.spr", BILINEAR, GFXTRUE);
-    static Texture dummy("white.bmp", 0, NEAREST, TEXTURE2D, TEXTURE_2D, GFXTRUE);
-
-    if (pointerStyle != MOUSE_POINTER_NONE) {
-        dummy.MakeActive();
-        GFXDisable(CULLFACE);
-
-        VSSprite *whichSprite = &MouseVSSprite;
-        switch (pointerStyle) {
-            case MOUSE_POINTER_NORMAL:
-                whichSprite = &MouseVSSprite;
-                break;
-            case MOUSE_POINTER_HOVER:
-                whichSprite = &MouseOverVSSprite;
-                break;
-            case MOUSE_POINTER_NONE:
-                return;
-        }
-
-        //GFXEndScene();bad things...only call this once
-        GFXHudMode(false);
-        GFXEnable(CULLFACE);
-        ConditionalCursorDraw(true);
-    }
-}
-

--- a/engine/src/gui/imgui_support.cpp
+++ b/engine/src/gui/imgui_support.cpp
@@ -33,9 +33,9 @@
 
 
 static bool softwarePosition;
-// virtual mouse x after sensitivity adjustmemt
+// virtual mouse x after sensitivity adjustment
 static int mmx = 0;
-// virtual mouse x after sensitivity adjustmemt
+// virtual mouse y after sensitivity adjustment
 static int mmy = 0;
 
 // Set the software mouse position

--- a/engine/src/gui/imgui_support.cpp
+++ b/engine/src/gui/imgui_support.cpp
@@ -1,0 +1,106 @@
+/*
+ * imgui_support.cpp
+ *
+ * Vega Strike - Space Simulation, Combat and Trading
+ * Copyright (C) 2001-2026 The Vega Strike Contributors:
+ * Project creator: Daniel Horn
+ * Original development team: As listed in the AUTHORS file
+ * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy, Danny Gehl
+ *
+ * https://github.com/vegastrike/Vega-Strike-Engine-Source
+ *
+ * This file is part of Vega Strike.
+ *
+ * Vega Strike is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Vega Strike is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <png.h>
+#include "gui/imgui_support.h"
+#include "gfx/sprite.h"
+#include "imgui/imgui.h"
+//#include "configuration/configuration.h"
+
+
+static bool softwarePosition;
+// virtual mouse x after sensitivity adjustmemt
+static int mmx = 0;
+// virtual mouse x after sensitivity adjustmemt
+static int mmy = 0;
+
+// Set the software mouse position
+void SetSoftwareMousePosition(int x, int y) {
+    softwarePosition = true;
+    mmx = x;
+    mmy = y;
+}
+
+/** Initialises a Frame with proper settings for ImGUI and mouse */
+void StartGUIFrame(void) {
+    softwarePosition = false;
+    GFXHudMode(true);
+    // this will hide whatever is behind (the cockpit)
+    GFXClear(GFXTRUE);
+}
+
+void DrawMouseCursor(MousePointerStyle pointerStyle) {
+    static VSSprite MouseOverVSSprite("mouseover.spr", BILINEAR, GFXTRUE);
+    static VSSprite MouseVSSprite("mouse.spr", BILINEAR, GFXTRUE);
+
+    if (pointerStyle != MOUSE_POINTER_NONE) {
+        VSSprite *whichSprite = &MouseVSSprite;
+        switch (pointerStyle) {
+            case MOUSE_POINTER_NORMAL:
+                whichSprite = &MouseVSSprite;
+                break;
+            case MOUSE_POINTER_HOVER:
+                whichSprite = &MouseOverVSSprite;
+                break;
+            case MOUSE_POINTER_NONE:
+                return;
+        }
+
+        float normX;
+        float normY;
+        // if(softwarePosition) {
+        //     normX = mmx;
+        //     normY = mmy;
+        //     int xrez = configuration().graphics.resolution_x;
+        //     const int whentodouble = configuration().joystick.double_mouse_position;
+        //     const float factor = configuration().joystick.double_mouse_factor_flt;
+        //     if (xrez >= whentodouble) {
+        //         normX /= factor;
+        //         normY /= factor;
+        //     }
+        // } else {
+            ImVec2 mousePos = ImGui::GetMousePos();
+            normX = (2.0f * mousePos.x / ImGui::GetIO().DisplaySize.x) - 1.0f;
+            normY = (1.0f - 2.0f * mousePos.y / ImGui::GetIO().DisplaySize.y);
+        // }
+
+
+        // VS_LOG(error, (boost::format("MouseLoc X: %1% | Computed Norm X: %2%") % globalEventManager().mouseLoc().x % normX).str());
+        whichSprite->SetPosition(normX, normY);
+
+        whichSprite->DrawWithImGui(ImGui::GetForegroundDrawList());
+    }
+}
+
+extern void ConditionalCursorDraw(bool);
+
+/** End a Frame with proper cleanup for ImGUI and draw mouse cursor in the foreground */
+void EndGUIFrame(MousePointerStyle pointerStyle) {
+    DrawMouseCursor(pointerStyle);
+    GFXHudMode(false);
+}
+

--- a/engine/src/gui/imgui_support.h
+++ b/engine/src/gui/imgui_support.h
@@ -1,11 +1,11 @@
 /*
- * glut_support.h
+ * imgui_support.h
  *
  * Vega Strike - Space Simulation, Combat and Trading
  * Copyright (C) 2001-2026 The Vega Strike Contributors:
  * Project creator: Daniel Horn
- * Original development team: As listed in the AUTHORS file. Specifically: David Ranger
- * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy
+ * Original development team: As listed in the AUTHORS file
+ * Current development team: Roy Falk, Benjamen R. Meyer, Stephen G. Tuggy, Danny Gehl
  *
  * https://github.com/vegastrike/Vega-Strike-Engine-Source
  *
@@ -24,20 +24,22 @@
  * You should have received a copy of the GNU General Public License
  * along with Vega Strike.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef VEGA_STRIKE_ENGINE_GUI_GLUT_SUPPORT_H
-#define VEGA_STRIKE_ENGINE_GUI_GLUT_SUPPORT_H
 
-/* If you have functions that perform the same operation, but use different parameters,
- * It may be best if you replace the following functions with wrappers to your own functions
+/**
+ * This util class contains helpers which can be used in the event loops
  */
+
+#include <boost/parameter/aux_/void.hpp>
 #include <vector>
 using std::vector;
-#include "gfxlib.h"
 
+enum MousePointerStyle {
+    MOUSE_POINTER_NONE,
+    MOUSE_POINTER_NORMAL,
+    MOUSE_POINTER_HOVER
+};
 
-void ShowColor(float x, float y, float wid, float hei, float red, float green, float blue, float alpha);
-void ShowText(float x, float y, float wid, int size, const char *string, int no_end);
-float WidthOfChar(char chr);
-extern int HAS_ALPHA;
-
-#endif    //VEGA_STRIKE_ENGINE_GUI_GLUT_SUPPORT_H
+void SetSoftwareMousePosition(int x, int y);
+void StartGUIFrame(void);
+void DrawMouseCursor(MousePointerStyle pointerStyle);
+void EndGUIFrame(MousePointerStyle pointerStyle);

--- a/engine/src/gui/window.cpp
+++ b/engine/src/gui/window.cpp
@@ -31,12 +31,9 @@
 #include "groupcontrol.h"
 #include "windowcontroller.h"
 
-#include "eventmanager.h"
-
 //For drawing the cursor.
-#include "gfx/aux_texture.h"
-#include "gfx/sprite.h"
 #include "imgui/imgui.h"
+#include "gui/imgui_support.h"
 
 //The outside boundaries of the window.
 void Window::setRect(const Rect &r) {
@@ -115,8 +112,8 @@ void Window::draw(void) {
         
         drawBackground();
         m_controls->draw();
+        ImGui::End();
     }
-    ImGui::End();
     
     ImGui::PopStyleColor();
 
@@ -206,17 +203,7 @@ extern void ConditionalCursorDraw(bool);
 //Draw all visible windows.
 void WindowManager::draw() {
     GFXHudMode(true);            //Load identity matrices.
-    GFXColorf(GUI_OPAQUE_WHITE());
 
-    GFXDisable(DEPTHTEST);
-    GFXEnable(DEPTHWRITE);
-    GFXDisable(LIGHTING);
-    GFXDisable(CULLFACE);
-    GFXClear(GFXTRUE);
-    GFXDisable(DEPTHWRITE);
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
-    GFXDisable(TEXTURE1);
-    GFXEnable(TEXTURE0);
     //Just loop through all the windows, and remember if anything gets drawn.
     //Since the first window in the list is drawn first, z-order is
     //maintained.  First entry is the bottom window, last is the top window.
@@ -230,32 +217,9 @@ void WindowManager::draw() {
             m_windows[i]->draw();
         }
     }
-    //Emulate EndGUIFrame.
-    static VSSprite MouseVSSprite("mouse.spr", BILINEAR, GFXTRUE);
-    static Texture dummy("white.bmp", 0, NEAREST, TEXTURE2D, TEXTURE_2D, GFXTRUE);
-    GFXDisable(CULLFACE);
-    ConditionalCursorDraw(true);
-    //Figure position of cursor sprite.
-    float sizex = 0.0, sizey = 0.0;
-    const Point loc = globalEventManager().mouseLoc();
-    MouseVSSprite.GetSize(sizex, sizey);
-    float tempx = 0.0, tempy = 0.0;
-    MouseVSSprite.GetPosition(tempx, tempy);
-    MouseVSSprite.SetPosition(tempx + loc.x + sizex / 2, tempy + loc.y + sizey / 2);
-
-    dummy.MakeActive();
-    GFXBlendMode(SRCALPHA, INVSRCALPHA);
-    GFXColorf(GUI_OPAQUE_WHITE());
-
-    //Draw the cursor sprite.
-    GFXEnable(TEXTURE0);
-    GFXDisable(DEPTHTEST);
-    GFXDisable(TEXTURE1);
-    //MouseVSSprite.Draw();
 
     GFXHudMode(false);
-    GFXEnable(CULLFACE);
-    MouseVSSprite.SetPosition(tempx, tempy);
+    EndGUIFrame(MOUSE_POINTER_NORMAL);
 }
 
 //A new window has been created and is ready to be drawn.

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -421,6 +421,9 @@ void Universe::StartDraw() {
                             configuration().graphics.resolution_y);
     ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
 
+    // hide the mouse cursor, we got a cooler one!
+    ImGui::SetMouseCursor(ImGuiMouseCursor_None);
+
     size_t i;
     StarSystem* lastStarSystem = nullptr;
     ImGui::Begin("main_window", nullptr, window_flags);


### PR DESCRIPTION
Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only

This PR migrates remaining UIs to ImGUI, I'll put a list here so we have a better overview.

## Migration overview

- [X] Basecomputer - already done with #1666 
- [X] Mouse cursor restored for main menu, bases and base computer
- [X] Nav screen migrated to use ImGUI drawing
- [ ] Render bases with ImGUI
- [ ] Pause screen - need to update my bindings to get there, don't have a Pause/Break key
- [ ] Help (key overview) - for this I'd create a separate PR which renders this screen using the actual key mapping instead of a static image
- [ ] Cockpit

## Drawing order considerations

**Important** currently we use 2 rendering methods, the original direct openGL drawing approach and ImGUI which collects all drawing instructions into a drawlist and draws it at the end of the event loop. This creates issues where we mix the approaches (prior to #1666) this was primarily text. In those cases, VS direct drawing will draw something only for ImGUI to overdraw it later without it becoming actually visible to the user. This is why the nav screen was broken and why migrating to ImGUI fixes it.

## Why not bases?

Bases are in principle just sprites and text, except for the landing bay however where the 3D model of the ship is drawn. I'm open for suggestions, but we can't draw the sprite with ImGUI easily without overdrawing the ship. I'm open for suggestions here as I might be missing something. It's not a massive issue from my perspective as this concerns a few isolated places. This is the only area where this happens as far as I'm aware, cockpit, nav computer etc. could all be migrated as there the GUI overlays the rendered space scene.

## Mouse

The mouse is now consistently disabled at the beginning of the event loop and drawn with a single method removing prior duplication of code. For the mouse to work properly, I needed to comment the software mouse sensitivity functionality which is ill-placed from my perspective (and therefore causing issues) and should be removed.

```
// biModifyMouseSensitivity(x, y, false);
```
I did see that @evertvorster made a similar change in #1678 in the meanwhile, now it is double-commented. This fixes #1668 and enables wonderful things like https://github.com/vegastrike/Assets-Production/pull/263 

## Sprite rendering

To render sprites I added a new `VSSprite::DrawWithImGui` method which is not the most beautiful solution. I picked it nonetheless because I think the Sprite is where it belongs and there is a `Draw` method already which is used widely and cannot just be updated (see drawing order section). For the mouse cursor, not all the sprite functionality is required and for the lack of any other use-case I left some features unimplemented. I'd suggest we implement once those use-cases become relevant (i.e. we need to draw sprites with mipmaps or the like). For all GUI use-cases this should do.

## Misc

Simplified some code and removed unneeded imports.