### PR TITLE
Return proper values for base width and height

### DIFF
--- a/libraries/root_generic/universe_util_generic.cpp
+++ b/libraries/root_generic/universe_util_generic.cpp
@@ -177,14 +177,13 @@ namespace UniverseUtil {
                 return std::to_string(configuration().graphics.resolution_y);
             }
             if (option == "base_max_width") {
-                // The GUI uses base_max_width as its screen width; in the old
-                // XML it always matched the render resolution (x_resolution),
-                // and bases.max_width (1440x1080) is the art's virtual size,
-                // not what the GUI should lay out at.
-                return std::to_string(configuration().graphics.resolution_x);
+                // The GUI uses base_max_width as its screen width; this can be
+                // a lower value than the actual max width to preserve the aspect ratio
+                // of the original game assets
+                return std::to_string(configuration().graphics.bases.max_width);
             }
             if (option == "base_max_height") {
-                return std::to_string(configuration().graphics.resolution_y);
+                return std::to_string(configuration().graphics.bases.max_height);
             }
             if (option == "aspect") {
                 return std::to_string(configuration().graphics.aspect_flt);
@@ -199,6 +198,7 @@ namespace UniverseUtil {
             }
         }
         return vs_config->getVariable(category, option, def);
+
     }
 
     Unit *launchJumppoint(string name_string,


### PR DESCRIPTION
Return the proper values to allow maintaining aspect ratio in bases

The original comment in the file was misleading, the main reason the resolutions matched was that they were mostly 4:3 aspect ratio resolutions. With wider screens this is no longer true however and the base width properties allow to not have stretched base screens.

Personally I'd go a step further and would calculate the following properties:

1. Aspect
2. base height (normally screen height but there could be screens with as aspect `< 4/3`
3. base width

This would simplify the configuration of the game.