### PR TITLE
Energy-limited shield recharge: scale recharge cost by shield deficit

### DIFF
--- a/engine/src/components/shield.cpp
+++ b/engine/src/components/shield.cpp
@@ -364,7 +364,10 @@ void Shield::Regenerate(const bool player_ship) {
         return;
     }
 
-    const double shield_regeneration_cost = regeneration.AdjustedValue() * configuration().components.shield.regeneration_factor_dbl;
+    // Energy-limited recharge: the cost scales with the deficit being rebuilt, so a
+    // shield too big for the reactor charges at a reduced rate (slower) rather than
+    // at full speed. (Consume() returns the fraction the reactor could actually supply.)
+    const double shield_regeneration_cost = (TotalMaxLayerValue() - TotalLayerValue()) * configuration().components.shield.regeneration_factor_dbl;
     SetConsumption(shield_regeneration_cost);
     const double actual_regeneration_percent = Consume();
     double regen = actual_regeneration_percent * regeneration.AdjustedValue() * simulation_atom_var;


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run?
  - [x] Demonstrate that the issue is fixed or the feature exercised
    - [x] Specific testing where a clear, present, demonstrable test can be provided; OR
    - [ ] Unit test(s) showing the exercise of the explicit code; OR
    - [x] Play test (see below) that demonstrates the feature/issue; OR
    - [x] Build test when things directly impact how the build functions or some part of the build is generated
  - [x] Play Tests
    - [x] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
    - [x] From the Main Menu, start a new Campaign.
    - [x] Basic flight.
    - [x] Docking to a planet.
    - [x] On planet actions:
        - [x] Save the game.
        - [x] Read news.
        - [x] Buy/Sell some goods.
        - [x] Buy/Sell a ship upgrade.
        - [x] Accept a mission from the bulletin board.
        - [x] Talk to someone in the bar.
    - [x] Primary and secondary weapon usage.
    - [x] Fight (you can fight with Oswald).
    - [x] SPEC flight.
    - [x] A jump to a different system.
    - [x] Docking to a non-planet location (mining base, etc).
    - [x] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
    - [x] Save the game again.
    - [x] Upgrade your new ship.
    - [x] Save once more.
    - [x] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
    - [x] Quit Vega Strike. Make sure it doesn't segfault on exit.
    - [x] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- - In the event that a user has a shield that requires for some or the other reason more power than the reactor can give, maybe it got damaged or the user made a stupid mistake in buying it.  The current code disallows the shield to work at all, but it should work in a degraded fashion. IMHO. 

Purpose:
- What is this pull request trying to do?
- - This fix would allow the user to still charge up the shield, but at a much lower rate, which is determined by the shortfall in power delivery. 

Ie, if the shield requires 100Mj/s to charge at its optimum rate, but the reactor can only deliver 90Mj/s, then the shield will charge at 90% of its normal speed. If the shortfall is much larger, then the shields will charge much, much slower, and be practically useless in a fight. 

Think of it a little like charging your Tesla at the wall outlet. Its slow, and a pain, but it might just give you a little hope. :)


- What release is this for?
- 0.11
- Is there a project or milestone we should apply this to?
