### PR TITLE
Feature: Support reading from split config files. 

### DIFF
--- a/libraries/vegadisk/vsfilesystem.cpp
+++ b/libraries/vegadisk/vsfilesystem.cpp
@@ -869,13 +869,20 @@ void InitPaths(string conf, string subdir) {
         SubDirectories.push_back(vec);
     }
 
-    // Load the split config files (config.json + bindings.json + theme.json + engine.json).
-    // Each is loaded from the datadir (defaults) then the homedir (user override), merging into
-    // the same configuration singleton. load_config() tolerates missing files, so if only
-    // config.json exists, only that is loaded.
-    for (const std::string & config_file_name : {"config.json", "bindings.json", "theme.json", "engine.json"}) {
+    // Load the split config files (config.json + bindings.json + theme.json + engine.json),
+    // merging each into the same configuration singleton. load_config() tolerates missing
+    // files, so if only config.json exists, only that is loaded.
+    //
+    // Precedence (later loads overwrite earlier ones):
+    //   1. All datadir files first (defaults).
+    //   2. All homedir files second (user overrides win over defaults).
+    //   3. Within each group, config.json loads last, so a user-facing setting in config.json
+    //      overwrites the same key in engine.json/theme.json/bindings.json.
+    for (const std::string & config_file_name : {"bindings.json", "theme.json", "engine.json", "config.json"}) {
         (const_cast<vega_config::Configuration&>(configuration())).load_config(
             boost::filesystem::path(datadir + "/" + config_file_name));
+    }
+    for (const std::string & config_file_name : {"bindings.json", "theme.json", "engine.json", "config.json"}) {
         (const_cast<vega_config::Configuration&>(configuration())).load_config(
             boost::filesystem::path(homedir + "/" + config_file_name));
     }

--- a/libraries/vegadisk/vsfilesystem.cpp
+++ b/libraries/vegadisk/vsfilesystem.cpp
@@ -869,10 +869,16 @@ void InitPaths(string conf, string subdir) {
         SubDirectories.push_back(vec);
     }
 
-    const boost::filesystem::path config_file_path{datadir + "/config.json"};
-    (const_cast<vega_config::Configuration&>(configuration())).load_config(config_file_path);
-    const boost::filesystem::path config_file_path2{homedir + "/config.json"};
-    (const_cast<vega_config::Configuration&>(configuration())).load_config(config_file_path2);
+    // Load the split config files (config.json + bindings.json + theme.json + engine.json).
+    // Each is loaded from the datadir (defaults) then the homedir (user override), merging into
+    // the same configuration singleton. load_config() tolerates missing files, so if only
+    // config.json exists, only that is loaded.
+    for (const std::string & config_file_name : {"config.json", "bindings.json", "theme.json", "engine.json"}) {
+        (const_cast<vega_config::Configuration&>(configuration())).load_config(
+            boost::filesystem::path(datadir + "/" + config_file_name));
+        (const_cast<vega_config::Configuration&>(configuration())).load_config(
+            boost::filesystem::path(homedir + "/" + config_file_name));
+    }
 
     LoadConfig(std::move(subdir));
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run?
  - [x] Demonstrate that the issue is fixed or the feature exercised
    - [x] Specific testing where a clear, present, demonstrable test can be provided; OR
    - [ ] Unit test(s) showing the exercise of the explicit code; OR
    - [ ] Play test (see below) that demonstrates the feature/issue; OR
    - [ ] Build test when things directly impact how the build functions or some part of the build is generated
  - [ ] Play Tests
    - [x] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
    - [x] From the Main Menu, start a new Campaign.
    - [x] Basic flight.
    - [x] Docking to a planet.
    - [x] On planet actions:
        - [x] Save the game.
        - [x] Read news.
        - [x] Buy/Sell some goods.
        - [x] Buy/Sell a ship upgrade.
        - [x] Accept a mission from the bulletin board.
        - [x] Talk to someone in the bar.
    - [x] Primary and secondary weapon usage.
    - [x] Fight (you can fight with Oswald).
    - [x] SPEC flight.
    - [ ] A jump to a different system.
    - [x] Docking to a non-planet location (mining base, etc).
    - [ ] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
    - [x] Save the game again.
    - [x] Upgrade your new ship.
    - [x] Save once more.
    - [ ] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
    - [ ] Quit Vega Strike. Make sure it doesn't segfault on exit.
    - [x] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
- [ ] This is a documentation change only

Issues:
- Please list any related issues
We are trying to upgrade and finally move the config app into the game engine. 
It has been suggested that the config file is too big, and needed to be split. 
This split config files still needs to be parsed by the engine. 

Purpose:
- What is this pull request trying to do?
- - These are the changes needed for the engine to read from a split config file set.

**If the config file is not split, this change has no effect, the engine reads all the configs from the one file, or the split, its all good**

**Pre-existing Issues?**
Ship Info is empty on bases. 
Oswald is nerfed, and does not attack. I can kill him with a few laser shots.
Capacitors don't regenerate when firing shots. I thought we fixed this one? I'll check. 
Accepted a mission from mission computer, then aborted it. Talked to confed officer in bar, and when accepting his mission, the game crashed. 
Navigation computer text going off the screen, and background text shining through making it very hard to read. 
Mouse flight controls don't work. <- I'm sitting on code that will make this work, but we first have to get the config utility upgraded. 
 
- What release is this for?
- -0.11
- Is there a project or milestone we should apply this to?
- 0.11