### PR TITLE
load_config: parse engine.json base section so split tuning loads

### DIFF
--- a/engine/src/configuration/configuration.cpp
+++ b/engine/src/configuration/configuration.cpp
@@ -75,7 +75,16 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         if (json_value.is_null()) {
             return;
         }
-        const boost::json::object & root_object = json_value.get_object();
+        // engine.json wraps its engine tuning under a "base" object (constants,
+        // components, ai, physics, ...). Parse that as the root so those keys are
+        // loaded; the config split moved them out of config.json into there.
+        // config.json / theme.json / bindings.json have no "base", so they keep
+        // parsing from the document root unchanged.
+        const boost::json::object * root_ptr = &json_value.get_object();
+        if (const auto * base_value = root_ptr->if_contains("base"); base_value && base_value->is_object()) {
+            root_ptr = &base_value->get_object();
+        }
+        const boost::json::object & root_object = *root_ptr;
 
 
 

--- a/engine/src/configuration/configuration.cpp
+++ b/engine/src/configuration/configuration.cpp
@@ -81,7 +81,8 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         // config.json / theme.json / bindings.json have no "base", so they keep
         // parsing from the document root unchanged.
         const boost::json::object * root_ptr = &json_value.get_object();
-        if (const auto * base_value = root_ptr->if_contains("base"); base_value && base_value->is_object()) {
+        const boost::json::value * base_value = root_ptr->if_contains("base");
+        if (base_value != nullptr && base_value->is_object()) {
             root_ptr = &base_value->get_object();
         }
         const boost::json::object & root_object = *root_ptr;


### PR DESCRIPTION
The 2026-08-09 config split moved engine tuning (constants, components, ai, physics, etc.) from config.json into engine.json -> base. load_config() parses each file from its root object and never looked inside 'base', so all of engine.json's base tuning was silently dropped and configuration() fell back to struct defaults.

When a loaded file has a top-level 'base' object (engine.json), treat it as the parse root. config.json / theme.json / bindings.json have no 'base', so they keep parsing from the document root unchanged.

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run?
  - [x] Demonstrate that the issue is fixed or the feature exercised
    - [x] Specific testing where a clear, present, demonstrable test can be provided; OR
    - [ ] Unit test(s) showing the exercise of the explicit code; OR
    - [ ] Play test (see below) that demonstrates the feature/issue; OR
    - [ ] Build test when things directly impact how the build functions or some part of the build is generated
  - [ ] Play Tests
    - [x] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
    - [x] From the Main Menu, start a new Campaign.
    - [x] Basic flight.
    - [x] Docking to a planet.
    - [ ] On planet actions:
        - [x] Save the game.
        - [x] Read news.
        - [x] Buy/Sell some goods.
        - [x] Buy/Sell a ship upgrade.
        - [x] Accept a mission from the bulletin board.
        - [x] Talk to someone in the bar.
    - [x] Primary and secondary weapon usage.
    - [x] Fight (you can fight with Oswald).
    - [x] SPEC flight.
    - [x] A jump to a different system.
    - [x] Docking to a non-planet location (mining base, etc).
    - [x] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
    - [x] Save the game again.
    - [x] Upgrade your new ship.
    - [x] Save once more.
    - [x] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
    - [x] Quit Vega Strike. Make sure it doesn't segfault on exit.
    - [x] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- - More fallout from the config file split. This just restores the engine to applying the actual values in the file. 

Purpose:
- What is this pull request trying to do?
- - fix engine not applying values in the split config file system. 
- What release is this for?
- - 0.11
- Is there a project or milestone we should apply this to?
- - 0.11