### PR TITLE
0.10.x: Add in contents of Pull-Request-Validation wiki page, with check boxes, into PR template itself

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,36 @@ Thank you for submitting a pull request and becoming a contributor to the Vega S
 Please answer the following:
 
 Code Changes:
-- [ ] Have the PR Validation Tests been run? See https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation
+- [ ] Have the PR Validation Tests been run?
+  - [ ] Demonstrate that the issue is fixed or the feature exercised
+    - [ ] Specific testing where a clear, present, demonstrable test can be provided; OR
+    - [ ] Unit test(s) showing the exercise of the explicit code; OR
+    - [ ] Play test (see below) that demonstrates the feature/issue; OR
+    - [ ] Build test when things directly impact how the build functions or some part of the build is generated
+  - [ ] Play Tests
+    - [ ] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
+    - [ ] From the Main Menu, start a new Campaign.
+    - [ ] Basic flight.
+    - [ ] Docking to a planet.
+    - [ ] On planet actions:
+        - [ ] Save the game.
+        - [ ] Read news.
+        - [ ] Buy/Sell some goods.
+        - [ ] Buy/Sell a ship upgrade.
+        - [ ] Accept a mission from the bulletin board.
+        - [ ] Talk to someone in the bar.
+    - [ ] Primary and secondary weapon usage.
+    - [ ] Fight (you can fight with Oswald).
+    - [ ] SPEC flight.
+    - [ ] A jump to a different system.
+    - [ ] Docking to a non-planet location (mining base, etc).
+    - [ ] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
+    - [ ] Save the game again.
+    - [ ] Upgrade your new ship.
+    - [ ] Save once more.
+    - [ ] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
+    - [ ] Quit Vega Strike. Make sure it doesn't segfault on exit.
+    - [ ] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
 - [ ] This is a documentation change only
 
 Issues:


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] This is a documentation change only

Issues Addressed:
- Implements #1689 for 0.10.x

Known Issues Remaining:
- Nothing new that I'm aware of, except that it should be noted that several of the screens off the Main Menu have been displaying the wrong version number and the wrong (SourceForge) URL for some time now

Purpose:
- What is this pull request trying to do? Implement https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1689 for 0.10.x, adding the actual contents of the Pull Request Validation wiki page into the PR template itself, with check boxes next to each item.
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
