### PR TITLE
Fix shield maintenance draining the capacitor at full shields

### DIFF
--- a/engine/src/components/shield.cpp
+++ b/engine/src/components/shield.cpp
@@ -340,6 +340,18 @@ void Shield::Regenerate(const bool player_ship) {
     * Finally, you adjust whatever used it to the value in question
     */
 
+    // Fully charged shields need no energy - return before any consumption.
+    // (Regression fix: the maintenance drain below used to run even at full
+    // shields, draining the primary capacitor (which the weapons also use) at
+    // max_shield x maintenance_factor per second. For ships whose shield max
+    // exceeds their reactor output - e.g. a Mule (18600 shields) or any
+    // capital ship - that left the capacitor empty, so neither the shields nor
+    // the weapons could ever function. See the 'capacitor never refills after
+    // firing' / 'AI ships never fire' reports.)
+    if (TotalLayerValue() == TotalMaxLayerValue()) {
+        return;
+    }
+
     // Shield Maintenance
     // TODO: lib_damage restore efficiency by replacing with shield->efficiency
     //const double efficiency = 1;
@@ -359,11 +371,6 @@ void Shield::Regenerate(const bool player_ship) {
     }
 
     // Shield Regeneration
-    if(TotalLayerValue() == TotalMaxLayerValue()) {
-        // Fully charged. No need for more action or energy consumption
-        return;
-    }
-
     const double shield_regeneration_cost = regeneration.AdjustedValue() * configuration().components.shield.regeneration_factor_dbl;
     SetConsumption(shield_regeneration_cost);
     const double actual_regeneration_percent = Consume();


### PR DESCRIPTION
Regression from ca3df7f9c (Feb 2025, PR #1016): Shield::Regenerate drained max_shield x maintenance_factor from the primary capacitor every atom, even at full shield health. For ships whose shield max exceeds their reactor output (e.g. Mule 18600 shields vs 80/s reactor), that left the weapon capacitor empty -- so neither the shields nor the weapons could function. AI ships with such shields never fired (Armed::Fire saw energy 0), and capital-ship shields disappeared.

Why tuning maintenance_factor can't fix this for large vessels:
  maintenance = max_shield x factor, but reactor output is a fixed per-ship
  value. For a ship to refill its capacitor you need maintenance < reactor,
  i.e. factor < reactor/max_shield. A Mule (18600 shields, 80/s reactor) needs
  factor < 0.0043; a capital ship (40000 shields, 115/s reactor) needs
  factor < 0.0029. No single global factor works for all ships -- the drain
  must not scale with max shield at all.

Fix (per devs' linear-recharge preference): move the fully-charged gate to the top of Regenerate, before any energy consumption. Full shields now cost 0 capacitor energy; the linear regeneration below is unchanged. This restores the pre-2025 behavior where shields only spend energy while actually recharging.

TL;DR The game was **designed** around full shields not costing anything, and any value that would allow a capship to keep its shields are effectively 0. So, lets not beat around the bush here and make it 0. 

Or, you know we spend the next few years re-balancing the game. 