### PR TITLE
Fix mouse wheel scrolling in SDL3 (base computer, navscreen, pickers)

### DIFF
--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -713,6 +713,24 @@ void winsys_process_events() {
                     }
                     break;
 
+                case SDL_EVENT_MOUSE_WHEEL:
+                    // SDL3 reports the wheel as its own event (not a button).
+                    // Synthesize wheel-up / wheel-down button presses so the
+                    // existing mouse-button pipeline (lookupMouseButton maps
+                    // WS_WHEEL_UP->3 / WS_WHEEL_DOWN->4) keeps working -- this
+                    // is what drives scrolling in the base computer etc.
+                    if (mouse_func) {
+                        const float wheel_y = event.wheel.y;
+                        if (wheel_y > 0.0F) {
+                            (*mouse_func)(WS_WHEEL_UP, WS_MOUSE_DOWN, event.wheel.mouse_x, event.wheel.mouse_y);
+                            (*mouse_func)(WS_WHEEL_UP, WS_MOUSE_UP, event.wheel.mouse_x, event.wheel.mouse_y);
+                        } else if (wheel_y < 0.0F) {
+                            (*mouse_func)(WS_WHEEL_DOWN, WS_MOUSE_DOWN, event.wheel.mouse_x, event.wheel.mouse_y);
+                            (*mouse_func)(WS_WHEEL_DOWN, WS_MOUSE_UP, event.wheel.mouse_x, event.wheel.mouse_y);
+                        }
+                    }
+                    break;
+
                 case SDL_EVENT_MOUSE_MOTION:
                     if (event.motion.state) {
                         /* buttons are down */


### PR DESCRIPTION
SDL3 reports the mouse wheel as a separate SDL_EVENT_MOUSE_WHEEL event, but winsys_process_events only handled SDL_EVENT_MOUSE_BUTTON_DOWN/UP, so wheel scrolls were dropped entirely and the base computer (and other scrollable widgets) couldn't scroll.

Add a MOUSE_WHEEL case that synthesizes wheel-up / wheel-down button presses (WS_WHEEL_UP=254 / WS_WHEEL_DOWN=255) into the existing mouse-button pipeline. lookupMouseButton already maps these to button 3/4, which the navscreen documents as wheel up/down (getMouseButtonStatus()&8 / &16).

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run?
  - [ ] Demonstrate that the issue is fixed or the feature exercised
    - [ ] Specific testing where a clear, present, demonstrable test can be provided; OR
    - [ ] Unit test(s) showing the exercise of the explicit code; OR
    - [ ] Play test (see below) that demonstrates the feature/issue; OR
    - [ ] Build test when things directly impact how the build functions or some part of the build is generated
  - [x] Play Tests
    - [x] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
    - [x] From the Main Menu, start a new Campaign.
    - [x] Basic flight.
    - [x] Docking to a planet.
    - [x] On planet actions:
        - [x] Save the game.
        - [x] Read news.
        - [x] Buy/Sell some goods.
        - [x] Buy/Sell a ship upgrade.
        - [x] Accept a mission from the bulletin board.
        - [x] Talk to someone in the bar.
    - [x] Primary and secondary weapon usage.
    - [x] Fight (you can fight with Oswald).
    - [x] SPEC flight.
    - [x] A jump to a different system.
    - [x] Docking to a non-planet location (mining base, etc).
    - [x] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
    - [x] Save the game again.
    - [x] Upgrade your new ship.
    - [x] Save once more.
    - [x] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
    - [x] Quit Vega Strike. Make sure it doesn't segfault on exit.
    - [x] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- - Scroll wheel not working in base computer. 

Purpose:
- What is this pull request trying to do?
- - Re-enable mouse scroll wheel after SDL3 conversion.
- What release is this for?
- -0.11
- Is there a project or milestone we should apply this to?
- - 0.11