### PR TITLE
Fix prohibited upgrades doubling

### DIFF
--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -44,6 +44,10 @@ Resource<double> ComponentsManager::credits = Resource<double>(0.0, 0.0);
 void ComponentsManager::Load(std::string unit_key) {
     mass = base_mass = UnitCSVFactory::GetVariable(unit_key, "Mass", 0.0);
 
+    // Clear any previously-loaded prohibited upgrades so repeated Load() calls
+    // (e.g. the two calls made from Unit::LoadRow) do not accumulate duplicates.
+    prohibited_upgrades.clear();
+
     // Consumer
     std::string prohibited_upgrades_string = UnitCSVFactory::GetVariable(unit_key, "Prohibited_Upgrades", std::string());
 

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -62,17 +62,26 @@ void ComponentsManager::Load(std::string unit_key) {
         std::vector<std::string> parts;
         boost::split(parts, upgrade, boost::is_any_of(":"));
         if (parts.size() == 1) {
-            const std::string& category = parts[0];
-            prohibited_upgrades.emplace_back(category, 0);
+            AddProhibitedUpgrade(parts[0], 0);
         } else if (parts.size() == 2) {
-            const std::string& category = parts[0];
-            const int limit = locale_aware_stoi(parts[1]);
-            //const std::pair<const std::string, const int> pair(category, limit);
-            prohibited_upgrades.emplace_back(category, limit);
+            AddProhibitedUpgrade(parts[0], locale_aware_stoi(parts[1]));
         } else {
             VS_LOG(error, (boost::format("%1%: Invalid format in prohibited upgrades string: %2%") % __FUNCTION__ % upgrade));
         }
     }
+}
+
+// The pre-existing doubling bug (Load() called twice per unit construction)
+// could have left many identical duplicate groups in a save's string. Adding
+// is done deduplicated so a bloated save is collapsed to one copy and repaired
+// on the next save.
+void ComponentsManager::AddProhibitedUpgrade(const std::string& category, int limit) {
+    for (const auto& existing : prohibited_upgrades) {
+        if (existing.first == category && existing.second == limit) {
+            return;
+        }
+    }
+    prohibited_upgrades.emplace_back(category, limit);
 }
 
 void ComponentsManager::Serialize(std::map<std::string, std::string>& unit) const {

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -68,6 +68,9 @@ class ComponentsManager {
 
     std::vector<std::pair<const std::string, const int>> prohibited_upgrades;
 
+    // Deduplicated add — repairs the doubling-bug ballooned save lists.
+    void AddProhibitedUpgrade(const std::string& category, int limit);
+
     friend class CargoHold;
     friend class Movable;
 

--- a/libraries/cmd/unit_csv.cpp
+++ b/libraries/cmd/unit_csv.cpp
@@ -586,7 +586,17 @@ void Unit::LoadRow(std::string unit_identifier, string modification, bool saved_
     string tmpstr;
     csvRow = unit_identifier;
 
-    this->Load(unit_identifier);
+    // Load the named unit's components. For the LEGACY save-game format the
+    // resolved unit_key below is remapped to "player_ship", so this first
+    // load seeds the named ship's row before the remap; the Load(unit_key)
+    // call near the end then applies the saved per-ship state. For the NEW
+    // save-game format unit_key stays unit_identifier, making this first load
+    // redundant with the later one.
+    // TODO: remove this and the legacy "player_ship" remap once the legacy
+    // save-game format is retired (see SaveGame::new_save_game_format).
+    if (saved_game && !SaveGame::new_save_game_format) {
+        this->Load(unit_identifier);
+    }
 
     // Textual Descriptions
     this->setUnitKey(unit_identifier);


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [X] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
- [ ] This is a documentation change only
This does not affect gameplay, only stopping writing double entries for prohibited upgrades. When a saved game is written.
It is achieved by reading only unique upgrades and discarding the duplicates. Then, when saving, it only saves one copy. 

Issues:
- Please list any related issues
- -Fixes #1687
- - Fixes #1630 

Purpose:
- What is this pull request trying to do?
- - Fix a bug where save files get really large
- What release is this for?
- - Git master
- Is there a project or milestone we should apply this to?
N/A