### PR TITLE
Settings port to 0.10

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -263,6 +263,7 @@ SET(LIBCOMPONENT
 
 SET(LIBGUI_SOURCES
     src/gui/button.cpp
+    src/gui/config_screen.cpp
     src/gui/control.cpp
     src/gui/eventmanager.cpp
     src/gui/eventresponder.cpp

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -264,6 +264,7 @@ SET(LIBCOMPONENT
 SET(LIBGUI_SOURCES
     src/gui/button.cpp
     src/gui/config_screen.cpp
+    src/gui/config_screen.h
     src/gui/control.cpp
     src/gui/eventmanager.cpp
     src/gui/eventresponder.cpp

--- a/engine/src/aldrv/al_init.cpp
+++ b/engine/src/aldrv/al_init.cpp
@@ -120,6 +120,30 @@ void AUDChangeVolume(float volume) {
 #endif
 }
 
+// The scalepos divisor folds the platform linuxadjust (the engine's audio units are
+// calibrated ~3x on non-Windows/macOS). Shared by AUDInit and AUDReapplyConfig so
+// the saved volume is applied faithfully in both.
+static double audio_volume_scale() {
+    double linuxadjust = 1;
+#ifndef _WIN32
+#ifndef __APPLE__
+    linuxadjust = 1.0 / 3.0;
+#endif
+#endif
+    return configuration().audio.volume_dbl * linuxadjust;
+}
+
+// Re-apply the audio volume/positional/doppler settings from configuration() after
+// an in-game settings change. Mirrors the bootstrap assignment in AUDInit (which
+// folds in the platform linuxadjust), so the saved volume is applied faithfully
+// (AUDChangeVolume is relative/delta-based and would miss linuxadjust).
+void AUDReapplyConfig() {
+#ifdef HAVE_AL
+    scalevel = configuration().audio.doppler_scale_flt;
+    scalepos = 1.0 / audio_volume_scale();
+#endif
+}
+
 float AUDGetVolume() {
 #ifdef HAVE_AL
     return 1. / scalepos;
@@ -165,13 +189,7 @@ bool AUDInit() {
     // g_game.sound_enabled =
     usedoppler = configuration().audio.doppler;
     usepositional = configuration().audio.positional;
-    double linuxadjust = 1;
-#ifndef _WIN32
-#ifndef __APPLE__
-    linuxadjust = 1.0 / 3.0;
-#endif
-#endif
-    scalepos = 1.0 / (configuration().audio.volume_dbl * linuxadjust);
+    scalepos = 1.0 / audio_volume_scale();
     scalevel = configuration().audio.doppler_scale_flt;
     g_game.audio_frequency_mode = configuration().audio.frequency;
     maxallowedsingle = configuration().audio.max_single_sounds;

--- a/engine/src/audiolib.h
+++ b/engine/src/audiolib.h
@@ -77,6 +77,9 @@ void AUDPlay(const int sound, const QVector &pos, const Vector &vel, const float
 void AUDPausePlaying(const int sound);
 ///Changes the volume (generally 0 or between 1 and 1000)
 void AUDChangeVolume(float volume);
+///Re-applies the audio volume/doppler from configuration() after an in-game settings
+///change (matches the bootstrap assignment in AUDInit, incl. the platform linuxadjust).
+void AUDReapplyConfig();
 float AUDGetVolume();
 ///changes the scale used for doppler...generally between 0 for off or .01 and 10
 void AUDChangeDoppler(float doppler);

--- a/engine/src/cmd/ai/firekeyboard.cpp
+++ b/engine/src/cmd/ai/firekeyboard.cpp
@@ -809,6 +809,13 @@ void FireKeyboard::TogglePause(const KBData &, KBSTATE k) {
     }
 }
 
+void FireKeyboard::ToggleConfigScreen(const KBData &, KBSTATE k) {
+    if (k == PRESS) {
+        VS_LOG(info, "FireKeyboard::ToggleConfigScreen(): Config key detected");
+        _Universe->ToggleOptionsActive();
+    }
+}
+
 extern unsigned int DoSpeech(Unit *un, Unit *player_un, const FSM::Node &convNode);
 extern Unit *GetThreat(const Unit *par, const Unit *leader);
 

--- a/engine/src/cmd/ai/firekeyboard.cpp
+++ b/engine/src/cmd/ai/firekeyboard.cpp
@@ -811,7 +811,6 @@ void FireKeyboard::TogglePause(const KBData &, KBSTATE k) {
 
 void FireKeyboard::ToggleConfigScreen(const KBData &, KBSTATE k) {
     if (k == PRESS) {
-        fprintf(stderr, "[config-screen debug] ToggleConfigScreen FIRED\n"); fflush(stderr);
         VS_LOG(info, "FireKeyboard::ToggleConfigScreen(): Config key detected");
         _Universe->ToggleOptionsActive();
     }

--- a/engine/src/cmd/ai/firekeyboard.cpp
+++ b/engine/src/cmd/ai/firekeyboard.cpp
@@ -811,6 +811,7 @@ void FireKeyboard::TogglePause(const KBData &, KBSTATE k) {
 
 void FireKeyboard::ToggleConfigScreen(const KBData &, KBSTATE k) {
     if (k == PRESS) {
+        fprintf(stderr, "[config-screen debug] ToggleConfigScreen FIRED\n"); fflush(stderr);
         VS_LOG(info, "FireKeyboard::ToggleConfigScreen(): Config key detected");
         _Universe->ToggleOptionsActive();
     }

--- a/engine/src/cmd/ai/firekeyboard.h
+++ b/engine/src/cmd/ai/firekeyboard.h
@@ -150,6 +150,7 @@ public:
     static void NearestPlanetKey(const KBData &, KBSTATE k);
     static void NearestJumpKey(const KBData &, KBSTATE k);
     static void TogglePause(const KBData &, KBSTATE);
+    static void ToggleConfigScreen(const KBData &, KBSTATE);
 
 protected:
     void *savedTargets[NUMSAVEDTARGETS];

--- a/engine/src/cmd/ai/flybywire.cpp
+++ b/engine/src/cmd/ai/flybywire.cpp
@@ -155,6 +155,17 @@ void MatchVelocity::Execute() {
     MatchAngularVelocity::Execute();
 
     MATCHLINVELSETUP();
+    // Also cap the desired velocity to set_speed (afterburn-aware) so the
+    // flight computer stops requesting more than the set speed while turning.
+    // This prevents the thrust from pushing the velocity past the limit in the
+    // first place; the physics clamp in UpdatePhysics is the hard backstop.
+    if (parent->graphicOptions.WarpFieldStrength == 1.0) {
+        const double limit = afterburn ? parent->MaxAfterburnerSpeed() : parent->computer.set_speed;
+        const double dmag = desired.Magnitude();
+        if (limit > 0 && dmag > limit) {
+            desired *= (limit / dmag);
+        }
+    }
     if (willfinish) {
         if ((done = done && fabs(desired.i - velocity.i) < VELTHRESHOLD && fabs(desired.j - velocity.j) < VELTHRESHOLD
                 && fabs(desired.k - velocity.k) < VELTHRESHOLD)) {

--- a/engine/src/cmd/ai/flykeyboard.cpp
+++ b/engine/src/cmd/ai/flykeyboard.cpp
@@ -255,6 +255,12 @@ void FlyByKeyboard::Execute(bool resetangvelocity) {
                 KeyboardRollRight(-1);
             }
         }
+        if (SSCK.accelpress > 0) {
+            Accel(1);
+        }
+        if (SSCK.decelpress > 0) {
+            Accel(-1);
+        }
         if (SSCK.ABpress >= 1) {
             Afterburn(1);
         } else {
@@ -274,12 +280,6 @@ void FlyByKeyboard::Execute(bool resetangvelocity) {
         }
         if (SSCK.inertialflightpress > 0) {
             InertialFlight(!initial_inertial_mode);
-        }
-        if (SSCK.accelpress > 0) {
-            Accel(1);
-        }
-        if (SSCK.decelpress > 0) {
-            Accel(-1);
         }
     } else {
         if (SSCK.uppress == 0 && SSCK.downpress == 0) {

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -731,6 +731,7 @@ void base_main_loop() {
     }
 
     // ImGui Init
+    ImGui_ApplyPendingFontSize();  // apply a pending font-size change before laying out
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplSDL2_NewFrame();
     ImGui::NewFrame();
@@ -746,6 +747,11 @@ void base_main_loop() {
 
     // ImGui End Frame
     ImGui::End();
+
+    // In-game config overlay (Alt+C / --configure) on top — a top-level window.
+    // Draw outside main_window so it covers it; no-op unless optionsActive.
+    DrawConfigOverlay();
+
     // Rendering
     ImGui::Render();
 

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -982,7 +982,11 @@ void BaseInterface::ClickWin(int button, int state, int x, int y) {
 }
 
 void BaseInterface::PassiveMouseOverWin(int x, int y) {
-    ModifyMouseSensitivity(x, y);
+    // Do NOT apply ModifyMouseSensitivity here. It doubles the mouse position
+    // (a low-res workaround) and clamps at the screen edges, which corrupts
+    // coordinates near the border. The click path (ClickWin) uses raw pixels,
+    // and the computer path applies its own sensitivity handling in
+    // EventManager. Passing raw pixels keeps hover consistent with clicks.
     SetSoftwareMousePosition(x, y);
     if (CurrentBase) {
         if (CurrentBase->CallComp) {
@@ -1001,7 +1005,7 @@ void BaseInterface::PassiveMouseOverWin(int x, int y) {
 }
 
 void BaseInterface::ActiveMouseOverWin(int x, int y) {
-    ModifyMouseSensitivity(x, y);
+    // See PassiveMouseOverWin: do NOT apply ModifyMouseSensitivity here.
     SetSoftwareMousePosition(x, y);
     if (CurrentBase) {
         if (CurrentBase->CallComp) {

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -143,38 +143,8 @@ std::vector<unsigned int> base_keyboard_queue;
 
 #define mymin(a, b) ( ( (a) < (b) ) ? (a) : (b) )
 
-// Letterboxed base viewport rect (in configured-resolution space), centered, from
-// graphics.bases.max_width/height. Returns false if no letterbox applies (the base
-// should fill the whole screen). This is the base-aspect viewport the bases render
-// into; the GL viewport maps it onto native pixels so bases display at the base
-// resolution (bases.max_width/height) rather than the screen resolution.
-static bool base_viewport_rect(int &x, int &y, int &w, int &h) {
-    const int sw = configuration().graphics.resolution_x;
-    const int sh = configuration().graphics.resolution_y;
-    const int mw = configuration().graphics.bases.max_width;
-    const int mh = configuration().graphics.bases.max_height;
-    if (mw <= 0 || mh <= 0) return false;
-    int rw = std::min(sw, mw);
-    int rh = std::min(sh, mh);
-    if (rw >= sw && rh >= sh) return false;      // base fills the screen
-    x = (sw - rw) / 2;
-    y = (sh - rh) / 2;
-    w = rw; h = rh;
-    return true;
-}
-
 static void SetupViewport() {
-    int vx = 0, vy = 0, vw = 0, vh = 0;
-    if (base_viewport_rect(vx, vy, vw, vh)) {
-        // Map the configured-resolution letterbox onto native (actual) pixels.
-        const int sw = configuration().graphics.resolution_x;
-        const int sh = configuration().graphics.resolution_y;
-        float sx = sw > 0 ? (float)native_resolution_x / sw : 1.0f;
-        float sy = sh > 0 ? (float)native_resolution_y / sh : 1.0f;
-        glViewport((int)(vx * sx), (int)(vy * sy), (int)(vw * sx), (int)(vh * sy));
-    } else {
-        glViewport(0, 0, native_resolution_x, native_resolution_y);
-    }
+    glViewport(0, 0, native_resolution_x, native_resolution_y);
 }
 
 #undef mymin
@@ -767,17 +737,10 @@ void base_main_loop() {
     ImGui::NewFrame();
     // End ImGui Init
 
-    // The base screen is a letterboxed viewport (base-aspect). Size/position the
-    // main window to that rect; fall back to fullscreen when no letterbox applies.
-    int vx = 0, vy = 0, vw = 0, vh = 0;
-    if (base_viewport_rect(vx, vy, vw, vh)) {
-        ImGui::SetNextWindowPos(ImVec2((float)vx, (float)vy), ImGuiCond_Always);
-        ImGui::SetNextWindowSize(ImVec2((float)vw, (float)vh), ImGuiCond_Always);
-    } else {
-        ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
-        ImGui::SetNextWindowSize(ImVec2((float)configuration().graphics.resolution_x,
-                                       (float)configuration().graphics.resolution_y), ImGuiCond_Always);
-    }
+    ImGui::SetNextWindowPos(ImVec2(0,0), ImGuiCond_Always);
+    const ImVec2 window_size(configuration().graphics.resolution_x,
+                             configuration().graphics.resolution_y);
+    ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
     ImGui::Begin("main_window", nullptr, window_flags);
     
     bool refresh_result = RefreshGUI();

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -309,7 +309,7 @@ void BaseInterface::Room::BaseShip::Draw(BaseInterface *base) {
         GFXHudMode(GFXFALSE);
         float tmp = configuration().graphics.fov_flt;
         const float standard_fov = configuration().graphics.bases.fov_flt;
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.fov_flt = standard_fov;
+        (configuration()).graphics.fov_flt = standard_fov;
         float tmp1 = _Universe->AccessCamera()->GetFov();
         _Universe->AccessCamera()->SetFov(standard_fov);
         Vector p, q, r;
@@ -355,7 +355,7 @@ void BaseInterface::Room::BaseShip::Draw(BaseInterface *base) {
         _Universe->AccessCamera()->UpdateGFX();
         SetupViewport();
         GFXHudMode(GFXTRUE);
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.fov_flt = tmp;
+        (configuration()).graphics.fov_flt = tmp;
         _Universe->AccessCamera()->SetFov(tmp1);
     }
 }
@@ -566,10 +566,10 @@ void BaseInterface::Room::BaseText::Draw(BaseInterface *base) {
     const int base_max_height = configuration().graphics.bases.max_height;
     if (base_max_width && base_max_height) {
         if (base_max_width < tmpx) {
-            (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = base_max_width;
+            (configuration()).graphics.resolution_x = base_max_width;
         }
         if (base_max_height < tmpy) {
-            (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = base_max_height;
+            (configuration()).graphics.resolution_y = base_max_height;
         }
     }
     const float base_text_background_alpha = configuration().graphics.bases.text_background_alpha_flt;
@@ -597,8 +597,8 @@ void BaseInterface::Room::BaseText::Draw(BaseInterface *base) {
         text.Draw(text.GetText(), 0, true, false, automatte);
     }
     text.background_color= static_cast<ImU32>(tmpbg);
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = tmpx;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = tmpy;
+    (configuration()).graphics.resolution_x = tmpx;
+    (configuration()).graphics.resolution_y = tmpy;
 }
 
 void RunPython(const char *filnam) {

--- a/engine/src/cmd/base_interface.cpp
+++ b/engine/src/cmd/base_interface.cpp
@@ -143,8 +143,38 @@ std::vector<unsigned int> base_keyboard_queue;
 
 #define mymin(a, b) ( ( (a) < (b) ) ? (a) : (b) )
 
+// Letterboxed base viewport rect (in configured-resolution space), centered, from
+// graphics.bases.max_width/height. Returns false if no letterbox applies (the base
+// should fill the whole screen). This is the base-aspect viewport the bases render
+// into; the GL viewport maps it onto native pixels so bases display at the base
+// resolution (bases.max_width/height) rather than the screen resolution.
+static bool base_viewport_rect(int &x, int &y, int &w, int &h) {
+    const int sw = configuration().graphics.resolution_x;
+    const int sh = configuration().graphics.resolution_y;
+    const int mw = configuration().graphics.bases.max_width;
+    const int mh = configuration().graphics.bases.max_height;
+    if (mw <= 0 || mh <= 0) return false;
+    int rw = std::min(sw, mw);
+    int rh = std::min(sh, mh);
+    if (rw >= sw && rh >= sh) return false;      // base fills the screen
+    x = (sw - rw) / 2;
+    y = (sh - rh) / 2;
+    w = rw; h = rh;
+    return true;
+}
+
 static void SetupViewport() {
-    glViewport(0, 0, native_resolution_x, native_resolution_y);
+    int vx = 0, vy = 0, vw = 0, vh = 0;
+    if (base_viewport_rect(vx, vy, vw, vh)) {
+        // Map the configured-resolution letterbox onto native (actual) pixels.
+        const int sw = configuration().graphics.resolution_x;
+        const int sh = configuration().graphics.resolution_y;
+        float sx = sw > 0 ? (float)native_resolution_x / sw : 1.0f;
+        float sy = sh > 0 ? (float)native_resolution_y / sh : 1.0f;
+        glViewport((int)(vx * sx), (int)(vy * sy), (int)(vw * sx), (int)(vh * sy));
+    } else {
+        glViewport(0, 0, native_resolution_x, native_resolution_y);
+    }
 }
 
 #undef mymin
@@ -737,10 +767,17 @@ void base_main_loop() {
     ImGui::NewFrame();
     // End ImGui Init
 
-    ImGui::SetNextWindowPos(ImVec2(0,0), ImGuiCond_Always);
-    const ImVec2 window_size(configuration().graphics.resolution_x,
-                             configuration().graphics.resolution_y);
-    ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
+    // The base screen is a letterboxed viewport (base-aspect). Size/position the
+    // main window to that rect; fall back to fullscreen when no letterbox applies.
+    int vx = 0, vy = 0, vw = 0, vh = 0;
+    if (base_viewport_rect(vx, vy, vw, vh)) {
+        ImGui::SetNextWindowPos(ImVec2((float)vx, (float)vy), ImGuiCond_Always);
+        ImGui::SetNextWindowSize(ImVec2((float)vw, (float)vh), ImGuiCond_Always);
+    } else {
+        ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+        ImGui::SetNextWindowSize(ImVec2((float)configuration().graphics.resolution_x,
+                                       (float)configuration().graphics.resolution_y), ImGuiCond_Always);
+    }
     ImGui::Begin("main_window", nullptr, window_flags);
     
     bool refresh_result = RefreshGUI();

--- a/engine/src/cmd/basecomputer.cpp
+++ b/engine/src/cmd/basecomputer.cpp
@@ -3312,8 +3312,12 @@ void BaseComputer::BuyUpgradeOperation::concludeTransaction(void) {
 
     if(playerUnit->BuyUpgrade(baseUnit, &m_part, quantity)) {
         double percent = 0;
-        // Modify upgrade quantity according to cargo quantity
-        m_newPart->mounts[0].ammo = quantity;
+        // Only missiles carry ammo. Non-missile weapons (beams, bolts) are
+        // energy weapons with unlimited ammo (-1); setting ammo here to 1
+        // burned bought guns out after a single shot (regression c3b14b93f).
+        if(m_newPart->mounts[0].IsMissileMount()) {
+            m_newPart->mounts[0].ammo = quantity;
+        }
 
         //Upgrade the ship.
         playerUnit->Upgrade(m_newPart, m_selectedMount, m_selectedTurret, 0, true, percent);

--- a/engine/src/components/afterburner.h
+++ b/engine/src/components/afterburner.h
@@ -43,6 +43,12 @@ public:
 
     Resource<double> speed;
 
+    // Whether the afterburner is actively engaged this step. Set in
+    // Movable::Thrust; the velocity clamp in Movable::UpdatePhysics reads this to
+    // allow afterburn speed only when the burner is truly active (not merely when
+    // fuel exists).
+    bool active = false;
+
     explicit Afterburner(EnergyContainer *source = nullptr);
 
     // Component Methods

--- a/engine/src/components/afterburner.h
+++ b/engine/src/components/afterburner.h
@@ -43,12 +43,6 @@ public:
 
     Resource<double> speed;
 
-    // Whether the afterburner is actively engaged this step. Set in
-    // Movable::Thrust; the velocity clamp in Movable::UpdatePhysics reads this to
-    // allow afterburn speed only when the burner is truly active (not merely when
-    // fuel exists).
-    bool active = false;
-
     explicit Afterburner(EnergyContainer *source = nullptr);
 
     // Component Methods

--- a/engine/src/components/components_manager.cpp
+++ b/engine/src/components/components_manager.cpp
@@ -43,6 +43,10 @@ Resource<double> ComponentsManager::credits = Resource<double>(0.0, 0.0);
 void ComponentsManager::Load(std::string unit_key) {
     mass = base_mass = UnitCSVFactory::GetVariable(unit_key, "Mass", 0.0);
 
+    // Clear any previously-loaded prohibited upgrades so repeated Load() calls
+    // (e.g. the two calls made from Unit::LoadRow) do not accumulate duplicates.
+    prohibited_upgrades.clear();
+
     // Consumer
     std::string prohibited_upgrades_string = UnitCSVFactory::GetVariable(unit_key, "Prohibited_Upgrades", std::string());
 
@@ -57,17 +61,26 @@ void ComponentsManager::Load(std::string unit_key) {
         std::vector<std::string> parts;
         boost::split(parts, upgrade, boost::is_any_of(":"));
         if (parts.size() == 1) {
-            const std::string& category = parts[0];
-            prohibited_upgrades.emplace_back(category, 0);
+            AddProhibitedUpgrade(parts[0], 0);
         } else if (parts.size() == 2) {
-            const std::string& category = parts[0];
-            const int limit = locale_aware_stoi(parts[1]);
-            //const std::pair<const std::string, const int> pair(category, limit);
-            prohibited_upgrades.emplace_back(category, limit);
+            AddProhibitedUpgrade(parts[0], locale_aware_stoi(parts[1]));
         } else {
             VS_LOG(error, (boost::format("%1%: Invalid format in prohibited upgrades string: %2%") % __FUNCTION__ % upgrade));
         }
     }
+}
+
+// The pre-existing doubling bug (Load() called twice per unit construction)
+// could have left many identical duplicate groups in a save's string. Adding
+// is done deduplicated so a bloated save is collapsed to one copy and repaired
+// on the next save.
+void ComponentsManager::AddProhibitedUpgrade(const std::string& category, int limit) {
+    for (const auto& existing : prohibited_upgrades) {
+        if (existing.first == category && existing.second == limit) {
+            return;
+        }
+    }
+    prohibited_upgrades.emplace_back(category, limit);
 }
 
 void ComponentsManager::Serialize(std::map<std::string, std::string>& unit) const {

--- a/engine/src/components/components_manager.h
+++ b/engine/src/components/components_manager.h
@@ -68,6 +68,9 @@ class ComponentsManager {
 
     std::vector<std::pair<const std::string, const int>> prohibited_upgrades;
 
+    // Deduplicated add — repairs the doubling-bug ballooned save lists.
+    void AddProhibitedUpgrade(const std::string& category, int limit);
+
     friend class CargoHold;
     friend class Movable;
 

--- a/engine/src/components/shield.cpp
+++ b/engine/src/components/shield.cpp
@@ -340,6 +340,18 @@ void Shield::Regenerate(const bool player_ship) {
     * Finally, you adjust whatever used it to the value in question
     */
 
+    // Fully charged shields need no energy - return before any consumption.
+    // (Regression fix: the maintenance drain below used to run even at full
+    // shields, draining the primary capacitor (which the weapons also use) at
+    // max_shield x maintenance_factor per second. For ships whose shield max
+    // exceeds their reactor output - e.g. a Mule (18600 shields) or any
+    // capital ship - that left the capacitor empty, so neither the shields nor
+    // the weapons could ever function. See the 'capacitor never refills after
+    // firing' / 'AI ships never fire' reports.)
+    if (TotalLayerValue() == TotalMaxLayerValue()) {
+        return;
+    }
+
     // Shield Maintenance
     // TODO: lib_damage restore efficiency by replacing with shield->efficiency
     //const double efficiency = 1;
@@ -359,11 +371,6 @@ void Shield::Regenerate(const bool player_ship) {
     }
 
     // Shield Regeneration
-    if(TotalLayerValue() == TotalMaxLayerValue()) {
-        // Fully charged. No need for more action or energy consumption
-        return;
-    }
-
     const double shield_regeneration_cost = regeneration.AdjustedValue() * configuration().components.shield.regeneration_factor_dbl;
     SetConsumption(shield_regeneration_cost);
     const double actual_regeneration_percent = Consume();

--- a/engine/src/config_xml.cpp
+++ b/engine/src/config_xml.cpp
@@ -49,6 +49,7 @@
 #include "src/python/python_compile.h"
 #include "src/vs_logging.h"
 #include "src/sdl_key_converter.h"
+#include "configuration/configuration.h"
 
 /* *********************************************************** */
 
@@ -255,249 +256,141 @@ void GameVegaConfig::initCommandMap() // DELETE ME
 
 /* *********************************************************** */
 
-void GameVegaConfig::doBindings(configNode *node) {
-    vector<easyDomNode *>::const_iterator siter;
-    for (siter = node->subnodes.begin(); siter != node->subnodes.end(); siter++) {
-        configNode *cnode = (configNode *) (*siter);
-        if ((cnode)->Name() == "bind") {
-            checkBind(cnode);
-        } else if (((cnode)->Name() == "axis")) {
-            doAxis(cnode);
-        } else {
-            VS_LOG(warning, (boost::format("Unknown tag: %1%") % (cnode)->Name()));
-        }
-    }
-}
-
-/* *********************************************************** */
-
-void GameVegaConfig::doAxis(configNode *node) {
-    string name = node->attr_value("name");
-    string myjoystick = node->attr_value("joystick");
-    string axis = node->attr_value("axis");
-    string invertstr = node->attr_value("inverse");
-    string mouse_str = node->attr_value("mouse");
-    if (name.empty() || (mouse_str.empty() && myjoystick.empty()) || axis.empty()) {
-        VS_LOG(warning, "no correct axis description given ");
-        return;
-    }
-    int joy_nr = atoi(myjoystick.c_str());
-    if (!mouse_str.empty()) {
-        joy_nr = MOUSE_JOYSTICK;
-    }
-    int axis_nr = atoi(axis.c_str());
-
-    //no checks for correct number yet
-
-    bool inverse = false;
-    if (!invertstr.empty()) {
-        inverse = XMLSupport::parse_bool(invertstr);
-    }
-    if (name == "x") {
-        axis_joy[0] = joy_nr;
-        joystick[joy_nr]->axis_axis[0] = axis_nr;
-        joystick[joy_nr]->axis_inverse[0] = inverse;
-    } else if (name == "y") {
-        axis_joy[1] = joy_nr;
-        joystick[joy_nr]->axis_axis[1] = axis_nr;
-        joystick[joy_nr]->axis_inverse[1] = inverse;
-    } else if (name == "z") {
-        axis_joy[2] = joy_nr;
-        joystick[joy_nr]->axis_axis[2] = axis_nr;
-        joystick[joy_nr]->axis_inverse[2] = inverse;
-    } else if (name == "throttle") {
-        axis_joy[3] = joy_nr;
-        joystick[joy_nr]->axis_axis[3] = axis_nr;
-        joystick[joy_nr]->axis_inverse[3] = inverse;
-    } else if (name == "hatswitch") {
-        string nr_str = node->attr_value("nr");
-        string margin_str = node->attr_value("margin");
-        if (nr_str.empty() || margin_str.empty()) {
-            VS_LOG(warning, "you have to assign a number and a margin to the hatswitch");
-            return;
-        }
-        int nr = atoi(nr_str.c_str());
-
-        float margin = atof(margin_str.c_str());
-        hatswitch_margin[nr] = margin;
-
-        hatswitch_axis[nr] = axis_nr;
-        hatswitch_joystick[nr] = joy_nr;
-
-        vector<easyDomNode *>::const_iterator siter;
-
-        hs_value_index = 0;
-        for (siter = node->subnodes.begin(); siter != node->subnodes.end(); siter++) {
-            configNode *cnode = (configNode *) (*siter);
-            checkHatswitch(nr, cnode);
-        }
-    } else {
-        VS_LOG(warning, (boost::format("unknown axis %1%") % name));
-        return;
-    }
-}
-
-/* *********************************************************** */
-
-void GameVegaConfig::checkHatswitch(int nr, configNode *node) {
-    if (node->Name() != "hatswitch") {
-        VS_LOG(warning, "not a hatswitch node ");
-        return;
-    }
-    string strval = node->attr_value("value");
-    float val = atof(strval.c_str());
-    if (val > 1.0 || val < -1.0) {
-        VS_LOG(error, "only hatswitch values from -1.0 to 1.0 allowed");
-        return;
-    }
-    hatswitch[nr][hs_value_index] = val;
-    VS_LOG(info, (boost::format("setting hatswitch nr %1% %2% = %3%") % nr % hs_value_index % val));
-    hs_value_index++;
-}
-
-/* *********************************************************** */
-
-void GameVegaConfig::checkBind(configNode *node) {
-    if (node->Name() != "bind") {
-        VS_LOG(warning, "not a bind node ");
-        return;
-    }
-    std::string modifier_string = node->attr_value("modifier");
-    int modifier = getModifier(modifier_string);
-
-    string cmdstr = node->attr_value("command");
-    string player_bound = node->attr_value("player");
-    if (player_bound.empty()) {
-        player_bound = "0";
-    }
-    KBHandler handler = commandMap[cmdstr];
-    if (handler == NULL) {
-        VS_LOG(error, (boost::format("No such command: %1%") % cmdstr));
-        return;
-    }
-    string player_str = node->attr_value("player");
-    string joy_str = node->attr_value("joystick");
-    string mouse_str = node->attr_value("mouse");
-    const std::string keystr = node->attr_value("key");
-    string additional_data = node->attr_value("data");
-    string buttonstr = node->attr_value("button");
-    string hat_str = node->attr_value("hatswitch");
-    string dighswitch = node->attr_value("digital-hatswitch");
-    string direction = node->attr_value("direction");
-    if (!player_str.empty()) {
-        if (!joy_str.empty()) {
-            int jn = atoi(joy_str.c_str());
-            if (jn < MAX_JOYSTICKS) {
-                joystick[jn]->player = atoi(player_str.c_str());
-            }
-        } else if (!mouse_str.empty()) {
-            joystick[MOUSE_JOYSTICK]->player = atoi(player_str.c_str());
-        }
-    }
-    if (!keystr.empty()) {
-        //normal keyboard key
-        //now map the command to a callback function and bind it
-        if (keystr.length() == 1) {
-            const int sdl_key_value = SDLKeyConverter::Convert(keystr);
-            BindKey(keystr[0], modifier, XMLSupport::parse_int(player_bound), handler, KBData(additional_data));
-        } else {
-            int glut_key = key_map[keystr];
-            if (glut_key == 0) {
-                VS_LOG(error, (boost::format("No such special key: %1%") % keystr));
-                return;
-            }
-            BindKey(glut_key, modifier, XMLSupport::parse_int(player_bound), handler, KBData(additional_data));
-        }
-    } else if (!buttonstr.empty()) {
-        //maps a joystick button or analogue hatswitch button
-        int button_nr = atoi(buttonstr.c_str());
-        if (joy_str.empty() && mouse_str.empty()) {
-            //it has to be the analogue hatswitch
-            if (hat_str.empty()) {
-                VS_LOG(error, "you got to give an analogue hatswitch number");
-                return;
-            }
-            int hatswitch_nr = atoi(hat_str.c_str());
-
-            BindHatswitchKey(hatswitch_nr, button_nr, handler, KBData(additional_data));
-
-        } else {
-            //joystick button
-            int joystick_nr;
-            if (mouse_str.empty()) {
-                joystick_nr = atoi(joy_str.c_str());
-            } else {
-                joystick_nr = (MOUSE_JOYSTICK);
-            }
-            if (joystick[joystick_nr]->isAvailable()) {
-                //now map the command to a callback function and bind it
-
-                //yet to check for correct buttons/joy-nr
-
-                BindJoyKey(joystick_nr, button_nr, handler, KBData(additional_data));
-            } else {
-                static bool first = true;
-                if (first) {
-                    VS_LOG(warning, "\nrefusing to bind command to joystick (joy-nr too high)");
-                    first = false;
-                }
-            }
-        }
-    } else if (!(dighswitch.empty() || direction.empty() || (mouse_str.empty() && joy_str.empty()))) {
-        //digital hatswitch or ...
-        if (dighswitch.empty() || direction.empty() || (mouse_str.empty() && joy_str.empty())) {
-            VS_LOG(error, "you have to specify joystick,digital-hatswitch,direction");
-            return;
-        }
-        int hsw_nr = atoi(dighswitch.c_str());
-
-        int joy_nr;
-        if (mouse_str.empty()) {
-            joy_nr = atoi(joy_str.c_str());
-        } else {
-            joy_nr = MOUSE_JOYSTICK;
-        }
-        if (!(joystick[joy_nr]->isAvailable() && hsw_nr < joystick[joy_nr]->nr_of_hats)) {
-            VS_LOG(error, "refusing to bind digital hatswitch: no such hatswitch");
-            return;
-        }
-        int dir_index;
-        if (direction == "center") {
-            dir_index = VS_HAT_CENTERED;
-        } else if (direction == "up") {
-            dir_index = VS_HAT_UP;
-        } else if (direction == "right") {
-            dir_index = VS_HAT_RIGHT;
-        } else if (direction == "left") {
-            dir_index = VS_HAT_LEFT;
-        } else if (direction == "down") {
-            dir_index = VS_HAT_DOWN;
-        } else if (direction == "rightup") {
-            dir_index = VS_HAT_RIGHTUP;
-        } else if (direction == "rightdown") {
-            dir_index = VS_HAT_RIGHTDOWN;
-        } else if (direction == "leftup") {
-            dir_index = VS_HAT_LEFTUP;
-        } else if (direction == "leftdown") {
-            dir_index = VS_HAT_LEFTDOWN;
-        } else {
-            VS_LOG(error, "no valid direction string");
-            return;
-        }
-        BindDigitalHatswitchKey(joy_nr, hsw_nr, dir_index, handler, KBData(additional_data));
-        VS_LOG(info,
-                (boost::format("Bound joy %1% hatswitch %2% dir_index %3% to command %4%") % joy_nr % hsw_nr % dir_index
-                        % cmdstr));
-    } else {
-        return;
-    }
-}
-
-/* *********************************************************** */
-
+// Fill the runtime input tables from the merged JSON config (the "actions"
+// and "axes" sections of bindings.json), replacing the old vegastrike.config
+// XML <bind>/<axis> path. The runtime input system itself
+// (BindKey/BindJoyKey/BindDigitalHatswitchKey + axis_joy[]/joystick[].axis_axis[])
+// is unchanged -- we populate the same in-memory structures the XML parser used to.
 void GameVegaConfig::bindKeys() {
-    doBindings(bindings);
+    const auto & cfg = configuration();
+    CommandMap & cmd_map = commandMap;  // command name -> handler (initGlobalCommandMap)
+
+    // Bind one keyboard entry (a single printable char, or a named special key).
+    auto bind_keyboard = [&](const std::string & cmd, const vega_config::Configuration::ActionBinding & b) {
+        KBHandler handler = cmd_map[cmd];
+        if (handler == nullptr) {
+            VS_LOG(error, (boost::format("No such command: %1%") % cmd));
+            return;
+        }
+        int mod = getModifier(b.modifier);
+        if (b.key.length() == 1) {
+            // single printable char (shift already encoded, e.g. '+' for Shift+=)
+            BindKey(b.key[0], mod, 0, handler, KBData());
+        } else {
+            // special key name (tab, cursor-up, function-1, keypad-*, ...)
+            auto it = key_map.find(b.key);
+            if (it == key_map.end()) {
+                VS_LOG(error, (boost::format("No such special key: %1%") % b.key));
+                return;
+            }
+            BindKey(it->second, mod, 0, handler, KBData());
+        }
+    };
+
+    // Bind one mouse or joystick button entry.
+    auto bind_button = [&](const std::string & cmd, const vega_config::Configuration::ActionBinding & b) {
+        KBHandler handler = cmd_map[cmd];
+        if (handler == nullptr) {
+            VS_LOG(error, (boost::format("No such command: %1%") % cmd));
+            return;
+        }
+        // Mouse buttons bind to the reserved mouse-joystick slot regardless of
+        // joystick.enabled; joystick buttons only bind when the joystick is
+        // enabled (so a Keyboard/Joystick selector can disable them).
+        if (!b.is_mouse && !cfg.joystick.enabled) {
+            return;
+        }
+        int joy_nr = b.is_mouse ? MOUSE_JOYSTICK : b.joystick;
+        if (joy_nr >= MAX_JOYSTICKS || joystick[joy_nr] == nullptr || !joystick[joy_nr]->isAvailable()) {
+            VS_LOG(warning, (boost::format("refusing to bind command %1% to joystick (not available)") % cmd));
+            return;
+        }
+        BindJoyKey(joy_nr, b.button, handler, KBData());
+    };
+
+    // Bind one digital-hatswitch entry.
+    auto bind_hat = [&](const std::string & cmd, const vega_config::Configuration::ActionBinding & b) {
+        KBHandler handler = cmd_map[cmd];
+        if (handler == nullptr) {
+            VS_LOG(error, (boost::format("No such command: %1%") % cmd));
+            return;
+        }
+        // Hatswitch is a joystick feature - ignore it when the joystick is disabled.
+        if (!cfg.joystick.enabled) {
+            return;
+        }
+        int joy_nr = b.joystick;
+        if (joy_nr >= MAX_JOYSTICKS || joystick[joy_nr] == nullptr || !joystick[joy_nr]->isAvailable()
+            || b.hatswitch >= joystick[joy_nr]->nr_of_hats) {
+            VS_LOG(warning, (boost::format("refusing to bind command %1% to hatswitch (not available)") % cmd));
+            return;
+        }
+        int dir_index = VS_HAT_CENTERED;
+        if (b.direction == "up") { dir_index = VS_HAT_UP; }
+        else if (b.direction == "right") { dir_index = VS_HAT_RIGHT; }
+        else if (b.direction == "down") { dir_index = VS_HAT_DOWN; }
+        else if (b.direction == "left") { dir_index = VS_HAT_LEFT; }
+        else if (b.direction == "rightup") { dir_index = VS_HAT_RIGHTUP; }
+        else if (b.direction == "rightdown") { dir_index = VS_HAT_RIGHTDOWN; }
+        else if (b.direction == "leftup") { dir_index = VS_HAT_LEFTUP; }
+        else if (b.direction == "leftdown") { dir_index = VS_HAT_LEFTDOWN; }
+        BindDigitalHatswitchKey(joy_nr, b.hatswitch, dir_index, handler, KBData());
+    };
+
+    // Walk every action and bind each of its four device arrays.
+    for (const auto & action : cfg.actions) {
+        const std::string & cmd = action.first;
+        const auto & bindings = action.second;
+        for (const auto & b : bindings.keyboard) { bind_keyboard(cmd, b); }
+        for (const auto & b : bindings.mouse) { bind_button(cmd, b); }
+        for (const auto & b : bindings.joystick) { bind_button(cmd, b); }
+        for (const auto & b : bindings.hat) { bind_hat(cmd, b); }
+    }
+
+    // Axes: x/y/z/throttle -> axis_joy[] + joystick[].axis_axis[]/axis_inverse[].
+    // The runtime reads these in flyjoystick.cpp; same contract as the old XML doAxis.
+    for (const auto & entry : cfg.axes) {
+        const std::string & role = entry.first;
+        const auto & ar = entry.second;
+        int idx = -1;
+        if (role == "x") { idx = AXIS_X; }
+        else if (role == "y") { idx = AXIS_Y; }
+        else if (role == "z") { idx = AXIS_Z; }
+        else if (role == "throttle") { idx = AXIS_THROTTLE; }
+        else { VS_LOG(warning, (boost::format("unknown axis %1%") % role)); continue; }
+
+        // The device for x/y is decided by the per-role source in bindings.json
+        // (axes.x/y.source), NOT by the global mouse.enabled flag - otherwise
+        // enabling the mouse would steal x/y away from the joystick. Mouse only
+        // drives x/y when that role is explicitly configured as source=mouse.
+        bool is_mouse_axis = (ar.source == "mouse");
+        // Joystick axes only apply when the joystick is enabled (Keyboard/Mouse modes disable it).
+        if (!is_mouse_axis && !cfg.joystick.enabled) {
+            continue;
+        }
+        int joy_nr;
+        bool inverse = ar.inverse;
+        int axis_nr = ar.axis;
+        if (is_mouse_axis && (idx == AXIS_X || idx == AXIS_Y)) {
+            // Mouse drives x/y via the reserved mouse-joystick slot; use its
+            // x/y physical axes (0/1) and honor the global mouse inverse_x/y.
+            joy_nr = MOUSE_JOYSTICK;
+            axis_nr = (idx == AXIS_X) ? 0 : 1;
+            inverse = (idx == AXIS_X) ? cfg.mouse.inverse_x : cfg.mouse.inverse_y;
+        } else {
+            joy_nr = (ar.source == "mouse") ? MOUSE_JOYSTICK : ar.joystick;
+        }
+        if (joy_nr >= MAX_JOYSTICKS || joystick[joy_nr] == nullptr) {
+            VS_LOG(warning, (boost::format("refusing to assign axis %1% to joystick (not available)") % role));
+            continue;
+        }
+        axis_joy[idx] = joy_nr;
+        joystick[joy_nr]->axis_axis[idx] = axis_nr;
+        joystick[joy_nr]->axis_inverse[idx] = inverse;
+    }
 }
+
+/* *********************************************************** */
 
 /* *********************************************************** */
 CommandMap initGlobalCommandMap() {

--- a/engine/src/config_xml.cpp
+++ b/engine/src/config_xml.cpp
@@ -359,6 +359,18 @@ void GameVegaConfig::bindKeys() {
         else if (role == "throttle") { idx = AXIS_THROTTLE; }
         else { VS_LOG(warning, (boost::format("unknown axis %1%") % role)); continue; }
 
+        // Unbind this axis up front so a mode switch clears the previous mode's
+        // binding. Otherwise axis_joy[] keeps the stale value (e.g. MOUSE_JOYSTICK
+        // for x/y) when the new mode skips binding this axis via a continue below,
+        // so the old input device still flies the ship on hot-apply. Each device
+        // re-binds only what it owns; the rest stay unbound (-1).
+        axis_joy[idx] = -1;
+        for (int js = 0; js < MAX_JOYSTICKS; ++js) {
+            if (joystick[js] != nullptr) {
+                joystick[js]->axis_axis[idx] = -1;
+            }
+        }
+
         // Bind the axes according to the selected flight-control device
         // (input.device), WITHOUT mutating the stored config (so the joystick
         // bindings survive a mode switch and come back when Joystick is re-selected).

--- a/engine/src/config_xml.cpp
+++ b/engine/src/config_xml.cpp
@@ -436,6 +436,7 @@ CommandMap initGlobalCommandMap() {
     commandMap["SheltonKey"] = FlyByKeyboard::SheltonKey;
     commandMap["MatchSpeedKey"] = FlyByKeyboard::MatchSpeedKey;
     commandMap["PauseKey"] = FireKeyboard::TogglePause;
+    commandMap["ConfigKey"] = FireKeyboard::ToggleConfigScreen;
     commandMap["JumpKey"] = FlyByKeyboard::JumpKey;
     commandMap["AutoKey"] = FlyByKeyboard::AutoKey;
     commandMap["SwitchCombatMode"] = FlyByKeyboard::SwitchCombatModeKey;

--- a/engine/src/config_xml.cpp
+++ b/engine/src/config_xml.cpp
@@ -359,11 +359,24 @@ void GameVegaConfig::bindKeys() {
         else if (role == "throttle") { idx = AXIS_THROTTLE; }
         else { VS_LOG(warning, (boost::format("unknown axis %1%") % role)); continue; }
 
+        // Bind the axes according to the selected flight-control device
+        // (input.device), WITHOUT mutating the stored config (so the joystick
+        // bindings survive a mode switch and come back when Joystick is re-selected).
+        //   - Keyboard: no device drives any axis -> all roles unbind.
+        //   - Mouse: only x/y (source=mouse) bind; z/throttle unbind.
+        //   - Joystick: the configured roles bind (joystick.enabled governs).
+        const std::string & device = cfg.input.device;
+        bool is_mouse_axis = (ar.source == "mouse");
+        if (device == "keyboard") {
+            continue;  // keyboard drives no axes
+        }
+        if (device == "mouse" && idx != AXIS_X && idx != AXIS_Y) {
+            continue;  // mouse drives only x/y; keep z/throttle unbound
+        }
         // The device for x/y is decided by the per-role source in bindings.json
         // (axes.x/y.source), NOT by the global mouse.enabled flag - otherwise
         // enabling the mouse would steal x/y away from the joystick. Mouse only
         // drives x/y when that role is explicitly configured as source=mouse.
-        bool is_mouse_axis = (ar.source == "mouse");
         // Joystick axes only apply when the joystick is enabled (Keyboard/Mouse modes disable it).
         if (!is_mouse_axis && !cfg.joystick.enabled) {
             continue;

--- a/engine/src/config_xml.h
+++ b/engine/src/config_xml.h
@@ -60,10 +60,6 @@ private:
     int hs_value_index;
 //vector<vColor *> colors;
     void bindKeys();
-    void doBindings(configNode *node);
-    void checkBind(configNode *node);
-    void doAxis(configNode *node);
-    void checkHatswitch(int nr, configNode *node);
 };
 
 #endif //VEGA_STRIKE_ENGINE_CONFIG_XML_H

--- a/engine/src/configuration/configuration.cpp
+++ b/engine/src/configuration/configuration.cpp
@@ -75,7 +75,17 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         if (json_value.is_null()) {
             return;
         }
-        const boost::json::object & root_object = json_value.get_object();
+        // engine.json wraps its engine tuning under a "base" object (constants,
+        // components, ai, physics, ...). Parse that as the root so those keys are
+        // loaded; the config split moved them out of config.json into there.
+        // config.json / theme.json / bindings.json have no "base", so they keep
+        // parsing from the document root unchanged.
+        const boost::json::object * root_ptr = &json_value.get_object();
+        const boost::json::value * base_value = root_ptr->if_contains("base");
+        if (base_value != nullptr && base_value->is_object()) {
+            root_ptr = &base_value->get_object();
+        }
+        const boost::json::object & root_object = *root_ptr;
 
 
 
@@ -8603,6 +8613,16 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
                 splash.auto_hide = boost::json::value_to<bool>(*auto_hide_value_ptr);
             }
 
+            const boost::json::value * loading_sprite_value_ptr = splash_object.if_contains("loading_sprite");
+            if (loading_sprite_value_ptr != nullptr) {
+                splash.loading_sprite = boost::json::value_to<std::string>(*loading_sprite_value_ptr);
+            }
+
+            const boost::json::value * loading_message_value_ptr = splash_object.if_contains("loading_message");
+            if (loading_message_value_ptr != nullptr) {
+                splash.loading_message = boost::json::value_to<std::string>(*loading_message_value_ptr);
+            }
+
         }
 
 
@@ -8947,13 +8967,195 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
 
         }
 
+        // Colors: read straight from the merged config object. theme.json is
+        // already merged into configuration() by vsfilesystem.cpp, so parsing
+        // the "colors" section here picks up every file that contributed one
+        // (datadir defaults, then any homedir overrides).
+        parseColors(root_object);
+
+        // Actions + axes (input bindings): read from the merged object too
+        // (bindings.json). See parseActions()/parseAxes().
+        parseActions(root_object);
+        parseAxes(root_object);
 
     } catch (std::exception const& e) {
         VS_LOG(error, (boost::format("%1%: Exception loading config: '%2%'") % __FUNCTION__ % e.what()));
     }
 }
 
-const vega_config::Configuration& configuration() {
-    static const vega_config::Configuration kConfiguration{};
+// Parse the "colors" section of the merged config into this->colors
+// (section -> { name : [r,g,b,a] }). VegaConfig's ctor reads this map to seed
+// its getColor() lookup table, so all the existing vs_config->getColor(...)
+// call sites keep working unchanged.
+//
+// Schema (theme.json):
+//   "colors": {
+//     "default": { "enemy": [1.0, 0.0, 0.0, 1.0], "friend": [0.0, 1.0, 0.0, 1.0], ... },
+//     "nav":      { "current_system": [1.0, 0.3, 0.3, 1.0], ... },
+//     ...
+//   }
+//
+// Because load_config() is called once per config file (and the same file may
+// be loaded again as a homedir override), a section/name that appears more
+// than once is simply overwritten with the latest value -- later loads win,
+// which matches the overall merge precedence.
+void vega_config::Configuration::parseColors(const boost::json::object& root_object) {
+    const boost::json::value* colors_value_ptr = root_object.if_contains("colors");
+    if (colors_value_ptr == nullptr || !colors_value_ptr->is_object()) {
+        return;  // no colors in this file (e.g. config.json, engine.json)
+    }
+
+    for (const auto& section_entry : colors_value_ptr->get_object()) {
+        const std::string& section = section_entry.key();
+        if (!section_entry.value().is_object()) {
+            continue;
+        }
+        for (const auto& color_entry : section_entry.value().get_object()) {
+            const std::string& name = color_entry.key();
+            if (!color_entry.value().is_array()) {
+                continue;
+            }
+            std::vector<float> rgba;
+            for (const auto& component : color_entry.value().get_array()) {
+                rgba.push_back(boost::json::value_to<float>(component));
+            }
+            if (rgba.size() >= 4) {
+                colors[section][name] = rgba;
+            }
+        }
+    }
+}
+
+// Read one device's array of ActionBinding objects from a JSON array of
+// objects. Each object holds the fields relevant to that device type (a
+// keyboard entry has 'key'+'modifier'; a joystick entry has 'joystick'+'button';
+// etc.). We read every field we know about and let the empty/absent ones stay
+// at their defaults, so a single function can serve keyboard, mouse, joystick
+// and digital-hat arrays.
+static void readBindingArray(const boost::json::array& array, bool is_mouse, std::vector<vega_config::Configuration::ActionBinding>& out) {
+    for (const auto& entry : array) {
+        if (!entry.is_object()) {
+            continue;
+        }
+        const boost::json::object& e = entry.get_object();
+        vega_config::Configuration::ActionBinding b;
+        b.is_mouse = is_mouse;
+        const auto* key = e.if_contains("key");
+        if (key != nullptr) { b.key = boost::json::value_to<std::string>(*key); }
+        const auto* mod = e.if_contains("modifier");
+        if (mod != nullptr) { b.modifier = boost::json::value_to<std::string>(*mod); }
+        const auto* btn = e.if_contains("button");
+        if (btn != nullptr) { b.button = boost::json::value_to<int>(*btn); }
+        const auto* joy = e.if_contains("joystick");
+        if (joy != nullptr) { b.joystick = boost::json::value_to<int>(*joy); }
+        const auto* hsw = e.if_contains("hatswitch");
+        if (hsw != nullptr) { b.hatswitch = boost::json::value_to<int>(*hsw); }
+        const auto* dir = e.if_contains("direction");
+        if (dir != nullptr) { b.direction = boost::json::value_to<std::string>(*dir); }
+        out.push_back(b);
+    }
+}
+
+// Parse the "actions" section of the merged config into this->actions
+// (command -> ActionBindings). Each action has up to four device arrays.
+//
+// Schema (bindings.json):
+//   "actions": {
+//     "ABKey": {
+//       "keyboard": [ { "key": "tab", "modifier": "none" } ],
+//       "mouse":    [ { "button": 2, "modifier": "none" } ],
+//       "joystick": [ { "joystick": 0, "button": 1 } ],
+//       "hat":      [ { "joystick": 0, "hatswitch": 0, "direction": "up" } ]
+//     },
+//     ...
+//   }
+//
+// Overlay/merge semantics: because load_config() is called once per config
+// file (datadir, then homedir), an action may be re-parsed. A homedir
+// overlay array replaces the datadir array for that device (so clearing a
+// binding works); absent device arrays are left as-is. This matches the
+// overall "later loads win" merge precedence.
+void vega_config::Configuration::parseActions(const boost::json::object& root_object) {
+    const boost::json::value* actions_value_ptr = root_object.if_contains("actions");
+    if (actions_value_ptr == nullptr || !actions_value_ptr->is_object()) {
+        return;  // no actions in this file (e.g. theme.json, config.json)
+    }
+
+    for (const auto& action_entry : actions_value_ptr->get_object()) {
+        const std::string& command = action_entry.key();
+        if (!action_entry.value().is_object()) {
+            continue;
+        }
+        // Start from the existing entry (if any) so overlay passes keep any
+        // device arrays the current file does not set.
+        vega_config::Configuration::ActionBindings bindings = actions.count(command) ? actions[command] : vega_config::Configuration::ActionBindings{};
+        const boost::json::object& bindings_object = action_entry.value().get_object();
+
+        const auto* kb_ptr = bindings_object.if_contains("keyboard");
+        if (kb_ptr != nullptr && kb_ptr->is_array()) {
+            bindings.keyboard.clear();
+            readBindingArray(kb_ptr->get_array(), /*is_mouse=*/false, bindings.keyboard);
+        }
+        const auto* ms_ptr = bindings_object.if_contains("mouse");
+        if (ms_ptr != nullptr && ms_ptr->is_array()) {
+            bindings.mouse.clear();
+            readBindingArray(ms_ptr->get_array(), /*is_mouse=*/true, bindings.mouse);
+        }
+        const auto* js_ptr = bindings_object.if_contains("joystick");
+        if (js_ptr != nullptr && js_ptr->is_array()) {
+            bindings.joystick.clear();
+            readBindingArray(js_ptr->get_array(), /*is_mouse=*/false, bindings.joystick);
+        }
+        const auto* ht_ptr = bindings_object.if_contains("hat");
+        if (ht_ptr != nullptr && ht_ptr->is_array()) {
+            bindings.hat.clear();
+            readBindingArray(ht_ptr->get_array(), /*is_mouse=*/false, bindings.hat);
+        }
+        actions[command] = bindings;
+    }
+}
+
+// Parse the "axes" section of the merged config into this->axes
+// (role x/y/z/throttle -> AxisRole).
+//
+// Schema (bindings.json):
+//   "axes": {
+//     "x": { "source": "joystick", "joystick": 0, "axis": 0, "inverse": false },
+//     ...
+//   }
+//
+// Merge/overlay semantics: a homedir overlay may contain only a partial entry
+// (e.g. just { "inverse": true }) to flip a single axis. We therefore start
+// from the existing AxisRole (if any) and only overwrite the fields present,
+// so unset fields keep their datadir values instead of falling back to
+// defaults (which would unbind the axis).
+void vega_config::Configuration::parseAxes(const boost::json::object& root_object) {
+    const boost::json::value* axes_value_ptr = root_object.if_contains("axes");
+    if (axes_value_ptr == nullptr || !axes_value_ptr->is_object()) {
+        return;  // no axes in this file
+    }
+
+    for (const auto& role_entry : axes_value_ptr->get_object()) {
+        const std::string& role = role_entry.key();
+        if (!role_entry.value().is_object()) {
+            continue;
+        }
+        vega_config::Configuration::AxisRole ar = axes.count(role) ? axes[role] : vega_config::Configuration::AxisRole{};
+        const boost::json::object& role_object = role_entry.value().get_object();
+
+        const auto* src = role_object.if_contains("source");
+        if (src != nullptr) { ar.source = boost::json::value_to<std::string>(*src); }
+        const auto* joy = role_object.if_contains("joystick");
+        if (joy != nullptr) { ar.joystick = boost::json::value_to<int>(*joy); }
+        const auto* axis = role_object.if_contains("axis");
+        if (axis != nullptr) { ar.axis = boost::json::value_to<int>(*axis); }
+        const auto* inv = role_object.if_contains("inverse");
+        if (inv != nullptr) { ar.inverse = boost::json::value_to<bool>(*inv); }
+        axes[role] = ar;
+    }
+}
+
+vega_config::Configuration& configuration() {
+    static vega_config::Configuration kConfiguration{};
     return kConfiguration;
 }

--- a/engine/src/configuration/configuration.cpp
+++ b/engine/src/configuration/configuration.cpp
@@ -87,6 +87,24 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         }
         const boost::json::object & root_object = *root_ptr;
 
+        // The `input` section holds the triple-state device switch and the
+        // per-device sub-objects (mouse/joystick/keyboard). Resolve it once so
+        // the mouse/joystick/keyboard blocks below read from input.* with a
+        // fallback to top-level keys (legacy homedir overlays).
+        const boost::json::value * input_value_ptr = root_object.if_contains("input");
+        const boost::json::object * input_object = (input_value_ptr && input_value_ptr->is_object())
+                                                    ? &input_value_ptr->get_object() : nullptr;
+        if (input_object) {
+            const boost::json::value * dv = input_object->if_contains("device");
+            if (dv != nullptr && dv->is_string())
+                input.device = boost::json::value_to<std::string>(*dv);
+            const boost::json::value * mp = input_object->if_contains("mouse_preset");
+            if (mp != nullptr && mp->is_string())
+                input.mouse_preset = boost::json::value_to<std::string>(*mp);
+            const boost::json::value * jp = input_object->if_contains("joystick_preset");
+            if (jp != nullptr && jp->is_string())
+                input.joystick_preset = boost::json::value_to<std::string>(*jp);
+        }
 
 
         const boost::json::value * settings_app_value_ptr = root_object.if_contains("settings_app");
@@ -112,6 +130,16 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
                 settings_app.physics = boost::json::value_to<std::string>(*physics_value_ptr);
             }
 
+        }
+
+        // Parse the "preset" section (config.json) into this->preset selectors.
+        const boost::json::value * preset_value_ptr = root_object.if_contains("preset");
+        if (preset_value_ptr != nullptr && preset_value_ptr->is_object()) {
+            for (const auto & kv : preset_value_ptr->get_object()) {
+                if (kv.value().is_string()) {
+                    preset[kv.key()] = boost::json::value_to<std::string>(kv.value());
+                }
+            }
         }
 
 
@@ -2091,7 +2119,8 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         }
 
 
-        const boost::json::value * mouse_value_ptr = root_object.if_contains("mouse");
+        const boost::json::value * mouse_value_ptr = input_object ? input_object->if_contains("mouse")
+                                                                    : root_object.if_contains("mouse");
         if (mouse_value_ptr != nullptr) {
             boost::json::object mouse_object = mouse_value_ptr->get_object();
             const boost::json::value * enabled_value_ptr = mouse_object.if_contains("enabled");
@@ -6823,7 +6852,8 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         }
 
 
-        const boost::json::value * joystick_value_ptr = root_object.if_contains("joystick");
+        const boost::json::value * joystick_value_ptr = input_object ? input_object->if_contains("joystick")
+                                                                      : root_object.if_contains("joystick");
         if (joystick_value_ptr != nullptr) {
             boost::json::object joystick_object = joystick_value_ptr->get_object();
             const boost::json::value * enabled_value_ptr = joystick_object.if_contains("enabled");
@@ -7024,7 +7054,8 @@ void vega_config::Configuration::load_config(const std::string& json_text) {
         }
 
 
-        const boost::json::value * keyboard_value_ptr = root_object.if_contains("keyboard");
+        const boost::json::value * keyboard_value_ptr = input_object ? input_object->if_contains("keyboard")
+                                                                      : root_object.if_contains("keyboard");
         if (keyboard_value_ptr != nullptr) {
             boost::json::object keyboard_object = keyboard_value_ptr->get_object();
             const boost::json::value * enable_unicode_value_ptr = keyboard_object.if_contains("enable_unicode");

--- a/engine/src/configuration/configuration.h
+++ b/engine/src/configuration/configuration.h
@@ -31,7 +31,10 @@
 
 #include <string>
 #include <memory>
+#include <map>
+#include <vector>
 #include <boost/filesystem/path.hpp>
+#include <boost/json.hpp>
 
 #include "components/energy_consumer.h"
 
@@ -43,6 +46,16 @@ namespace vega_config {
 
 		void load_config(const std::string& json_text);
 		void load_config(const boost::filesystem::path & config_file_path);
+
+		// Parses the "colors" section (theme.json) into this->colors. Called
+		// from load_config() for each merged config file.
+		void parseColors(const boost::json::object& root_object);
+
+		// Parses the "actions" section (bindings.json) into this->actions.
+		void parseActions(const boost::json::object& root_object);
+
+		// Parses the "axes" section (bindings.json) into this->axes.
+		void parseAxes(const boost::json::object& root_object);
 
 
     struct {
@@ -56,6 +69,44 @@ namespace vega_config {
     struct {
 
     } advanced;
+
+    // --- Actions (input bindings) ---
+    //
+    // command -> per-device binding arrays. This replaces the old flat
+    // 'controls' struct and the vegastrike.config XML <bind> / <axis> blocks.
+    // The engine fills the same in-memory input tables (BindKey/BindJoyKey/...)
+    // from these in GameVegaConfig::bindKeys(); the runtime input system
+    // itself is unchanged.
+    //
+    // Source: bindings.json, section "actions". See parseActions().
+    struct ActionBinding {
+        std::string key;        // keyboard: key name, e.g. "a" or "tab"
+        std::string modifier;   // "none" | "alt" | "ctrl" (shift encoded in key)
+        int button = -1;        // mouse/joystick: button index
+        int joystick = -1;      // joystick: device index (mouse uses -1 + is_mouse)
+        bool is_mouse = false;  // true for mouse-button binds (mouse-as-joystick slot)
+        int hatswitch = -1;     // digital hat: hat index
+        std::string direction;  // digital hat: VS_HAT_* name ("up","right",...)
+    };
+    struct ActionBindings {
+        std::vector<ActionBinding> keyboard;
+        std::vector<ActionBinding> mouse;
+        std::vector<ActionBinding> joystick;
+        std::vector<ActionBinding> hat;
+    };
+    std::map<std::string, ActionBindings> actions;
+
+    // --- Axes (input axes) ---
+    //
+    // role (x/y/z/throttle) -> source device + physical axis + inverse flag.
+    // Source: bindings.json, section "axes". See parseAxes().
+    struct AxisRole {
+        std::string source = "joystick";  // "joystick" | "mouse"
+        int joystick = 0;
+        int axis = -1;
+        bool inverse = false;
+    };
+    std::map<std::string, AxisRole> axes;
 
     struct {
 
@@ -2651,6 +2702,8 @@ namespace vega_config {
 
     struct {
         bool auto_hide = true;
+        std::string loading_sprite = "load_screen.ani";
+        std::string loading_message = "Loading...";
 
     } splash;
 
@@ -2788,9 +2841,25 @@ namespace vega_config {
 
     } weapons;
 
+    // Colors: section -> { name : [r, g, b, a] }.
+    //
+    // Ported from the old vegastrike.config <colors> section, which now lives in
+    // theme.json. The engine merges theme.json into the configuration() object at
+    // startup, so this map is read straight from the merged config. VegaConfig's
+    // ctor seeds its getColor() lookup table from this map, so all the existing
+    // vs_config->getColor(section, name) call sites keep working unchanged.
+    //
+    // Schema (theme.json):
+    //   "colors": {
+    //     "default": { "enemy": [1.0, 0.0, 0.0, 1.0], "friend": [0.0, 1.0, 0.0, 1.0], ... },
+    //     "nav":      { "current_system": [1.0, 0.3, 0.3, 1.0], ... },
+    //     ...
+    //   }
+    std::map<std::string, std::map<std::string, std::vector<float>>> colors;
+
     };
 }
 
-extern const vega_config::Configuration& configuration();
+extern vega_config::Configuration& configuration();
 
 #endif //VEGA_STRIKE_ENGINE_CONFIG_CONFIGURATION_H

--- a/engine/src/configuration/configuration.h
+++ b/engine/src/configuration/configuration.h
@@ -66,6 +66,11 @@ namespace vega_config {
 
     } settings_app;
 
+    // Preset selectors from config.json's "preset" section (e.g.
+    // computer="4000MHz", shaders="highshader"). Metadata for the settings app;
+    // the engine does not expand these itself. Key is the lowercase category.
+    std::map<std::string, std::string> preset;
+
     struct {
 
     } advanced;
@@ -2231,6 +2236,16 @@ namespace vega_config {
         bool enable_unicode = true;
 
     } keyboard;
+
+    // The `input` section (config.json) — the triple-state device switch and
+    // behavior-preset selectors. The mouse/joystick/keyboard sub-structs above
+    // are populated from input.mouse / input.joystick / input.keyboard.
+    struct {
+        std::string device = "keyboard";        // "keyboard" | "mouse" | "joystick"
+        std::string mouse_preset = "glide_mouse";
+        std::string joystick_preset = "joy_normal";
+
+    } input;
 
     struct {
         int vsdebug = 0;

--- a/engine/src/configuration/configuration.h
+++ b/engine/src/configuration/configuration.h
@@ -34,7 +34,7 @@
 #include <map>
 #include <vector>
 #include <boost/filesystem/path.hpp>
-#include <boost/json.hpp>
+#include <boost/json/fwd.hpp>
 
 #include "components/energy_consumer.h"
 

--- a/engine/src/gfx/cockpit.cpp
+++ b/engine/src/gfx/cockpit.cpp
@@ -46,6 +46,7 @@
 #include "src/vegastrike.h"
 #include "gfx/gauge.h"
 #include "gfx/cockpit.h"
+#include "gldrv/mouse_cursor.h"
 #include "src/universe.h"
 #include "src/star_system.h"
 #include "cmd/unit_generic.h"
@@ -1900,7 +1901,48 @@ void GameCockpit::Draw() {
         if ((view == CP_PAN
                 && !mousecursor_pancam)
                 || (view == CP_PANTARGET && !mousecursor_pantgt) || (view == CP_CHASE && !mousecursor_chasecam)) {
-        } 
+        } else {
+            // Glide mouse flight: the OS cursor is hidden (see universe.cpp) and we
+            // draw an in-game crosshair sprite instead, so we can (a) mirror its Y
+            // movement to match the inverted flight axis in inverse-glide (the OS
+            // cursor cannot be inverted) and (b) scale it down near the center
+            // within the glide deadzone. Both apply to normal glide; only the Y
+            // mirror is specific to inverse-glide (reverse_mouse_spr).
+            static VSSprite MouseVSSprite(configuration().joystick.mouse_crosshair.c_str(), BILINEAR, GFXTRUE);
+            const std::pair<int, int> mp = GetMousePosition();
+            const float mousex = static_cast<float>(mp.first);
+            const float mousey = static_cast<float>(mp.second);
+            const float sgn = configuration().joystick.reverse_mouse_spr ? -1.0f : 1.0f;
+            // Normalized -1..1 coordinates. ycoord uses sgn * (1 - mousey/.5res):
+            //   normal glide (sgn=+1): ycoord =  1 - mousey/(.5*res) (follows mouse)
+            //   inverse glide (sgn=-1): ycoord = -1 + mousey/(.5*res) (mirrored Y)
+            float xcoord = -1.0f + mousex / (0.5f * static_cast<float>(configuration().graphics.resolution_x));
+            float ycoord = sgn * (1.0f - mousey / (0.5f * static_cast<float>(configuration().graphics.resolution_y)));
+            GFXBlendMode(SRCALPHA, INVSRCALPHA);
+            GFXColor4f(1, 1, 1, 1);
+            GFXEnable(TEXTURE0);
+            GFXDisable(DEPTHTEST);
+            GFXDisable(LIGHTING);
+            // Deadband resize: shrink the crosshair when near the center. Use the
+            // same hardcoded deadzone (0.15) as the glide flight path
+            // (GetRelativeJoystickCoordinatesForAxis) so the scaling lines up with
+            // where the ship actually stops responding. The joystick deadzone
+            // config (deadband_flt) is for real joysticks, not the mouse.
+            float sx = 0.0f, sy = 0.0f;
+            MouseVSSprite.GetSize(sx, sy);
+            const float deadband = 0.15f;
+            if (xcoord < deadband && ycoord < deadband && xcoord > -deadband && ycoord > -deadband) {
+                MouseVSSprite.SetSize(sx / 2.0f, sy / 2.0f);
+            } else if (xcoord < deadband && xcoord > -deadband) {
+                MouseVSSprite.SetSize(sx / 2.0f, sy * 5.0f / 6.0f);
+            } else if (ycoord < deadband && ycoord > -deadband) {
+                MouseVSSprite.SetSize(sx * 5.0f / 6.0f, sy / 2.0f);
+            }
+            MouseVSSprite.SetPosition(xcoord, ycoord);
+            MouseVSSprite.Draw();
+            MouseVSSprite.SetSize(sx, sy);
+            GFXDisable(TEXTURE0);
+        }
     }
     if (view < CP_CHASE && damage_flash_first == false && getNewTime() - shake_time < damage_flash_length) {
         DrawDamageFlash(shake_type);

--- a/engine/src/gfx/vdu.cpp
+++ b/engine/src/gfx/vdu.cpp
@@ -1250,7 +1250,7 @@ void VDU::DrawStarSystemAgain(float x, float y, float w, float h, VIEWSTYLE view
     GFXEnable(DEPTHWRITE);
     VIEWSTYLE which = viewStyle;
     float tmpaspect = configuration().graphics.aspect_flt;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt = w / h;
+    (configuration()).graphics.aspect_flt = w / h;
     _Universe->AccessCamera(which)->SetSubwindow(x, y, w, h);
     _Universe->SelectCamera(which);
     VIEWSTYLE tmp = _Universe->AccessCockpit()->GetView();
@@ -1260,7 +1260,7 @@ void VDU::DrawStarSystemAgain(float x, float y, float w, float h, VIEWSTYLE view
     GFXClear(GFXFALSE);
     GFXColor4f(1, 1, 1, 1);
     _Universe->activeStarSystem()->Draw(false);
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt = tmpaspect;
+    (configuration()).graphics.aspect_flt = tmpaspect;
     _Universe->AccessCamera(which)->SetSubwindow(0, 0, 1, 1);
     _Universe->AccessCockpit()->SetView(tmp);
     _Universe->AccessCockpit()->SelectProperCamera();

--- a/engine/src/gfxlib.h
+++ b/engine/src/gfxlib.h
@@ -529,6 +529,7 @@ int GFXShaderConstantv(int name, unsigned int numvals, const float *value);
 int GFXShaderConstantv(int name, unsigned int numvals, const int *value);
 bool GFXDefaultShaderSupported();
 void GFXReloadDefaultShader();
+void GFXApplyShaderSetting();
 void GFXUploadLightState(int max_light_location,
         int active_light_array,
         int apparent_light_size_array,

--- a/engine/src/gfxlib.h
+++ b/engine/src/gfxlib.h
@@ -529,7 +529,6 @@ int GFXShaderConstantv(int name, unsigned int numvals, const float *value);
 int GFXShaderConstantv(int name, unsigned int numvals, const int *value);
 bool GFXDefaultShaderSupported();
 void GFXReloadDefaultShader();
-void GFXApplyShaderSetting();
 void GFXUploadLightState(int max_light_location,
         int active_light_array,
         int apparent_light_size_array,

--- a/engine/src/gfxlib_struct.cpp
+++ b/engine/src/gfxlib_struct.cpp
@@ -145,7 +145,7 @@ void GFXVertexList::RefreshDisplayList() {
     if (configuration().graphics.vbo && !vbo_data) {
         if (glGenBuffersARB_p == nullptr || glBindBufferARB_p == nullptr || glBufferDataARB_p == nullptr || glMapBufferARB_p == nullptr
                 || glUnmapBufferARB_p == nullptr) {
-            (const_cast<vega_config::Configuration &>(configuration())).graphics.vbo = false;
+            (configuration()).graphics.vbo = false;
         } else {
             (*glGenBuffersARB_p)(1, (GLuint *) &vbo_data);
             if (changed & HAS_INDEX) {

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -551,7 +551,10 @@ void init_opengl_extensions() {
     VS_LOG(info, (boost::format("Max vertex array vertices: %1%") % gl_options.max_array_vertices));
 }
 
-static void initfov() {
+// Copy the model/LOD + texture feature flags from configuration() into the legacy
+// g_game global. Historical bootstrap ran this once; GFXReinitConfig re-runs it so
+// in-game settings changes (feature flags) take effect without a restart.
+void initfov() {
     g_game.detaillevel = configuration().graphics.model_detail_flt;
     g_game.use_textures = configuration().graphics.use_textures;
     g_game.use_ship_textures = configuration().graphics.use_ship_textures;
@@ -571,6 +574,32 @@ static void initfov() {
      *  VSFileSystem::Close (fp);
      *  }
      */
+}
+
+// Copy the config-driven gl_options fields from configuration(). These were set
+// inline during GFXInit (one-shot). Factored out so GFXReinitConfig can re-run them
+// after an in-game settings change. Only the fields that directly mirror a config
+// value are copied here; the hardware-limited ones (max_rect_dimension, PaletteExt,
+// max_array_*, max_texture_dimension) are one-shot GL/extension queries and are not
+// re-derived.
+static void reapply_gl_options() {
+    gl_options.wireframe = configuration().graphics.use_wireframe;
+    gl_options.smooth_shade = configuration().graphics.smooth_shade;
+    gl_options.mipmap = configuration().graphics.mipmap_detail;
+    gl_options.compression = configuration().graphics.texture_compression;
+    gl_options.Multitexture = configuration().graphics.reflection;
+    gl_options.display_lists = configuration().graphics.displaylists;
+}
+
+// Re-initialize the graphics runtime state from the in-memory configuration() after
+// an in-game settings change (the config screen's Save path). Reuses the bootstrap
+// copy code (initfov + reapply_gl_options) so the change takes effect without a
+// restart. Also re-binds the GL viewport to the current drawable size. Does NOT
+// recreate the window or GL context (those stay one-shot); see gl_init.h.
+void GFXReinitConfig() {
+    initfov();
+    reapply_gl_options();
+    glViewport(0, 0, native_resolution_x, native_resolution_y);
 }
 
 static void Reshape(int x, int y) {
@@ -629,14 +658,13 @@ void GFXInit(int argc, char **argv) {
         VS_LOG(trace, "Using NPOT video textures");
     }*/
     // Removing gl_options soon
-    gl_options.smooth_shade = configuration().graphics.smooth_shade;
-    gl_options.mipmap = configuration().graphics.mipmap_detail;
-    gl_options.compression = configuration().graphics.texture_compression;
-    gl_options.Multitexture = configuration().graphics.reflection;
+    // Config-driven gl_options copies (extracted so GFXReinitConfig can re-run them
+    // on an in-game settings change). The self-assignment lines below keep their
+    // original meaning (config already holds the value; assigned back for clarity).
+    reapply_gl_options();
     (const_cast<vega_config::Configuration &>(configuration())).graphics.smooth_lines = configuration().graphics.smooth_lines;
     (const_cast<vega_config::Configuration &>(configuration())).graphics.smooth_points = configuration().graphics.smooth_points;
 
-    gl_options.display_lists = configuration().graphics.displaylists;
     (const_cast<vega_config::Configuration &>(configuration())).graphics.s3tc = configuration().graphics.s3tc;
     (const_cast<vega_config::Configuration &>(configuration())).graphics.ext_clamp_to_edge = configuration().graphics.ext_clamp_to_edge;
     (const_cast<vega_config::Configuration &>(configuration())).graphics.ext_clamp_to_border = configuration().graphics.ext_clamp_to_border;

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -462,7 +462,7 @@ void init_opengl_extensions() {
         VS_LOG(trace, "OpenGL::S3TC Texture Compression supported");
         //should be true;
     } else {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.s3tc = false;
+        (configuration()).graphics.s3tc = false;
         VS_LOG(info, "OpenGL::S3TC Texture Compression unsupported");
     }
     if ((glMultiTexCoord2fARB_p && glMultiTexCoord4fARB_p && glClientActiveTextureARB_p && glActiveTextureARB_p)
@@ -493,14 +493,14 @@ void init_opengl_extensions() {
         VS_LOG(trace, "OpenGL::S3TC Texture Clamp-to-Edge supported");
         // should be true
     } else {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.ext_clamp_to_edge = false;
+        (configuration()).graphics.ext_clamp_to_edge = false;
         VS_LOG(info, "OpenGL::S3TC Texture Clamp-to-Edge unsupported");
     }
     if (vsExtensionSupported("GL_ARB_texture_border_clamp") || vsExtensionSupported("GL_SGIS_texture_border_clamp")) {
         VS_LOG(trace, "OpenGL::S3TC Texture Clamp-to-Border supported");
         // should be true
     } else {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.ext_clamp_to_border = false;
+        (configuration()).graphics.ext_clamp_to_border = false;
         VS_LOG(info, "OpenGL::S3TC Texture Clamp-to-Border unsupported");
     }
     if (vsExtensionSupported("GL_ARB_framebuffer_sRGB") || vsExtensionSupported("GL_EXT_framebuffer_sRGB")) {
@@ -603,8 +603,8 @@ void GFXReinitConfig() {
 }
 
 static void Reshape(int x, int y) {
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = x;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = y;
+    (configuration()).graphics.resolution_x = x;
+    (configuration()).graphics.resolution_y = y;
     VS_LOG(trace, (boost::format("Reshaping %1% %2%") % x % y));
 }
 
@@ -619,13 +619,13 @@ void GFXInit(int argc, char **argv) {
     
     static GFXColor clearcol = vs_config->getColor("space_background");;
     gl_options.wireframe = configuration().graphics.use_wireframe;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.max_texture_dimension = configuration().graphics.max_texture_dimension;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.max_movie_dimension = configuration().graphics.max_movie_dimension;
+    (configuration()).graphics.max_texture_dimension = configuration().graphics.max_texture_dimension;
+    (configuration()).graphics.max_movie_dimension = configuration().graphics.max_movie_dimension;
     bool textsupported =
             (vsExtensionSupported("GL_ARB_texture_non_power_of_two") || vsExtensionSupported("GL_ARB_texture_rectangle")
                     || vsExtensionSupported("GL_NV_texture_rectangle")) ? "true" : "false";
 
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.rect_textures = configuration().graphics.rect_textures ? true : textsupported;
+    (configuration()).graphics.rect_textures = configuration().graphics.rect_textures ? true : textsupported;
 
     if (configuration().graphics.rect_textures) {
         VS_LOG(trace, "RECT textures supported");
@@ -643,12 +643,12 @@ void GFXInit(int argc, char **argv) {
     bool vidsupported = (configuration().graphics.rect_textures
                          || (vsExtensionSupported("GL_ARB_texture_non_power_of_two") && vsVendorMatch("nvidia")));
 
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.pot_video_textures = configuration().graphics.pot_video_textures ? true : vidsupported;
+    (configuration()).graphics.pot_video_textures = configuration().graphics.pot_video_textures ? true : vidsupported;
 
     if (!configuration().graphics.pot_video_textures && configuration().graphics.rect_textures) {
         // Enforce max rect texture for movies, which use them
         if (configuration().graphics.max_movie_dimension > gl_options.max_rect_dimension) {
-            (const_cast<vega_config::Configuration &>(configuration())).graphics.max_movie_dimension = gl_options.max_rect_dimension;
+            (configuration()).graphics.max_movie_dimension = gl_options.max_rect_dimension;
         }
     }
 
@@ -662,12 +662,12 @@ void GFXInit(int argc, char **argv) {
     // on an in-game settings change). The self-assignment lines below keep their
     // original meaning (config already holds the value; assigned back for clarity).
     reapply_gl_options();
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.smooth_lines = configuration().graphics.smooth_lines;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.smooth_points = configuration().graphics.smooth_points;
+    (configuration()).graphics.smooth_lines = configuration().graphics.smooth_lines;
+    (configuration()).graphics.smooth_points = configuration().graphics.smooth_points;
 
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.s3tc = configuration().graphics.s3tc;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.ext_clamp_to_edge = configuration().graphics.ext_clamp_to_edge;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.ext_clamp_to_border = configuration().graphics.ext_clamp_to_border;
+    (configuration()).graphics.s3tc = configuration().graphics.s3tc;
+    (configuration()).graphics.ext_clamp_to_edge = configuration().graphics.ext_clamp_to_edge;
+    (configuration()).graphics.ext_clamp_to_border = configuration().graphics.ext_clamp_to_border;
 
     glClearColor(clearcol.r, clearcol.g, clearcol.b, clearcol.a);
     winsys_set_reshape_func(Reshape);

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -600,6 +600,29 @@ void GFXReinitConfig() {
     initfov();
     reapply_gl_options();
     glViewport(0, 0, native_resolution_x, native_resolution_y);
+
+    // Recompute the base-computer letterbox viewport (bases.max_width/height) from
+    // the current resolution, preserving the existing base aspect ratio. This is
+    // what `apply_display_to_config` computes on a settings Save; without it a
+    // window resize leaves the base letterboxed at the old size, so base hitboxes
+    // are off. The base aspect is derived from the current bases.max_width/height
+    // (default 16:10) and the letterbox is the largest rect of that aspect that
+    // fits the current resolution.
+    auto &g = (const_cast<vega_config::Configuration &>(configuration())).graphics;
+    const int res_x = g.resolution_x;
+    const int res_y = g.resolution_y;
+    if (res_x > 0 && res_y > 0) {
+        float base_aspect = 1.6f;   // default 16:10
+        if (g.bases.max_height > 0) {
+            float cur = (float)g.bases.max_width / (float)g.bases.max_height;
+            if (cur > 0) { base_aspect = cur; }
+        }
+        int W = res_x, H = res_y;
+        if (base_aspect >= (float)res_x / res_y) { W = res_x; H = (int)(res_x / base_aspect); }
+        else { H = res_y; W = (int)(res_y * base_aspect); }
+        g.bases.max_width = W;
+        g.bases.max_height = H;
+    }
 }
 
 static void Reshape(int x, int y) {

--- a/engine/src/gldrv/gl_init.cpp
+++ b/engine/src/gldrv/gl_init.cpp
@@ -600,29 +600,6 @@ void GFXReinitConfig() {
     initfov();
     reapply_gl_options();
     glViewport(0, 0, native_resolution_x, native_resolution_y);
-
-    // Recompute the base-computer letterbox viewport (bases.max_width/height) from
-    // the current resolution, preserving the existing base aspect ratio. This is
-    // what `apply_display_to_config` computes on a settings Save; without it a
-    // window resize leaves the base letterboxed at the old size, so base hitboxes
-    // are off. The base aspect is derived from the current bases.max_width/height
-    // (default 16:10) and the letterbox is the largest rect of that aspect that
-    // fits the current resolution.
-    auto &g = (const_cast<vega_config::Configuration &>(configuration())).graphics;
-    const int res_x = g.resolution_x;
-    const int res_y = g.resolution_y;
-    if (res_x > 0 && res_y > 0) {
-        float base_aspect = 1.6f;   // default 16:10
-        if (g.bases.max_height > 0) {
-            float cur = (float)g.bases.max_width / (float)g.bases.max_height;
-            if (cur > 0) { base_aspect = cur; }
-        }
-        int W = res_x, H = res_y;
-        if (base_aspect >= (float)res_x / res_y) { W = res_x; H = (int)(res_x / base_aspect); }
-        else { H = res_y; W = (int)(res_y * base_aspect); }
-        g.bases.max_width = W;
-        g.bases.max_height = H;
-    }
 }
 
 static void Reshape(int x, int y) {

--- a/engine/src/gldrv/gl_init.h
+++ b/engine/src/gldrv/gl_init.h
@@ -32,6 +32,16 @@ extern "C"
 {
 #endif
 
+// Re-initialize the graphics runtime state from the (already-updated) in-memory
+// configuration(). The game historically assumed the config never changes in-game,
+// so config->runtime copies (g_game feature flags, gl_options, GL viewport) ran only
+// once at bootstrap. The in-game settings screen (Alt+C / --configure) can now change
+// any setting and Save them; call this after Save to re-bind those copies so the
+// change takes effect without a restart. Reuses the same copy code as bootstrap
+// (initfov + the gl_options config copies). Does NOT recreate the window/GL context.
+// A brief re-orient pause is acceptable (and expected) while it re-binds.
+extern void GFXReinitConfig();
+
 //#include "src/vegastrike.h"
 
 /* Hack to fix compiling problem with old gl.h's, reported by Steve

--- a/engine/src/gldrv/gl_program.cpp
+++ b/engine/src/gldrv/gl_program.cpp
@@ -486,20 +486,6 @@ void GFXReloadDefaultShader() {
     }
 }
 
-// Live-apply the configured shader setting. The shader name is read once into the
-// file-level hifiProgramName when getDefaultProgram() first runs; on an in-game
-// settings change the config value changes but hifiProgramName stays stale, so a
-// plain GFXReloadDefaultShader would recompile the OLD shader (funky colors until
-// restart). Re-read the name from configuration() first, then reload.
-void GFXApplyShaderSetting() {
-#if defined(__APPLE__) && defined (__MACH__)
-    hifiProgramName = configuration().graphics.mac_shader_name;
-#else
-    hifiProgramName = configuration().graphics.shader_name;
-#endif
-    GFXReloadDefaultShader();
-}
-
 enum GameSpeed {
     JUSTRIGHT,
     TOOSLOW,

--- a/engine/src/gldrv/gl_program.cpp
+++ b/engine/src/gldrv/gl_program.cpp
@@ -475,6 +475,20 @@ void GFXReloadDefaultShader() {
     }
 }
 
+// Live-apply the configured shader setting. The shader name is read once into the
+// file-level hifiProgramName when getDefaultProgram() first runs; on an in-game
+// settings change the config value changes but hifiProgramName stays stale, so a
+// plain GFXReloadDefaultShader would recompile the OLD shader (funky colors until
+// restart). Re-read the name from configuration() first, then reload.
+void GFXApplyShaderSetting() {
+#if defined(__APPLE__) && defined (__MACH__)
+    hifiProgramName = configuration().graphics.mac_shader_name;
+#else
+    hifiProgramName = configuration().graphics.shader_name;
+#endif
+    GFXReloadDefaultShader();
+}
+
 enum GameSpeed {
     JUSTRIGHT,
     TOOSLOW,

--- a/engine/src/gldrv/gl_program.cpp
+++ b/engine/src/gldrv/gl_program.cpp
@@ -446,12 +446,23 @@ void GFXReloadDefaultShader() {
     // Increasing the timestamp makes all programs elsewhere recompile
     ++programVersion;
 
-    bool islow = (lowfiprog == defaultprog);
-    if (glDeleteProgram_p && defaultprog) {
-        glDeleteProgram_p(lowfiprog);
-        glDeleteProgram_p(hifiprog);
+    // Remove the old shader programs from the program cache before deleting the GL
+    // objects. programCache/programICache map name -> program ID and are NOT cleared
+    // by glDeleteProgram; if they keep the old (now-deleted) ID, the next
+    // GFXCreateProgram for the same shader returns the stale cached ID instead of
+    // recompiling -> the shader hot-apply renders with funky/unloaded colors.
+    if (defaultprog) {
+        GFXDestroyProgram(lowfiprog);
+        GFXDestroyProgram(hifiprog);
+        if (glDeleteProgram_p) {
+            if (lowfiprog) glDeleteProgram_p(lowfiprog);
+            if (hifiprog) glDeleteProgram_p(hifiprog);
+        }
     }
     programChanged = true;
+    // For the low/high resolution split below: islow tracks which program was the
+    // default before the reload (so we re-select the same default after recompile).
+    bool islow = (lowfiprog == defaultprog);
     if (islow) {
         hifiprog = GFXCreateProgram(hifiProgramName.c_str(), hifiProgramName.c_str(), NULL);
         if (hifiprog == 0) {

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -566,6 +566,27 @@ void winsys_process_events() {
                     }
                     break;
 
+                case SDL_MOUSEWHEEL:
+                    // SDL2 reports the wheel as its own event (SDL_MOUSEWHEEL,
+                    // not a button press). Synthesize wheel-up / wheel-down
+                    // button presses so the existing mouse-button pipeline
+                    // (WS_WHEEL_UP->3 / WS_WHEEL_DOWN->4 in lookupMouseButton)
+                    // keeps working -- this drives scrolling in the base
+                    // computer, navscreen, pickers, etc.
+                    if (mouse_func) {
+                        int mx = 0;
+                        int my = 0;
+                        SDL_GetMouseState(&mx, &my);
+                        if (event.wheel.y > 0) {
+                            (*mouse_func)(WS_WHEEL_UP, WS_MOUSE_DOWN, mx, my);
+                            (*mouse_func)(WS_WHEEL_UP, WS_MOUSE_UP, mx, my);
+                        } else if (event.wheel.y < 0) {
+                            (*mouse_func)(WS_WHEEL_DOWN, WS_MOUSE_DOWN, mx, my);
+                            (*mouse_func)(WS_WHEEL_DOWN, WS_MOUSE_UP, mx, my);
+                        }
+                    }
+                    break;
+
                 case SDL_MOUSEMOTION:
                     if (event.motion.state) {
                         /* buttons are down */

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -404,13 +404,32 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
         SDL_ClearError();
     }
 
-    SDL_GL_GetDrawableSize(window, &width, &height);
-    // Use the measured drawable size as the render target so the viewport always
-    // matches the actual window/display mode (a mode change may resolve to the
-    // closest mode, or the window may have been clamped). This is the actual size
-    // the game renders into, regardless of the configured request.
-    native_resolution_x = width;
-    native_resolution_y = height;
+    // Measure the ACTUAL window size after creation. In windowed mode the WM /
+    // compositor may clamp a requested size down to fit the screen, so the game
+    // must adopt the window it actually got rather than assume it got the
+    // requested size (otherwise the viewport/layout render at the oversized
+    // request while the window is smaller -> cut off). The GL drawable size is
+    // the render target (native_resolution -> glViewport); the logical window
+    // size is what the layout/HUD/ImGui/config-screen read (graphics.resolution).
+    // On a non-scaling display these are equal; on a scaled display they differ
+    // (points vs pixels) and we keep them distinct.
+    int logical_w = 0, logical_h = 0;
+    SDL_GetWindowSize(window, &logical_w, &logical_h);
+    int drawable_w = 0, drawable_h = 0;
+    SDL_GL_GetDrawableSize(window, &drawable_w, &drawable_h);
+    if (logical_w <= 0) { logical_w = width; }
+    if (logical_h <= 0) { logical_h = height; }
+    if (drawable_w <= 0) { drawable_w = logical_w; }
+    if (drawable_h <= 0) { drawable_h = logical_h; }
+    native_resolution_x = drawable_w;
+    native_resolution_y = drawable_h;
+    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = logical_w;
+    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = logical_h;
+    // Keep the screen aspect consistent with the actual window resolution.
+    if (logical_h > 0) {
+        (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
+                (float)logical_w / (float)logical_h;
+    }
 
     SDL_GLContext context = SDL_GL_CreateContext(window);
 
@@ -791,6 +810,21 @@ void winsys_process_events() {
 #if !(defined (_WIN32) && defined (SDL_WINDOWING ))
                     (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = event.window.data1;
                     (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = event.window.data2;
+                    if (event.window.data2 > 0) {
+                        (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
+                                (float)event.window.data1 / (float)event.window.data2;
+                    }
+                    // A manual window resize must also re-bind the GL viewport to the
+                    // actual drawable size, otherwise native_resolution_x/y go stale
+                    // and the scene renders at the old size into the resized window.
+                    {
+                        int d_w = 0, d_h = 0;
+                        SDL_GL_GetDrawableSize(window, &d_w, &d_h);
+                        if (d_w > 0 && d_h > 0) {
+                            native_resolution_x = d_w;
+                            native_resolution_y = d_h;
+                        }
+                    }
                     //setup_sdl_video_mode(argc, argv);
                     if (reshape_func) {
                         (*reshape_func)(event.window.data1,

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -144,6 +144,19 @@ void winsys_set_keyboard_func(winsys_keyboard_func_t func) {
     keyboard_func = func;
 }
 
+// Whether the in-game config overlay is open. While active, winsys suppresses
+// forwarding mouse/keyboard to the game handlers (the overlay consumes input) so
+// clicks don't pass through to the game behind.
+static bool config_overlay_active = false;
+
+void winsys_set_config_overlay_active(bool active) {
+    config_overlay_active = active;
+}
+
+bool winsys_config_overlay_active() {
+    return config_overlay_active;
+}
+
 /*---------------------------------------------------------------------------*/
 /*!
  *  Sets the mouse button-press callback
@@ -590,7 +603,7 @@ void winsys_process_events() {
                         break;
                     }
 
-                    if (keyboard_func) {
+                    if (!config_overlay_active && keyboard_func) {
 //                        VS_LOG(debug, (boost::format("Kbd: %1$s mod:%2$x sym:%3$x scan:%4$x")
 //                                       % ((event.type == SDL_KEYUP) ? "KEYUP" : "KEYDOWN")
 //                                       % event.key.keysym.mod
@@ -607,7 +620,7 @@ void winsys_process_events() {
 
                 case SDL_MOUSEBUTTONDOWN:
                 case SDL_MOUSEBUTTONUP:
-                    if (mouse_func) {
+                    if (!config_overlay_active && mouse_func) {
                         (*mouse_func)(event.button.button,
                                 event.button.state,
                                 event.button.x,
@@ -637,17 +650,19 @@ void winsys_process_events() {
                     break;
 
                 case SDL_MOUSEMOTION:
-                    if (event.motion.state) {
-                        /* buttons are down */
-                        if (motion_func) {
-                            (*motion_func)(event.motion.x,
+                    if (!config_overlay_active) {
+                        if (event.motion.state) {
+                            /* buttons are down */
+                            if (motion_func) {
+                                (*motion_func)(event.motion.x,
+                                        event.motion.y);
+                            }
+                        } else
+                            /* no buttons are down */
+                        if (passive_motion_func) {
+                            (*passive_motion_func)(event.motion.x,
                                     event.motion.y);
                         }
-                    } else
-                        /* no buttons are down */
-                    if (passive_motion_func) {
-                        (*passive_motion_func)(event.motion.x,
-                                event.motion.y);
                     }
                     break;
 

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -713,10 +713,17 @@ void winsys_apply_resolution(int width, int height, bool fullscreen) {
 extern int shiftdown(int);
 extern int shiftup(int);
 
+// Debounce state for window resizes. A live drag fires many SIZE_CHANGED/RESIZED
+// events in quick succession; we re-init only after the resize has been quiet for
+// RESIZE_DEBOUNCE_MS, so we don't thrash the re-init on every intermediate frame.
+static int pending_resize_w = -1;
+static int pending_resize_h = -1;
+static Uint32 resize_deadline = 0;
+static const Uint32 RESIZE_DEBOUNCE_MS = 100;
+
 // Handle a window size change (resize or size-changed). Re-binds the game to the
 // new actual window size and requests a redraw so the game re-renders at the new
-// size. Called for both SDL_WINDOWEVENT_RESIZED and SDL_WINDOWEVENT_SIZE_CHANGED;
-// we re-init on every one (can't reliably know which is last across WMs).
+// size. This is the actual re-init; callers debounce it via the resize_request below.
 static void handle_window_resize(int new_w, int new_h) {
     (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = new_w;
     (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = new_h;
@@ -844,16 +851,24 @@ void winsys_process_events() {
                     }
                     break;
 
-                case SDL_WINDOWEVENT_RESIZED:
-#if !(defined (_WIN32) && defined (SDL_WINDOWING ))
-                    handle_window_resize(event.window.data1, event.window.data2);
-#endif
-                    break;
-
-                case SDL_WINDOWEVENT_SIZE_CHANGED:
-                    // A size change (e.g. during a live drag, or from an API call)
-                    // must also re-bind + redraw, same as a completed resize.
-                    handle_window_resize(event.window.data1, event.window.data2);
+                case SDL_WINDOWEVENT:
+                    // event.type == SDL_WINDOWEVENT (0x200); the actual sub-type is
+                    // event.window.event (RESIZED=5, SIZE_CHANGED=6, MOVED=3, ...).
+                    // Record the latest resize; the actual re-init is performed once
+                    // the resize has been quiet for RESIZE_DEBOUNCE_MS (debounced,
+                    // checked after the event pump), so a live drag doesn't thrash it.
+                    switch (event.window.event) {
+                        case SDL_WINDOWEVENT_RESIZED:
+                        case SDL_WINDOWEVENT_SIZE_CHANGED:
+                            pending_resize_w = event.window.data1;
+                            pending_resize_h = event.window.data2;
+                            resize_deadline = SDL_GetTicks() + RESIZE_DEBOUNCE_MS;
+                            break;
+                        default:
+                            // Other window events (moved, exposed, shown, ...)
+                            // need no re-init; ignore.
+                            break;
+                    }
                     break;
 
                 case SDL_JOYDEVICEADDED:
@@ -876,6 +891,14 @@ void winsys_process_events() {
             }
             SDL_LockAudio();
             SDL_UnlockAudio();
+        }
+        // Apply a pending debounced resize now that the resize events have quieted
+        // down (no new event for RESIZE_DEBOUNCE_MS). This re-binds the viewport /
+        // config to the final size and requests a redraw.
+        if (pending_resize_w >= 0 && SDL_GetTicks() >= resize_deadline) {
+            handle_window_resize(pending_resize_w, pending_resize_h);
+            pending_resize_w = -1;
+            pending_resize_h = -1;
         }
         if (redisplay && display_func) {
             redisplay = false;

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -54,7 +54,7 @@
 #include "configuration/configuration.h"
 #include "libraries/gui/gui.h"
 #include "backends/imgui_impl_sdl2.h"
-#include "config_screen.h"
+#include "gui/config_screen.h"
 
 #include "SDL2/SDL_video.h"
 

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -248,6 +248,31 @@ int native_resolution_y;
 
 /*---------------------------------------------------------------------------*/
 /*!
+ *  Find the SDL display mode matching the requested resolution on the given
+ *  display, returning true if matched. Falls back to the desktop (native) mode
+ *  when the requested resolution isn't an available fullscreen mode, so we never
+ *  fail to enter fullscreen (per Evert: detect available resolutions and only
+ *  offer those; if not gotten, fall back to native).
+ */
+static bool find_fullscreen_display_mode(int display_index, int width, int height,
+        SDL_DisplayMode *out_mode) {
+    int nmodes = SDL_GetNumDisplayModes(display_index);
+    for (int i = 0; i < nmodes; ++i) {
+        SDL_DisplayMode mode;
+        if (SDL_GetDisplayMode(display_index, i, &mode) != 0) continue;
+        if (mode.w == width && mode.h == height) {
+            *out_mode = mode;
+            return true;
+        }
+    }
+    // Not an available fullscreen mode -> fall back to the desktop (native) mode.
+    if (SDL_GetDesktopDisplayMode(display_index, out_mode) == 0) {
+        return true;
+    }
+    return false;
+}
+
+/*!
  *  Sets up the SDL OpenGL rendering context
  *  \author  jfpatry
  *  \date    Created:  2000-10-20
@@ -258,16 +283,25 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
     Uint32 video_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
     int bpp = 0; // Bits per pixel?
     int width, height;
+    // Fullscreen uses a real display mode change (SDL_WINDOW_FULLSCREEN +
+    // SDL_SetWindowDisplayMode), so the selected resolution is honored rather
+    // than always rendering at the desktop resolution (SDL_WINDOW_FULLSCREEN_DESKTOP).
+    // If the requested resolution isn't an available fullscreen mode, fall back to
+    // the native/desktop mode (see find_fullscreen_display_mode).
+    SDL_DisplayMode requested_fullscreen_mode;
+    bool have_fullscreen_mode = false;
     if (configuration().graphics.full_screen) {
-        video_flags |= SDL_WINDOW_BORDERLESS;
+        video_flags |= SDL_WINDOW_FULLSCREEN;
 
-        SDL_DisplayMode currentDisplayMode;
-        if (SDL_GetCurrentDisplayMode(screen_number, &currentDisplayMode) != 0) {
-            VS_LOG_FLUSH_EXIT(fatal, (boost::format("SDL_GetCurrentDisplayMode failed: %1%") % SDL_GetError()), -1);
-        } else {
-            native_resolution_x = currentDisplayMode.w;
-            native_resolution_y = currentDisplayMode.h;
+        // Choose the display mode: the configured resolution if available, else native.
+        have_fullscreen_mode = find_fullscreen_display_mode(screen_number,
+                configuration().graphics.resolution_x, configuration().graphics.resolution_y,
+                &requested_fullscreen_mode);
+        if (!have_fullscreen_mode) {
+            VS_LOG_FLUSH_EXIT(fatal, (boost::format("Could not find any fullscreen display mode for display %1%") % screen_number), -1);
         }
+        native_resolution_x = requested_fullscreen_mode.w;
+        native_resolution_y = requested_fullscreen_mode.h;
     } else {
         video_flags |= SDL_WINDOW_RESIZABLE;
 
@@ -357,7 +391,10 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
     }
 
     if (configuration().graphics.full_screen) {
-        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
+        if (have_fullscreen_mode) {
+            SDL_SetWindowDisplayMode(window, &requested_fullscreen_mode);
+        }
     }
 
     if (SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl")) {
@@ -368,6 +405,12 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
     }
 
     SDL_GL_GetDrawableSize(window, &width, &height);
+    // Use the measured drawable size as the render target so the viewport always
+    // matches the actual window/display mode (a mode change may resolve to the
+    // closest mode, or the window may have been clamped). This is the actual size
+    // the game renders into, regardless of the configured request.
+    native_resolution_x = width;
+    native_resolution_y = height;
 
     SDL_GLContext context = SDL_GL_CreateContext(window);
 
@@ -565,7 +608,18 @@ void winsys_apply_resolution(int width, int height, bool fullscreen) {
     }
 
     if (fullscreen) {
-        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
+        // Request a real fullscreen display mode so the selected resolution is
+        // honored (not always desktop-res). If the exact size isn't an available
+        // fullscreen mode, fall back to native. Update width/height to the mode
+        // actually used so the measurements below track the real render size.
+        SDL_DisplayMode fs_mode;
+        const int screen_number = g.screen;
+        if (find_fullscreen_display_mode(screen_number, width, height, &fs_mode)) {
+            SDL_SetWindowDisplayMode(window, &fs_mode);
+            width = fs_mode.w;
+            height = fs_mode.h;
+        }
     } else {
         SDL_SetWindowFullscreen(window, 0);
         SDL_SetWindowSize(window, width, height);

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -43,6 +43,7 @@
 #include <sstream>
 
 #include "gl_globals.h"
+#include "gl_init.h"
 #include "winsys.h"
 #include "root_generic/vs_globals.h"
 #include "root_generic/xml_support.h"
@@ -814,9 +815,11 @@ void winsys_process_events() {
                         (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
                                 (float)event.window.data1 / (float)event.window.data2;
                     }
-                    // A manual window resize must also re-bind the GL viewport to the
-                    // actual drawable size, otherwise native_resolution_x/y go stale
-                    // and the scene renders at the old size into the resized window.
+                    // A manual window resize must re-bind the GL viewport to the
+                    // actual drawable size, otherwise the scene renders at the old
+                    // size into the resized window. We re-init on every resize event
+                    // (we can't reliably know which is the last one across WMs); if
+                    // it thrashs we'll see it and can throttle.
                     {
                         int d_w = 0, d_h = 0;
                         SDL_GL_GetDrawableSize(window, &d_w, &d_h);
@@ -825,7 +828,8 @@ void winsys_process_events() {
                             native_resolution_y = d_h;
                         }
                     }
-                    //setup_sdl_video_mode(argc, argv);
+                    // Re-bind the viewport/GFX state from the new size.
+                    GFXReinitConfig();
                     if (reshape_func) {
                         (*reshape_func)(event.window.data1,
                                 event.window.data2);

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -725,6 +725,20 @@ static const Uint32 RESIZE_DEBOUNCE_MS = 100;
 // new actual window size and requests a redraw so the game re-renders at the new
 // size. This is the actual re-init; callers debounce it via the resize_request below.
 static void handle_window_resize(int new_w, int new_h) {
+    // Use the ACTUAL window size (SDL_GetWindowSize = logical points) for
+    // graphics.resolution_x/y, NOT the event data. On a scaled/HiDPI display the
+    // resize event reports the drawable pixel size, which differs from the logical
+    // window size that ImGui uses (io.DisplaySize = SDL_GetWindowSize). If we set
+    // graphics.resolution from pixels, the ImGui config overlay is sized at the
+    // pixel size but ImGui hit-tests in point space -> an "invisible cursor"
+    // offset (mouseover fires for the wrong position). Using the logical window
+    // size keeps graphics.resolution consistent with io.DisplaySize.
+    if (window != nullptr) {
+        int lw = 0, lh = 0;
+        SDL_GetWindowSize(window, &lw, &lh);
+        if (lw > 0) { new_w = lw; }
+        if (lh > 0) { new_h = lh; }
+    }
     (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = new_w;
     (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = new_h;
     if (new_h > 0) {

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -441,6 +441,11 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
 
     // Initialize imgui
     InitGui();
+    // Apply the persisted font size (config was loaded before this). Without
+    // this the ImGui UI resets to the 18.0f hardcoded default in InitGui()
+    // regardless of the saved graphics.font_point; the pending request is
+    // applied at the next frame start via ImGui_ApplyPendingFontSize().
+    RequestImGuiFontSize(configuration().graphics.font_point_flt);
 
     return true;
 }

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -55,6 +55,7 @@
 #include "libraries/gui/gui.h"
 #include "backends/imgui_impl_sdl2.h"
 #include "gui/config_screen.h"
+#include "in_kb.h"
 
 #include "SDL2/SDL_video.h"
 
@@ -580,8 +581,16 @@ void winsys_process_events() {
                     //does same thing as KEYDOWN, but with different state.
                 case SDL_KEYDOWN:
 
+                    // Global (always-active) actions fire in any context (in-flight,
+                    // docked, nav, text) -- e.g. Alt+C (ConfigKey) opens the settings
+                    // screen regardless of where the player is. Handled globally so it
+                    // is not double-fired by the context-specific dispatch below.
+                    SDL_GetMouseState(&x, &y);
+                    if (HandleGlobalKey(event.key.keysym.sym, event.key.keysym.mod, !state, x, y)) {
+                        break;
+                    }
+
                     if (keyboard_func) {
-                        SDL_GetMouseState(&x, &y);
 //                        VS_LOG(debug, (boost::format("Kbd: %1$s mod:%2$x sym:%3$x scan:%4$x")
 //                                       % ((event.type == SDL_KEYUP) ? "KEYUP" : "KEYDOWN")
 //                                       % event.key.keysym.mod

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -53,6 +53,8 @@
 #include "src/vs_exit.h"
 #include "configuration/configuration.h"
 #include "libraries/gui/gui.h"
+#include "backends/imgui_impl_sdl2.h"
+#include "config_screen.h"
 
 #include "SDL2/SDL_video.h"
 
@@ -503,6 +505,38 @@ void winsys_show_cursor(bool visible) {
     }
 }
 
+// Apply a new resolution/fullscreen to the live window (from the in-game config
+// screen). Sets configuration(), then applies windowed/fullscreen + size via
+// SDL2, and forces the reshape so the viewport/measurements update immediately.
+void winsys_apply_resolution(int width, int height, bool fullscreen) {
+    auto &g = const_cast<vega_config::Configuration &>(configuration()).graphics;
+    g.resolution_x = width;
+    g.resolution_y = height;
+    g.full_screen = fullscreen;
+
+    if (window == nullptr) {
+        return;
+    }
+
+    if (fullscreen) {
+        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        native_resolution_x = width;
+        native_resolution_y = height;
+    } else {
+        SDL_SetWindowFullscreen(window, 0);
+        SDL_SetWindowSize(window, width, height);
+        native_resolution_x = width;
+        native_resolution_y = height;
+    }
+
+    // Force the reshape so native_resolution_x/y and the GL viewport update; in
+    // windowed this normally fires via SDL_WINDOWEVENT_RESIZED, but fullscreen
+    // mode changes may not, so apply it directly here.
+    if (reshape_func) {
+        (*reshape_func)(native_resolution_x, native_resolution_y);
+    }
+}
+
 /*---------------------------------------------------------------------------*/
 /*!
  *  Processes and dispatches events.  This function never returns.
@@ -532,6 +566,12 @@ void winsys_process_events() {
         SDL_LockAudio();
         SDL_UnlockAudio();
         while (SDL_PollEvent(&event)) {
+            // forward all events to ImGui (drives the config screen, and any
+            // other ImGui UI) without altering the game's own dispatch below.
+            ImGui_ImplSDL2_ProcessEvent(&event);
+            // Forward to the config screen (binding capture, joystick hotplug)
+            // while it is open.
+            vs_settings_ng::HandleConfigEvent(&event);
 
             state = false;
             switch (event.type) {

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -76,6 +76,7 @@
  */
 
 static SDL_Window *window = nullptr;
+static SDL_Renderer *renderer = nullptr;   // created at bootstrap; reused to re-issue logical size on resize
 static SDL_Surface *screen = nullptr;
 
 static winsys_display_func_t display_func = nullptr;
@@ -383,7 +384,7 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
         VS_LOG_FLUSH_EXIT(fatal, "Failed to make window context current", 1);
     }
 
-    SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
     if (renderer == nullptr) {
         VS_LOG_AND_FLUSH(error, (boost::format(
             "SDL_CreateRenderer(...) with VSync option failed; trying again without VSync option. Error was: %1%") %
@@ -555,23 +556,58 @@ void winsys_show_cursor(bool visible) {
 // SDL2, and forces the reshape so the viewport/measurements update immediately.
 void winsys_apply_resolution(int width, int height, bool fullscreen) {
     auto &g = const_cast<vega_config::Configuration &>(configuration()).graphics;
-    g.resolution_x = width;
-    g.resolution_y = height;
     g.full_screen = fullscreen;
 
     if (window == nullptr) {
+        g.resolution_x = width;
+        g.resolution_y = height;
         return;
     }
 
     if (fullscreen) {
         SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-        native_resolution_x = width;
-        native_resolution_y = height;
     } else {
         SDL_SetWindowFullscreen(window, 0);
         SDL_SetWindowSize(window, width, height);
-        native_resolution_x = width;
-        native_resolution_y = height;
+    }
+
+    // Measure the ACTUAL window size after the resize. In windowed mode the WM /
+    // compositor may clamp a requested size down to fit the screen, and on a
+    // HiDPI/Wayland display the logical window size (points) differs from the GL
+    // drawable size (pixels). Using the measured sizes (rather than the requested
+    // width/height) keeps the scene viewport, ImGui overlay, and config write-out
+    // all consistent with the real window. The GL drawable size is what the legacy
+    // viewport must map to; the logical window size is what ImGui
+    // (io.DisplaySize = SDL_GetWindowSize) and the config screen use.
+    int logical_w = 0, logical_h = 0;
+    SDL_GetWindowSize(window, &logical_w, &logical_h);
+    int drawable_w = 0, drawable_h = 0;
+    SDL_GL_GetDrawableSize(window, &drawable_w, &drawable_h);
+    if (logical_w <= 0) { logical_w = width; }
+    if (logical_h <= 0) { logical_h = height; }
+    if (drawable_w <= 0) { drawable_w = logical_w; }
+    if (drawable_h <= 0) { drawable_h = logical_h; }
+
+    // In fullscreen, the legacy GL viewport should fill the whole drawable. In
+    // windowed on a scaled display the drawable is the pixel size; the legacy GL
+    // scene must render into it. The config/graphics resolution (used by ImGui and
+    // the config screen) is the logical window size.
+    native_resolution_x = drawable_w;
+    native_resolution_y = drawable_h;
+    g.resolution_x = logical_w;
+    g.resolution_y = logical_h;
+
+    // Re-issue the renderer logical size (bound once at bootstrap). Present is via
+    // SDL_GL_SwapWindow, so this mainly keeps SDL_GetRenderOutputSize consistent
+    // for anything that reads it.
+    if (renderer != nullptr) {
+        SDL_RenderSetLogicalSize(renderer, drawable_w, drawable_h);
+    }
+
+    // Recompute the screen aspect from the actual resolution so the in-game
+    // camera/cockpit viewport isn't distorted after a live change.
+    if (g.resolution_y > 0) {
+        g.aspect_flt = (float)g.resolution_x / (float)g.resolution_y;
     }
 
     // Force the reshape so native_resolution_x/y and the GL viewport update; in

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -713,6 +713,36 @@ void winsys_apply_resolution(int width, int height, bool fullscreen) {
 extern int shiftdown(int);
 extern int shiftup(int);
 
+// Handle a window size change (resize or size-changed). Re-binds the game to the
+// new actual window size and requests a redraw so the game re-renders at the new
+// size. Called for both SDL_WINDOWEVENT_RESIZED and SDL_WINDOWEVENT_SIZE_CHANGED;
+// we re-init on every one (can't reliably know which is last across WMs).
+static void handle_window_resize(int new_w, int new_h) {
+    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = new_w;
+    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = new_h;
+    if (new_h > 0) {
+        (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
+                (float)new_w / (float)new_h;
+    }
+    // Re-bind the GL viewport to the actual drawable size, so the scene renders at
+    // the new size rather than the old.
+    if (window != nullptr) {
+        int d_w = 0, d_h = 0;
+        SDL_GL_GetDrawableSize(window, &d_w, &d_h);
+        if (d_w > 0 && d_h > 0) {
+            native_resolution_x = d_w;
+            native_resolution_y = d_h;
+        }
+    }
+    GFXReinitConfig();
+    if (reshape_func) {
+        (*reshape_func)(new_w, new_h);
+    }
+    // A resize must trigger a redraw (the event loop only redraws on redisplay,
+    // otherwise it relies on idle_func which can be paused, e.g. in the overlay).
+    redisplay = true;
+}
+
 void winsys_process_events() {
     SDL_Event event;
     int x, y;
@@ -816,32 +846,14 @@ void winsys_process_events() {
 
                 case SDL_WINDOWEVENT_RESIZED:
 #if !(defined (_WIN32) && defined (SDL_WINDOWING ))
-                    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = event.window.data1;
-                    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = event.window.data2;
-                    if (event.window.data2 > 0) {
-                        (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
-                                (float)event.window.data1 / (float)event.window.data2;
-                    }
-                    // A manual window resize must re-bind the GL viewport to the
-                    // actual drawable size, otherwise the scene renders at the old
-                    // size into the resized window. We re-init on every resize event
-                    // (we can't reliably know which is the last one across WMs); if
-                    // it thrashs we'll see it and can throttle.
-                    {
-                        int d_w = 0, d_h = 0;
-                        SDL_GL_GetDrawableSize(window, &d_w, &d_h);
-                        if (d_w > 0 && d_h > 0) {
-                            native_resolution_x = d_w;
-                            native_resolution_y = d_h;
-                        }
-                    }
-                    // Re-bind the viewport/GFX state from the new size.
-                    GFXReinitConfig();
-                    if (reshape_func) {
-                        (*reshape_func)(event.window.data1,
-                                event.window.data2);
-                    }
+                    handle_window_resize(event.window.data1, event.window.data2);
 #endif
+                    break;
+
+                case SDL_WINDOWEVENT_SIZE_CHANGED:
+                    // A size change (e.g. during a live drag, or from an API call)
+                    // must also re-bind + redraw, same as a completed resize.
+                    handle_window_resize(event.window.data1, event.window.data2);
                     break;
 
                 case SDL_JOYDEVICEADDED:

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -314,7 +314,7 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
     int rs, gs, bs;
     rs = gs = bs = (bpp == 16) ? 5 : 8;
     if (configuration().graphics.rgb_pixel_format == "undefined") {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.rgb_pixel_format = ((bpp == 16) ? "555" : "888");
+        (configuration()).graphics.rgb_pixel_format = ((bpp == 16) ? "555" : "888");
     }
     if ((configuration().graphics.rgb_pixel_format.length() == 3) && isdigit(configuration().graphics.rgb_pixel_format[0])
             && isdigit(configuration().graphics.rgb_pixel_format[1]) && isdigit(configuration().graphics.rgb_pixel_format[2])) {
@@ -431,11 +431,11 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
     if (drawable_h <= 0) { drawable_h = logical_h; }
     native_resolution_x = drawable_w;
     native_resolution_y = drawable_h;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = logical_w;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = logical_h;
+    (configuration()).graphics.resolution_x = logical_w;
+    (configuration()).graphics.resolution_y = logical_h;
     // Keep the screen aspect consistent with the actual window resolution.
     if (logical_h > 0) {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
+        (configuration()).graphics.aspect_flt =
                 (float)logical_w / (float)logical_h;
     }
 
@@ -495,7 +495,7 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
             SDL_ClearError();
             freeMouseCursors();
             SDL_Quit();
-            (const_cast<vega_config::Configuration &>(configuration())).graphics.gl_accelerated_visual = false;
+            (configuration()).graphics.gl_accelerated_visual = false;
             return false;
         } else {
             VS_LOG(error, "GDI Generic software driver reported, reset failed.");
@@ -625,7 +625,7 @@ void winsys_show_cursor(bool visible) {
 // screen). Sets configuration(), then applies windowed/fullscreen + size via
 // SDL2, and forces the reshape so the viewport/measurements update immediately.
 void winsys_apply_resolution(int width, int height, bool fullscreen) {
-    auto &g = const_cast<vega_config::Configuration &>(configuration()).graphics;
+    auto &g = configuration().graphics;
     g.full_screen = fullscreen;
 
     if (window == nullptr) {
@@ -739,10 +739,10 @@ static void handle_window_resize(int new_w, int new_h) {
         if (lw > 0) { new_w = lw; }
         if (lh > 0) { new_h = lh; }
     }
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = new_w;
-    (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = new_h;
+    (configuration()).graphics.resolution_x = new_w;
+    (configuration()).graphics.resolution_y = new_h;
     if (new_h > 0) {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.aspect_flt =
+        (configuration()).graphics.aspect_flt =
                 (float)new_w / (float)new_h;
     }
     // Re-bind the GL viewport to the actual drawable size, so the scene renders at

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -376,6 +376,13 @@ static bool setup_sdl_video_mode(int *argc, char **argv) {
         VS_LOG_FLUSH_EXIT(fatal, "No window", 1);
     }
 
+    // Always mark the window resizable (SDL_SetWindowResizable works dynamically,
+    // independent of the creation flags). On a fullscreen launch the window was
+    // created without SDL_WINDOW_RESIZABLE, so switching to windowed would lose
+    // the resize handles/maximize button. Setting it explicitly here ensures a
+    // windowed resize is possible whether we started fullscreen or windowed.
+    SDL_SetWindowResizable(window, SDL_TRUE);
+
     if(screen_number > 0) {
         // Get bounds of the secondary monitor
         SDL_Rect displayBounds;

--- a/engine/src/gldrv/winsys.cpp
+++ b/engine/src/gldrv/winsys.cpp
@@ -56,6 +56,7 @@
 #include "backends/imgui_impl_sdl2.h"
 #include "gui/config_screen.h"
 #include "in_kb.h"
+#include "in_joystick.h"
 
 #include "SDL2/SDL_video.h"
 
@@ -155,6 +156,31 @@ void winsys_set_config_overlay_active(bool active) {
 
 bool winsys_config_overlay_active() {
     return config_overlay_active;
+}
+
+// Re-attach joysticks when a device is hotplugged (SDL_JOYDEVICEADDED). We use
+// fake-present slots set up at startup (bindings are bound there), so a new
+// device is Attach()ed to the first free physical slot without re-binding
+// (which would cause input inconsistency). On removal the slot just stays; the
+// device detaches. bindings stay valid because they are keyed by slot index.
+static void winsys_refresh_joysticks() {
+    int n = SDL_NumJoysticks();
+    if (n > MAX_JOYSTICKS) {
+        n = MAX_JOYSTICKS;
+    }
+    // Attach each present device index to the matching free physical slot.
+    for (int dev = 0; dev < n; ++dev) {
+        for (int i = 0; i < MAX_JOYSTICKS; ++i) {
+            if (i == MOUSE_JOYSTICK) {
+                continue;
+            }
+            if (joystick[i] != nullptr && joystick[i]->joy == nullptr) {
+                joystick[i]->Attach(dev);
+                VS_LOG(important_info, (boost::format("[hotplug] attached device %1% to slot %2%") % dev % i));
+                break;
+            }
+        }
+    }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -676,6 +702,17 @@ void winsys_process_events() {
                                 event.window.data2);
                     }
 #endif
+                    break;
+
+                case SDL_JOYDEVICEADDED:
+                    // A joystick appeared: attach the new device to a free slot
+                    // (no re-bind — bindings are set at startup).
+                    winsys_refresh_joysticks();
+                    break;
+
+                case SDL_JOYDEVICEREMOVED:
+                    // Joystick removed: the fake slot stays; the device simply
+                    // detaches. Nothing to re-init.
                     break;
 
                 case SDL_QUIT:

--- a/engine/src/gldrv/winsys.h
+++ b/engine/src/gldrv/winsys.h
@@ -339,6 +339,7 @@ void winsys_set_passive_motion_func(winsys_motion_func_t func);
 void winsys_swap_buffers();
 void winsys_warp_pointer(int x, int y);
 void winsys_show_cursor(bool visible);
+void winsys_apply_resolution(int width, int height, bool fullscreen);
 
 void winsys_init(int *argc, char **argv, char const *window_title,
         char const *icon_title);

--- a/engine/src/gldrv/winsys.h
+++ b/engine/src/gldrv/winsys.h
@@ -340,6 +340,8 @@ void winsys_swap_buffers();
 void winsys_warp_pointer(int x, int y);
 void winsys_show_cursor(bool visible);
 void winsys_apply_resolution(int width, int height, bool fullscreen);
+void winsys_set_config_overlay_active(bool active);
+bool winsys_config_overlay_active();
 
 void winsys_init(int *argc, char **argv, char const *window_title,
         char const *icon_title);

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -1624,6 +1624,8 @@ static void draw_presets_frame() {
 } // namespace
 
 void DrawConfigScreen() {
+    static bool s_debug_once = false;
+    if (!s_debug_once) { fprintf(stderr, "[config-screen debug] DrawConfigScreen CALLED (overlay rendering)\n"); fflush(stderr); s_debug_once = true; }
     // Load flight-control mode from the persisted input.device once.
     static bool s_loaded = false;
     if (!s_loaded) {

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -205,7 +205,7 @@ static bool highest_monitor_resolution(int id, int &w, int &h) {
 // ---------------------------------------------------------------------------
 
 static vega_config::Configuration &cfg() {
-    return const_cast<vega_config::Configuration &>(configuration());
+    return configuration();
 }
 
 // Load the display-frame state from Configuration (on first open).

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -1695,11 +1695,13 @@ void DrawConfigScreen() {
     }
     if (ImGui::Button("Save", ImVec2(btnw, 0))) {
         if (dirty) {
+            // Detect a shader change BEFORE write_out_dirty() clears g_dirty_paths.
+            // Shaders are NOT hot-applied (unreliable live); persist the change and
+            // tell the user a restart is required.
+            const bool shader_changed = shader_config_dirty();
             apply_all();
             write_out_dirty();   // persist the dirty paths to the user overlay
-            // If a shader config path changed, we DON'T hot-apply it (unreliable
-            // live); tell the user a restart is required. The change is persisted.
-            if (shader_config_dirty()) {
+            if (shader_changed) {
                 shader_restart_notice = true;
             }
             // Re-initialize the runtime from the updated in-memory configuration().

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -73,6 +73,10 @@ static boost::json::value read_config_value(const std::string &path);
 static bool bind_dialog_open = false;
 static bool bind_capturing = false;
 static int  bind_rebind_row = -1;
+
+// Set on Save when a shader config path changed; shows a "restart required"
+// notice (shaders are written out but not hot-applied).
+static bool shader_restart_notice = false;
 static std::string bind_capture_cmd;
 
 enum { FONT_AA_VEC = 0, FONT_VEC, FONT_HELVETICA, FONT_TIMES, FONT_FIXED };
@@ -113,6 +117,20 @@ static std::set<std::string> g_dirty_paths;
 static void mark_dirty(const std::string &path) {
     dirty = true;
     g_dirty_paths.insert(path);
+}
+
+// Shader-related config paths (set by the "shaders" preset). Shaders are NOT
+// hot-applied; a change requires a restart. Flagged on Save so we can tell the
+// user rather than silently applying (or silently skipping) the change.
+static bool shader_config_dirty() {
+    static const char *shader_paths[] = {
+        "graphics.technique_set", "graphics.mac_shader_name",
+        "graphics.default_full_technique", "graphics.default_simple_technique"
+    };
+    for (const char *p : shader_paths) {
+        if (g_dirty_paths.count(p)) return true;
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -660,9 +678,10 @@ static void reinit_from_saved_config() {
     // Graphics: g_game feature flags + gl_options + GL viewport (reuses initfov
     // and reapply_gl_options, the same copy code as bootstrap).
     GFXReinitConfig();
-    // Shader: re-read the configured shader name and recompile (a stale
-    // hifiProgramName otherwise yields funky colors until restart).
-    GFXApplyShaderSetting();
+    // NOTE: shaders are intentionally NOT hot-applied here. A shader change hits
+    // the OS/driver shader cache and other technique state that can't be safely
+    // reloaded live (it produced funky colors). Shader changes are written out
+    // and require a restart; the Save handler shows a dialog for this.
     // Audio/volume: re-apply the live volume functions from the new config.
     AUDReapplyConfig();
     Music::SetVolume(configuration().audio.music_volume_flt, -1, false);
@@ -1678,6 +1697,11 @@ void DrawConfigScreen() {
         if (dirty) {
             apply_all();
             write_out_dirty();   // persist the dirty paths to the user overlay
+            // If a shader config path changed, we DON'T hot-apply it (unreliable
+            // live); tell the user a restart is required. The change is persisted.
+            if (shader_config_dirty()) {
+                shader_restart_notice = true;
+            }
             // Re-initialize the runtime from the updated in-memory configuration().
             // The game assumed config never changes in-game, so config->runtime
             // copies (g_game feature flags, gl_options, GL viewport, legacy font
@@ -1712,6 +1736,21 @@ void DrawConfigScreen() {
     // Bindings dialog (modal on top).
     if (bind_dialog_open) ImGui::OpenPopup("Bindings");
     draw_bindings_dialog();
+
+    // Shader-change notice (modal on top). Shaders are written out but not
+    // hot-applied; tell the user a restart is required. Dismissed on OK.
+    if (shader_restart_notice) {
+        ImGui::OpenPopup("Shader Change");
+    }
+    if (ImGui::BeginPopupModal("Shader Change", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::TextUnformatted("Shader changes take effect after a restart.");
+        ImGui::TextUnformatted("The new settings were saved. Restart the game to apply them.");
+        if (ImGui::Button("OK", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+            shader_restart_notice = false;
+        }
+        ImGui::EndPopup();
+    }
 
     ImGui::End();
     ImGui::PopStyleColor();

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -131,10 +131,14 @@ static void refresh_screen_aspect_text() {
     }
 }
 
-// The ideal font height (font_point) for the current resolution. Font size scales
-// with the horizontal resolution: ~10 at 800x600, ~32 at 2560x1440 (width / 80).
+// The ideal font height (font_point) for the current resolution. Linear scale:
+// 8 at 800x600, 16 at 1920x1080, scaling linearly across all other resolutions.
+// formula: 8 + (width - 800) / 140, rounded to the nearest integer.
 static int ideal_font_height() {
-    return sel_res_w > 0 ? sel_res_w / 80 : 16;
+    if (sel_res_w <= 0) return 16;
+    // Round to nearest integer (ideal is always positive, so +0.5 truncates to nearest).
+    float ideal = 8.0f + (float)(sel_res_w - 800) / 140.0f;
+    return (int)(ideal + 0.5f);
 }
 
 static void prefill_text_height() {

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -1635,10 +1635,13 @@ void DrawConfigScreen() {
         if (flight_control == FC_MOUSE) load_mouse_staging();
         else if (flight_control == FC_JOYSTICK) load_joystick_staging();
     }
-    // Cover the whole screen (game resolution), not a floating window.
+    // Cover the whole screen (game resolution), not a floating window. The
+    // default ImGui WindowBg is only ~0.94 alpha, so the game/HUD shows through;
+    // push a fully-opaque WindowBg so the config screen hides it entirely.
     ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
     ImGui::SetNextWindowSize(ImVec2(configuration().graphics.resolution_x,
                                     configuration().graphics.resolution_y), ImGuiCond_Always);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.06f, 0.06f, 0.08f, 1.0f));
     ImGui::Begin("Config", nullptr,
                  ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
                  ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoCollapse);
@@ -1733,6 +1736,7 @@ void DrawConfigScreen() {
     draw_bindings_dialog();
 
     ImGui::End();
+    ImGui::PopStyleColor();
 }
 
 void HandleConfigEvent(const SDL_Event *event) {

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -1624,8 +1624,6 @@ static void draw_presets_frame() {
 } // namespace
 
 void DrawConfigScreen() {
-    static bool s_debug_once = false;
-    if (!s_debug_once) { fprintf(stderr, "[config-screen debug] DrawConfigScreen CALLED (overlay rendering)\n"); fflush(stderr); s_debug_once = true; }
     // Load flight-control mode from the persisted input.device once.
     static bool s_loaded = false;
     if (!s_loaded) {

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -50,8 +50,6 @@ std::string monitor_text, resolution_text;
 char text_height_buf[16] = "16";
 static const char *aspect_opts[] = { "16:10 (1.6)", "16:9 (1.78)", "4:3 (1.33)", "5:4 (1.25)", "1:1 (1.0)" };
 static const float aspect_vals[] = { 1.6f, 16.0f / 9.0f, 4.0f / 3.0f, 1.25f, 1.0f };
-int  sel_base_aspect = 0;      // aspect_opts[0] = 16:10 (default base aspect)
-std::string base_aspect_text = aspect_opts[0];
 int  sel_screen_aspect = -1;      // -1 = auto (W/H)
 std::string screen_aspect_text;
 bool display_inited = false;
@@ -178,35 +176,6 @@ static bool highest_monitor_resolution(int id, int &w, int &h) {
     return true;
 }
 
-// The base-computer viewport (base_max_width/height) from the base aspect ratio.
-static void compute_base_max(int &w, int &h) {
-    w = h = 0;
-    if (sel_res_w <= 0 || sel_res_h <= 0) return;
-    float A = aspect_vals[sel_base_aspect];
-    if (A >= (float)sel_res_w / sel_res_h) { w = sel_res_w; h = (int)(sel_res_w / A); }
-    else { h = sel_res_h; w = (int)(sel_res_h * A); }
-}
-
-// Derive sel_base_aspect from the stored base viewport (bases.max_width/height)
-// so reopening the screen reflects the saved base aspect (default 16:10).
-static void load_base_aspect_from_config() {
-    const auto &g = configuration().graphics;
-    int bw = g.bases.max_width;
-    int bh = g.bases.max_height;
-    sel_base_aspect = 0;      // default = aspect_opts[0] (16:10)
-    if (bw > 0 && bh > 0) {
-        float ratio = (float)bw / (float)bh;
-        int best = 0;
-        float best_d = fabsf(ratio - aspect_vals[0]);
-        for (size_t i = 1; i < sizeof(aspect_vals) / sizeof(aspect_vals[0]); ++i) {
-            float d = fabsf(ratio - aspect_vals[i]);
-            if (d < best_d) { best_d = d; best = (int)i; }
-        }
-        sel_base_aspect = best;
-    }
-    base_aspect_text = aspect_opts[sel_base_aspect];
-}
-
 // ---------------------------------------------------------------------------
 // Configuration read/write (the vs-05 model_set_var/get_var, mapped to the
 // engine's Configuration struct).
@@ -237,7 +206,6 @@ static void load_display_from_config() {
     if (!g.high_quality_font && g.font_antialias) sel_font_type = FONT_AA_VEC;
     else if (!g.high_quality_font && !g.font_antialias) sel_font_type = FONT_VEC;
     else sel_font_type = FONT_HELVETICA;   // bitmap (font name will refine; v1 defaults)
-    load_base_aspect_from_config();
     refresh_screen_aspect_text();
     resolution_text = std::to_string(sel_res_w) + "x" + std::to_string(sel_res_h);
     display_inited = true;
@@ -288,19 +256,6 @@ static void apply_display_to_config() {
     mark_dirty("graphics.aspect");
     g.draw_rendered_crosshairs = rendered_crosshair;
     mark_dirty("graphics.draw_rendered_crosshairs");
-    // Base viewport (graphics.bases.max_width/height) from the base aspect ratio.
-    // compute_base_max() yields the largest viewport of the chosen aspect that fits
-    // the selected resolution; the imgui bases render into this letterboxed viewport.
-    {
-        int bw = 0, bh = 0;
-        compute_base_max(bw, bh);
-        if (bw > 0 && bh > 0) {
-            g.bases.max_width = bw;
-            g.bases.max_height = bh;
-            mark_dirty("graphics.bases.max_width");
-            mark_dirty("graphics.bases.max_height");
-        }
-    }
     // screen (monitor) index.
     g.screen = sel_monitor;
     mark_dirty("graphics.screen");
@@ -407,14 +362,6 @@ void draw_display_frame() {
             }
             ImGui::EndPopup();
         }
-    }
-    // Base aspect ratio.
-    if (ImGui::Button("Base Aspect Ratio")) ImGui::OpenPopup("##pick_asp");
-    ImGui::SameLine(); ImGui::TextUnformatted(base_aspect_text.c_str());
-    if (ImGui::BeginPopup("##pick_asp")) {
-        for (size_t i = 0; i < sizeof(aspect_opts) / sizeof(aspect_opts[0]); ++i)
-            if (ImGui::MenuItem(aspect_opts[i])) { sel_base_aspect = (int)i; base_aspect_text = aspect_opts[i]; dirty = true; }
-        ImGui::EndPopup();
     }
     ImGui::EndChild();   // end dpyframe (left column)
 

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -1,0 +1,1754 @@
+// config_screen.cpp — in-game configuration screen for vs-settings-ng.
+//
+// Port of the vs-05 modern UI frames into the engine, reading/writing the
+// engine's Configuration object directly. Drawn inside the in-game ImGui
+// overlay (Alt+C -> DrawConfigOverlay -> this).
+//
+// Scope: this iteration focuses on the editing frames. Applying changes live to
+// the running game (e.g. changing resolution) and writing back to config files
+// are deferred until the config write-out work.
+
+#include "config_screen.h"
+
+#include "configuration/configuration.h"
+#include "gldrv/winsys.h"
+#include "universe.h"
+#include "vegadisk/vsfilesystem.h"
+#include "root_generic/vs_globals.h"
+#include "config_xml.h"
+#include <boost/json.hpp>
+#include <boost/filesystem.hpp>
+#include <imgui.h>
+#include "libraries/gui/gui.h"
+#include <SDL3/SDL.h>
+#include <algorithm>
+#include <vector>
+#include <string>
+#include <map>
+#include <set>
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+namespace fs = boost::filesystem;
+
+namespace vs_settings_ng {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Display frame state (mirrors vs-05 modern_ui.cpp)
+// ---------------------------------------------------------------------------
+int  sel_monitor = 0;
+SDL_DisplayID sel_display_id = 0;
+int  sel_res_w = 0, sel_res_h = 0;
+std::string monitor_text, resolution_text;
+char text_height_buf[16] = "16";
+static const char *aspect_opts[] = { "16:10 (1.6)", "16:9 (1.78)", "4:3 (1.33)", "5:4 (1.25)", "1:1 (1.0)" };
+static const float aspect_vals[] = { 1.6f, 16.0f / 9.0f, 4.0f / 3.0f, 1.25f, 1.0f };
+int  sel_base_aspect = 0;      // aspect_opts[0] = 16:10 (default base aspect)
+std::string base_aspect_text = aspect_opts[0];
+int  sel_screen_aspect = -1;      // -1 = auto (W/H)
+std::string screen_aspect_text;
+bool display_inited = false;
+
+bool rendered_crosshair = true;
+bool cfg_full_screen = true;
+
+// Mouse / Joystick dialog open flags.
+static bool mouse_dialog_open = false;
+static bool joy_dialog_open = false;
+
+// Forward declarations (defined below; used by draw_display_frame).
+static void load_mouse_staging();
+static void load_joystick_staging();
+static void load_bindings_staging();
+static void draw_bindings_dialog();
+static void handle_bindings_event(const SDL_Event *event);
+static boost::json::value read_config_value(const std::string &path);
+
+// Bindings dialog state (declared here so draw_display_frame can open it).
+static bool bind_dialog_open = false;
+static bool bind_capturing = false;
+static int  bind_rebind_row = -1;
+static std::string bind_capture_cmd;
+
+enum { FONT_AA_VEC = 0, FONT_VEC, FONT_HELVETICA, FONT_TIMES, FONT_FIXED };
+static const char *font_type_names[] = { "Antialiased Vector", "Vector", "Helvetica", "Times", "Fixed" };
+int  sel_font_type = FONT_AA_VEC;
+int  sel_bitmap_size[3] = { -1, -1, -1 };   // 0=Helvetica 1=Times 2=Fixed
+
+enum { FC_KEYBOARD = 0, FC_MOUSE = 1, FC_JOYSTICK = 2 };
+int  flight_control = FC_KEYBOARD;
+static const char *fc_names[] = { "Keyboard", "Mouse", "Joystick" };
+
+struct BitmapFamily {
+    const char *name;
+    int  n;
+    const char **size_names;
+    const int *px;
+};
+static const char *helv_sizes[] = { "10", "12", "18" };
+static const int   helv_px[]    = { 14, 16, 23 };
+static const char *times_sizes[] = { "10", "24" };
+static const int   times_px[]   = { 14, 29 };
+static const char *fixed_sizes[] = { "8x13", "9x15" };
+static const int   fixed_px[]   = { 14, 16 };
+static const BitmapFamily bitmap_families[] = {
+    { "Helvetica", 3, helv_sizes, helv_px },
+    { "Times", 2, times_sizes, times_px },
+    { "Fixed", 2, fixed_sizes, fixed_px },
+};
+
+bool dirty = false;
+
+// The set of config paths changed (dirty). Populated by the apply_*_to_config
+// functions on Save; consumed by write_out_dirty() (the single write-out entry
+// point, deferred to Layer 3) so it knows exactly what to persist.
+static std::set<std::string> g_dirty_paths;
+
+// Record a changed config path and mark the config dirty.
+static void mark_dirty(const std::string &path) {
+    dirty = true;
+    g_dirty_paths.insert(path);
+}
+
+// ---------------------------------------------------------------------------
+// Display-frame helpers (from vs-05)
+// ---------------------------------------------------------------------------
+
+static float current_screen_aspect() {
+    return sel_res_h > 0 ? (float)sel_res_w / sel_res_h : 0.0f;
+}
+
+static void refresh_screen_aspect_text() {
+    if (sel_screen_aspect >= 0) screen_aspect_text = aspect_opts[sel_screen_aspect];
+    else {
+        char b[24]; snprintf(b, sizeof(b), "Auto (%.2f)", current_screen_aspect());
+        screen_aspect_text = b;
+    }
+}
+
+// The ideal font height (font_point) for the current resolution. Font size scales
+// with the horizontal resolution: ~10 at 800x600, ~32 at 2560x1440 (width / 80).
+static int ideal_font_height() {
+    return sel_res_w > 0 ? sel_res_w / 80 : 16;
+}
+
+static void prefill_text_height() {
+    if (sel_res_h > 0) {
+        int fp = ideal_font_height();
+        snprintf(text_height_buf, sizeof(text_height_buf), "%d", fp);
+    }
+}
+
+// Suggest the bitmap size (index) nearest the ideal vector height.
+static int suggested_bitmap_size(int family) {
+    const BitmapFamily &f = bitmap_families[family];
+    int ideal = ideal_font_height();
+    int best = 0, bestdiff = 1000000;
+    for (int i = 0; i < f.n; i++) {
+        int d = f.px[i] < ideal ? ideal - f.px[i] : f.px[i] - ideal;
+        if (d < bestdiff) { bestdiff = d; best = i; }
+    }
+    return best;
+}
+
+static bool highest_monitor_resolution(SDL_DisplayID id, int &w, int &h) {
+    int cnt = 0;
+    SDL_DisplayMode **modes = SDL_GetFullscreenDisplayModes(id, &cnt);
+    if (!modes || cnt == 0) {
+        const SDL_DisplayMode *cm = SDL_GetCurrentDisplayMode(id);
+        if (cm) { w = cm->w; h = cm->h; return true; }
+        return false;
+    }
+    int best_i = 0, best_area = -1;
+    for (int i = 0; i < cnt; i++) {
+        int area = modes[i]->w * modes[i]->h;
+        if (area > best_area) { best_area = area; best_i = i; }
+    }
+    w = modes[best_i]->w; h = modes[best_i]->h;
+    return true;
+}
+
+// The base-computer viewport (base_max_width/height) from the base aspect ratio.
+static void compute_base_max(int &w, int &h) {
+    w = h = 0;
+    if (sel_res_w <= 0 || sel_res_h <= 0) return;
+    float A = aspect_vals[sel_base_aspect];
+    if (A >= (float)sel_res_w / sel_res_h) { w = sel_res_w; h = (int)(sel_res_w / A); }
+    else { h = sel_res_h; w = (int)(sel_res_h * A); }
+}
+
+// Derive sel_base_aspect from the stored base viewport (bases.max_width/height)
+// so reopening the screen reflects the saved base aspect (default 16:10).
+static void load_base_aspect_from_config() {
+    const auto &g = configuration().graphics;
+    int bw = g.bases.max_width;
+    int bh = g.bases.max_height;
+    sel_base_aspect = 0;      // default = aspect_opts[0] (16:10)
+    if (bw > 0 && bh > 0) {
+        float ratio = (float)bw / (float)bh;
+        int best = 0;
+        float best_d = fabsf(ratio - aspect_vals[0]);
+        for (size_t i = 1; i < sizeof(aspect_vals) / sizeof(aspect_vals[0]); ++i) {
+            float d = fabsf(ratio - aspect_vals[i]);
+            if (d < best_d) { best_d = d; best = (int)i; }
+        }
+        sel_base_aspect = best;
+    }
+    base_aspect_text = aspect_opts[sel_base_aspect];
+}
+
+// ---------------------------------------------------------------------------
+// Configuration read/write (the vs-05 model_set_var/get_var, mapped to the
+// engine's Configuration struct).
+// ---------------------------------------------------------------------------
+
+static vega_config::Configuration &cfg() {
+    return const_cast<vega_config::Configuration &>(configuration());
+}
+
+// Load the display-frame state from Configuration (on first open).
+static void load_display_from_config() {
+    const auto &g = configuration().graphics;
+    sel_res_w = g.resolution_x;
+    sel_res_h = g.resolution_y;
+    rendered_crosshair = g.draw_rendered_crosshairs;
+    cfg_full_screen = g.full_screen;
+    int fp = (int)g.font_point_flt;
+    snprintf(text_height_buf, sizeof(text_height_buf), "%d", fp);
+    // screen (monitor) index.
+    sel_monitor = g.screen;
+    int nd = 0; SDL_DisplayID *ids = SDL_GetDisplays(&nd);
+    if (nd < 1) nd = 1;
+    if (sel_monitor >= nd) sel_monitor = 0;
+    sel_display_id = ids ? ids[sel_monitor] : 0;
+    const char *nm = sel_display_id ? SDL_GetDisplayName(sel_display_id) : NULL;
+    monitor_text = std::to_string(sel_monitor) + "  " + (nm ? nm : "(unnamed)");
+    if (ids) SDL_free(ids);
+    // Font type from high_quality_font + font_antialias (vector AA / vector / bitmap).
+    if (!g.high_quality_font && g.font_antialias) sel_font_type = FONT_AA_VEC;
+    else if (!g.high_quality_font && !g.font_antialias) sel_font_type = FONT_VEC;
+    else sel_font_type = FONT_HELVETICA;   // bitmap (font name will refine; v1 defaults)
+    load_base_aspect_from_config();
+    refresh_screen_aspect_text();
+    resolution_text = std::to_string(sel_res_w) + "x" + std::to_string(sel_res_h);
+    display_inited = true;
+}
+
+// Apply the display-frame state back to Configuration (Save).
+static void apply_display_to_config() {
+    auto &g = cfg().graphics;
+    // Apply the resolution/fullscreen live to the running game (reuses the
+    // windowed-mode resize cascade: SetWindowSize -> WINDOW_RESIZED ->
+    // get_screen_measurements + Reshape). Respects the current windowed/fullscreen
+    // choice.
+    winsys_apply_resolution(sel_res_w, sel_res_h, cfg_full_screen);
+    mark_dirty("graphics.resolution_x");
+    mark_dirty("graphics.resolution_y");
+    mark_dirty("graphics.full_screen");
+    g.font_point_flt = (float)atoi(text_height_buf);
+    mark_dirty("graphics.font_point");
+    RequestImGuiFontSize(g.font_point_flt);   // live-rebuild the ImGui font atlas at the new size
+    if (sel_font_type == FONT_AA_VEC) {
+        g.high_quality_font = false;
+        g.high_quality_font_computer = false;
+        g.font_antialias = true;
+    } else if (sel_font_type == FONT_VEC) {
+        g.high_quality_font = false;
+        g.high_quality_font_computer = false;
+        g.font_antialias = false;
+    } else {
+        int fam = sel_font_type - FONT_HELVETICA;
+        const BitmapFamily &f = bitmap_families[fam];
+        int sz = sel_bitmap_size[fam];
+        if (sz < 0) sz = suggested_bitmap_size(fam);
+        if (sz < 0 || sz >= f.n) sz = 0;
+        g.high_quality_font = true;
+        g.high_quality_font_computer = true;
+        g.font_antialias = false;
+        std::string nm;
+        if (fam == 0) nm = "helvetica" + std::string(f.size_names[sz]);
+        else if (fam == 1) nm = "times" + std::string(f.size_names[sz]);
+        else nm = "fixed" + std::string(f.size_names[sz]).substr(2);
+        g.font = nm;
+        mark_dirty("graphics.font");
+    }
+    mark_dirty("graphics.high_quality_font");
+    mark_dirty("graphics.high_quality_font_computer");
+    mark_dirty("graphics.font_antialias");
+    g.aspect_flt = sel_screen_aspect >= 0 ? aspect_vals[sel_screen_aspect] : current_screen_aspect();
+    mark_dirty("graphics.aspect");
+    g.draw_rendered_crosshairs = rendered_crosshair;
+    mark_dirty("graphics.draw_rendered_crosshairs");
+    // Base viewport (graphics.bases.max_width/height) from the base aspect ratio.
+    // compute_base_max() yields the largest viewport of the chosen aspect that fits
+    // the selected resolution; the imgui bases render into this letterboxed viewport.
+    {
+        int bw = 0, bh = 0;
+        compute_base_max(bw, bh);
+        if (bw > 0 && bh > 0) {
+            g.bases.max_width = bw;
+            g.bases.max_height = bh;
+            mark_dirty("graphics.bases.max_width");
+            mark_dirty("graphics.bases.max_height");
+        }
+    }
+    // screen (monitor) index.
+    g.screen = sel_monitor;
+    mark_dirty("graphics.screen");
+}
+
+// ---------------------------------------------------------------------------
+// Display frame (full vs-05 version: monitor, resolution list, text height,
+// screen aspect, base aspect, font picker)
+// ---------------------------------------------------------------------------
+
+void draw_display_frame() {
+    if (!display_inited) {
+        load_display_from_config();
+        if (sel_res_h == 0) {
+            int w = 0, h = 0;
+            if (highest_monitor_resolution(sel_display_id, w, h)) { sel_res_w = w; sel_res_h = h; }
+            if (sel_res_h > 0) resolution_text = std::to_string(sel_res_w) + "x" + std::to_string(sel_res_h);
+        }
+        refresh_screen_aspect_text();
+    }
+
+    float btn_h = ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
+    float avail_w = ImGui::GetContentRegionAvail().x;
+    float dpy_w = avail_w * 0.72f;
+    float side_w = avail_w - dpy_w;
+
+    ImGui::BeginChild("dpyframe", ImVec2(dpy_w, 6 * btn_h), ImGuiChildFlags_Borders);
+    // Monitor selector.
+    if (ImGui::Button("Monitor")) ImGui::OpenPopup("##pick_mon");
+    ImGui::SameLine(); ImGui::TextUnformatted(monitor_text.c_str());
+    if (ImGui::BeginPopup("##pick_mon")) {
+        int nd = 0; SDL_DisplayID *ids = SDL_GetDisplays(&nd);
+        for (int i = 0; i < nd; ++i) {
+            const char *nm = SDL_GetDisplayName(ids[i]);
+            char lbl[160]; snprintf(lbl, sizeof(lbl), "%d  %s", i, nm ? nm : "(unnamed)");
+            if (ImGui::MenuItem(lbl)) {
+                sel_monitor = i; sel_display_id = ids[i];
+                monitor_text = lbl; dirty = true;
+                const SDL_DisplayMode *cm = SDL_GetCurrentDisplayMode(ids[i]);
+                if (cm) { sel_res_w = cm->w; sel_res_h = cm->h;
+                    resolution_text = std::to_string(cm->w) + "x" + std::to_string(cm->h);
+                    if (sel_screen_aspect < 0) refresh_screen_aspect_text(); }
+            }
+        }
+        if (ids) SDL_free(ids);
+        ImGui::EndPopup();
+    }
+    // Resolution selector (detected fullscreen modes, deduplicated).
+    if (ImGui::Button("Resolution")) ImGui::OpenPopup("##pick_res");
+    ImGui::SameLine(); ImGui::TextUnformatted(resolution_text.c_str());
+    if (ImGui::BeginPopup("##pick_res")) {
+        int cnt = 0; SDL_DisplayMode **modes = SDL_GetFullscreenDisplayModes(sel_display_id, &cnt);
+        if (modes) {
+            std::vector<std::string> seen;
+            for (int i = 0; i < cnt; ++i) {
+                char lbl[32]; snprintf(lbl, sizeof(lbl), "%dx%d", modes[i]->w, modes[i]->h);
+                if (std::find(seen.begin(), seen.end(), lbl) != seen.end()) continue;
+                seen.push_back(lbl);
+                if (ImGui::MenuItem(lbl)) {
+                    sel_res_w = modes[i]->w; sel_res_h = modes[i]->h;
+                    resolution_text = lbl; prefill_text_height(); dirty = true;
+                    if (sel_screen_aspect < 0) refresh_screen_aspect_text();
+                }
+            }
+        }
+        if (modes) SDL_free(modes);
+        ImGui::EndPopup();
+    }
+    // Screen aspect.
+    if (ImGui::Button("Screen Aspect")) ImGui::OpenPopup("##pick_sa");
+    ImGui::SameLine(); ImGui::TextUnformatted(screen_aspect_text.c_str());
+    if (ImGui::BeginPopup("##pick_sa")) {
+        if (ImGui::MenuItem("Auto (W/H)")) { sel_screen_aspect = -1; refresh_screen_aspect_text(); dirty = true; }
+        ImGui::Separator();
+        for (size_t i = 0; i < sizeof(aspect_opts) / sizeof(aspect_opts[0]); ++i)
+            if (ImGui::MenuItem(aspect_opts[i])) { sel_screen_aspect = (int)i; refresh_screen_aspect_text(); dirty = true; }
+        ImGui::EndPopup();
+    }
+    // Font type picker.
+    ImGui::Text("Font"); ImGui::SameLine();
+    if (ImGui::Button(font_type_names[sel_font_type])) ImGui::OpenPopup("##pick_font");
+    if (ImGui::BeginPopup("##pick_font")) {
+        for (size_t i = 0; i < sizeof(font_type_names) / sizeof(font_type_names[0]); ++i)
+            if (ImGui::MenuItem(font_type_names[i])) { sel_font_type = (int)i; dirty = true; }
+        ImGui::EndPopup();
+    }
+    if (sel_font_type == FONT_AA_VEC || sel_font_type == FONT_VEC) {
+        // Text Height input for vector fonts.
+        ImGui::SameLine(); ImGui::Text("Text Height"); ImGui::SameLine();
+        ImGui::SetNextItemWidth(60);
+        if (ImGui::InputText("##textheight", text_height_buf, sizeof(text_height_buf), ImGuiInputTextFlags_CharsDecimal))
+            dirty = true;
+    } else {
+        // Bitmap size picker for Helvetica/Times/Fixed.
+        int fam = sel_font_type - FONT_HELVETICA;
+        const BitmapFamily &f = bitmap_families[fam];
+        int sz = sel_bitmap_size[fam];
+        if (sz < 0) sz = suggested_bitmap_size(fam);
+        if (sz < 0 || sz >= f.n) sz = 0;
+        ImGui::SameLine();
+        if (ImGui::Button(f.size_names[sz])) ImGui::OpenPopup("##pick_bsize");
+        if (ImGui::BeginPopup("##pick_bsize")) {
+            for (int i = 0; i < f.n; i++) {
+                bool sel = (i == sz);
+                if (ImGui::Selectable(f.size_names[i], sel)) { sel_bitmap_size[fam] = i; dirty = true; }
+            }
+            ImGui::EndPopup();
+        }
+    }
+    // Base aspect ratio.
+    if (ImGui::Button("Base Aspect Ratio")) ImGui::OpenPopup("##pick_asp");
+    ImGui::SameLine(); ImGui::TextUnformatted(base_aspect_text.c_str());
+    if (ImGui::BeginPopup("##pick_asp")) {
+        for (size_t i = 0; i < sizeof(aspect_opts) / sizeof(aspect_opts[0]); ++i)
+            if (ImGui::MenuItem(aspect_opts[i])) { sel_base_aspect = (int)i; base_aspect_text = aspect_opts[i]; dirty = true; }
+        ImGui::EndPopup();
+    }
+    ImGui::EndChild();   // end dpyframe (left column)
+
+    // Right column: Flight Control + Input buttons + Rendered Crosshair, side by
+    // side with the monitor/resolution/display controls (as vs-05).
+    ImGui::SameLine();
+    ImGui::BeginChild("dpybtns", ImVec2(side_w, 6 * btn_h), ImGuiChildFlags_Borders);
+    if (ImGui::Button(("Flight Control: " + std::string(fc_names[flight_control])).c_str(), ImVec2(-1, 0)))
+        ImGui::OpenPopup("##flight");
+    if (ImGui::BeginPopup("##flight")) {
+        for (int i = 0; i < 3; ++i) {
+            if (ImGui::MenuItem(fc_names[i])) {
+                flight_control = i;
+                if (i == FC_MOUSE) { load_mouse_staging(); }
+                else if (i == FC_JOYSTICK) { load_joystick_staging(); }
+                dirty = true;
+            }
+        }
+        ImGui::EndPopup();
+    }
+    // Flight-control gating: only the active device's settings are enabled.
+    if (flight_control != FC_MOUSE) ImGui::BeginDisabled();
+    if (ImGui::Button("Mouse Settings", ImVec2(-1, 0))) { load_mouse_staging(); mouse_dialog_open = true; }
+    if (flight_control != FC_MOUSE) ImGui::EndDisabled();
+    if (flight_control != FC_JOYSTICK) ImGui::BeginDisabled();
+    if (ImGui::Button("Joystick Settings", ImVec2(-1, 0))) { load_joystick_staging(); joy_dialog_open = true; }
+    if (flight_control != FC_JOYSTICK) ImGui::EndDisabled();
+    if (ImGui::Button("Bindings", ImVec2(-1, 0))) { load_bindings_staging(); bind_capture_cmd.clear(); bind_rebind_row = -1; bind_capturing = false; bind_dialog_open = true; }
+    if (ImGui::Checkbox("Rendered Crosshair", &rendered_crosshair)) dirty = true;
+    ImGui::EndChild();   // end dpybtns (right column)
+}
+
+// ---------------------------------------------------------------------------
+// Flight Control + Mouse + Joystick (ported from vs-05 modern_ui.cpp)
+// ---------------------------------------------------------------------------
+
+// Mouse flight-mode names (the Mouse preset options in engine.json).
+static const char *mouse_mode_names[] = { "glide_mouse", "inv_glide_mouse", "warp_mouse", "inv_warp_mouse", "no_mouse" };
+
+// Mouse staging.
+struct MouseStaging {
+    bool cam_pancam = false, cam_pantgt = false, cam_chasecam = true;
+    char warp_zone[8] = "200", exponent[8] = "1.5", deadband[8] = "0.05";
+    int  mode_idx = 0;   // index into mouse_mode_names
+};
+static MouseStaging mouse_stg;
+
+// Joystick flight roles (x/y/z/throttle).
+static const char *joy_role_names[] = { "x", "y", "z", "throttle" };
+static int  joy_bind_stick[4] = { 0, 0, 0, 0 };
+static int  joy_bind_axis[4] = { -1, -1, -1, -1 };
+static bool joy_bind_inv[4] = { false, false, false, false };
+static char joy_deadband[8] = "0.05";
+static bool joy_ffb = false;
+static char joy_ff_device[8] = "0";
+static bool joy_auto_sampling = false;
+static float joy_auto_timer = 0.0f, joy_auto_max = 0.0f;
+
+// Which flight role (if any) maps to this physical (stick, axis).
+static int role_for_axis(int stick, int axis) {
+    for (int r = 0; r < 4; ++r)
+        if (joy_bind_stick[r] == stick && joy_bind_axis[r] == axis) return r;
+    return -1;
+}
+
+// Sample the bound axes for Auto Deadband (max deflection over ~1s).
+static float joy_sample_bound_axes() {
+    float m = 0.0f;
+    SDL_UpdateJoysticks();
+    int n = 0; SDL_JoystickID *ids = SDL_GetJoysticks(&n);
+    for (int r = 0; r < 4; ++r) {
+        int s = joy_bind_stick[r];
+        if (s < 0 || s >= n || joy_bind_axis[r] < 0) continue;
+        SDL_Joystick *joy = SDL_OpenJoystick(ids[s]);
+        if (!joy) continue;
+        float v = SDL_GetJoystickAxis(joy, joy_bind_axis[r]) / 32768.0f;
+        if (v < 0) v = -v;
+        if (v > m) m = v;
+        SDL_CloseJoystick(joy);
+    }
+    if (ids) SDL_free(ids);
+    return m;
+}
+
+// Load mouse staging from Configuration.joystick.
+static void load_mouse_staging() {
+    const auto &j = configuration().joystick;
+    mouse_stg.cam_pancam = j.mouse_cursor_pancam;
+    mouse_stg.cam_pantgt = j.mouse_cursor_pantgt;
+    mouse_stg.cam_chasecam = j.mouse_cursor_chasecam;
+    snprintf(mouse_stg.warp_zone, sizeof(mouse_stg.warp_zone), "%d", j.warp_mouse_zone);
+    snprintf(mouse_stg.exponent, sizeof(mouse_stg.exponent), "%.1f", j.mouse_exponent_flt);
+    snprintf(mouse_stg.deadband, sizeof(mouse_stg.deadband), "%.2f", j.mouse_deadband_flt);
+    // Load the persisted mouse mode (input.mouse_preset) into the picker.
+    mouse_stg.mode_idx = 0;
+    const std::string &mp = configuration().input.mouse_preset;
+    for (int i = 0; i < 5; ++i)
+        if (mouse_mode_names[i] == mp) { mouse_stg.mode_idx = i; break; }
+}
+
+// Load joystick staging from Configuration.joystick + input.axes.
+static void load_joystick_staging() {
+    const auto &j = configuration().joystick;
+    snprintf(joy_deadband, sizeof(joy_deadband), "%.2f", j.deadband_flt);
+    joy_ffb = j.force_feedback;
+    snprintf(joy_ff_device, sizeof(joy_ff_device), "%d", j.ff_device);
+    const auto &axes = configuration().axes;
+    for (int r = 0; r < 4; ++r) {
+        joy_bind_stick[r] = 0; joy_bind_axis[r] = -1; joy_bind_inv[r] = false;
+        auto it = axes.find(joy_role_names[r]);
+        if (it != axes.end() && it->second.axis >= 0) {
+            joy_bind_stick[r] = it->second.joystick;
+            joy_bind_axis[r] = it->second.axis;
+            joy_bind_inv[r] = it->second.inverse;
+        }
+    }
+}
+
+// Apply flight-control exclusivity to Configuration.joystick.
+static void apply_flight_to_config() {
+    auto &j = cfg().joystick;
+    // The triple-state device switch (input.device) drives flight-control mode.
+    cfg().input.device = (flight_control == FC_MOUSE) ? "mouse"
+                       : (flight_control == FC_JOYSTICK) ? "joystick" : "keyboard";
+    mark_dirty("input.device");
+    if (flight_control == FC_MOUSE) {
+        j.force_use_of_joystick = false;
+        j.warp_mouse = true;
+    } else if (flight_control == FC_JOYSTICK) {
+        j.force_use_of_joystick = true;
+    } else {
+        j.force_use_of_joystick = false;
+        j.warp_mouse = false;
+    }
+    mark_dirty("input.joystick.force_use_of_joystick");
+    mark_dirty("input.joystick.warp_mouse");
+    // Route the x/y flight axes to the mouse (MOUSE_JOYSTICK) only when Mouse
+    // flight control is selected. The engine's config_xml axis router keys off
+    // axes.x/y.source; without this, selecting Mouse silently does nothing.
+    // For Keyboard/Joystick modes, restore source to joystick (preserving any
+    // existing axis/joystick numbers so we don't clobber joystick config).
+    auto &axes = cfg().axes;
+    if (flight_control == FC_MOUSE) {
+        // Mark x/y as mouse-driven.  We deliberately do NOT overwrite the stored
+        // axis/joystick numbers here -- bindKeys() forces the mouse x/y physical
+        // axes (0/1) at bind time, so writing them would clobber the joystick
+        // numbers and lose them on the next switch back to Joystick.  The inverse
+        // flag is only what Mouse still needs from the role entry.
+        axes["x"].source = "mouse"; axes["x"].inverse = cfg().mouse.inverse_x;
+        axes["y"].source = "mouse"; axes["y"].inverse = cfg().mouse.inverse_y;
+    } else {
+        for (const char *role : {"x", "y"}) {
+            auto it = axes.find(role);
+            if (it != axes.end() && it->second.source == "mouse")
+                it->second.source = "joystick";
+        }
+    }
+    mark_dirty("bindings.axes");
+}
+
+// Apply mouse staging to Configuration.joystick.
+static void apply_mouse_to_config() {
+    auto &j = cfg().joystick;
+    j.mouse_cursor_pancam = mouse_stg.cam_pancam;
+    j.mouse_cursor_pantgt = mouse_stg.cam_pantgt;
+    j.mouse_cursor_chasecam = mouse_stg.cam_chasecam;
+    j.warp_mouse_zone = atoi(mouse_stg.warp_zone);
+    j.mouse_exponent_flt = (float)atof(mouse_stg.exponent);
+    j.mouse_deadband_flt = (float)atof(mouse_stg.deadband);
+    mark_dirty("input.joystick.mouse_cursor_pancam");
+    mark_dirty("input.joystick.mouse_cursor_pantgt");
+    mark_dirty("input.joystick.mouse_cursor_chasecam");
+    mark_dirty("input.joystick.warp_mouse_zone");
+    mark_dirty("input.joystick.mouse_exponent");
+    mark_dirty("input.joystick.mouse_deadband");
+    // Apply the full mouse-mode preset (glide/inv_glide/warp/inv_warp/no_mouse):
+    // the vars (mouse_cursor/warp_mouse/reverse_mouse_spr/sensitivity) + the
+    // x/y axis routing with the per-mode y-axis inversion. Only meaningful when
+    // Mouse is the active flight device.
+    if (flight_control != FC_MOUSE) return;
+    const char *mode = mouse_mode_names[mouse_stg.mode_idx];
+    bool warp = (std::string(mode) == "warp_mouse" || std::string(mode) == "inv_warp_mouse");
+    bool glide = (std::string(mode) == "glide_mouse" || std::string(mode) == "inv_glide_mouse");
+    // Preset vars (defaults: mouse off, not inverted).
+    j.mouse_cursor = glide;                 // cursor shown in glide, hidden in warp/no
+    j.reverse_mouse_spr = (std::string(mode) == "inv_glide_mouse");
+    j.warp_mouse = warp;
+    j.mouse_sensitivity_flt = warp ? 120.0f : 40.0f;
+    mark_dirty("input.joystick.mouse_cursor");
+    mark_dirty("input.joystick.reverse_mouse_spr");
+    mark_dirty("input.joystick.warp_mouse");
+    mark_dirty("input.joystick.mouse_sensitivity");
+    // Axis routing + y-inversion come from the mouse preset (glide/warp vs
+    // inv_glide/inv_warp), matching the vs-05 convention: the non-inverted
+    // modes (glide_mouse, warp_mouse) invert y (top-down screen y needs the
+    // flip); the "inv_" modes do not. bindKeys() reads the mouse y-inversion
+    // from cfg.mouse.inverse_y (not axes.y.inverse), so set and persist that.
+    const bool invert_y = (std::string(mode).rfind("inv_", 0) == std::string::npos);
+    auto &axes = cfg().axes;
+    axes["x"].source = "mouse"; axes["x"].axis = 0; axes["x"].inverse = false;
+    axes["y"].source = "mouse"; axes["y"].axis = 1;
+    axes["y"].inverse = invert_y;
+    cfg().mouse.inverse_y = invert_y;
+    mark_dirty("input.mouse.inverse_y");
+    mark_dirty("bindings.axes");
+}
+
+// Apply joystick staging to Configuration.joystick + input.axes.
+static void apply_joystick_to_config() {
+    if (flight_control != FC_JOYSTICK) return;
+    auto &j = cfg().joystick;
+    j.deadband_flt = (float)atof(joy_deadband);
+    j.force_feedback = joy_ffb;
+    j.ff_device = atoi(joy_ff_device);
+    // Joystick mode never shows a mouse cursor in flight (mouse_cursor is only
+    // meaningful for mouse flight, where the glide preset sets it). Force it off
+    // so switching from mouse back to joystick clears the cursor.
+    j.mouse_cursor = false;
+    mark_dirty("input.joystick.deadband");
+    mark_dirty("input.joystick.force_feedback");
+    mark_dirty("input.joystick.ff_device");
+    mark_dirty("input.joystick.mouse_cursor");
+    // Write the x/y/z/throttle axes. An unbound role is kept with axis=-1 (the
+    // engine's "unbound" sentinel) rather than erased, so parseAxes' overlay
+    // merge preserves the unbind on restart (an absent key would fall back to
+    // the datadir default and re-bind it).
+    auto &axes = cfg().axes;
+    for (int r = 0; r < 4; ++r) {
+        const char *role = joy_role_names[r];
+        vega_config::Configuration::AxisRole &ar = axes[role];   // ensures the role exists (even if unbound)
+        if (joy_bind_axis[r] < 0) {
+            ar.source = "joystick"; ar.joystick = 0; ar.axis = -1; ar.inverse = false;
+        } else {
+            ar.source = "joystick";
+            ar.joystick = joy_bind_stick[r];
+            ar.axis = joy_bind_axis[r];
+            ar.inverse = joy_bind_inv[r];
+        }
+    }
+    // Persist the axes (including unbinds like a removed throttle) so they
+    // survive a restart; write_out_dirty serializes cfg().axes to bindings.json.
+    mark_dirty("bindings.axes");
+}
+
+// Write the accumulated dirty config paths out to the user config files.
+// Set a dotted path ("graphics.fog") into a nested boost::json::object.
+static void json_set_path(boost::json::object &root, const std::string &path, const boost::json::value &val) {
+    size_t dot = path.find('.');
+    if (dot == std::string::npos) { root[path] = val; return; }
+    std::string head = path.substr(0, dot);
+    std::string rest = path.substr(dot + 1);
+    if (!root.contains(head) || !root[head].is_object())
+        root[head] = boost::json::object();
+    json_set_path(root[head].as_object(), rest, val);
+}
+
+// Deep-merge src into dst (src's values win). Objects merge recursively; all
+// other types are replaced. Used to overlay the dirty paths onto the existing
+// user overlay so a Save does not drop previously-saved overrides.
+static void json_merge(boost::json::value &dst, const boost::json::value &src) {
+    if (!src.is_object() || !dst.is_object()) { dst = src; return; }
+    auto &d = dst.as_object();
+    for (const auto &kv : src.as_object()) {
+        if (d.contains(kv.key()) && d[kv.key()].is_object() && kv.value().is_object()) {
+            json_merge(d[kv.key()], kv.value());
+        } else {
+            d[kv.key()] = kv.value();
+        }
+    }
+}
+
+// Read an existing user overlay file (if any) into an object, else empty.
+static boost::json::object read_existing_overlay(const std::string &path) {
+    boost::json::object obj;
+    std::ifstream in(path);
+    if (in) {
+        std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        try {
+            boost::json::value v = boost::json::parse(text);
+            if (v.is_object()) obj = v.as_object();
+        } catch (...) { /* corrupt/partial — start fresh */ }
+    }
+    return obj;
+}
+
+// Write the accumulated dirty config paths out to the user config files
+// (VSFileSystem::homedir/config.json + bindings.json). Single write-out entry point.
+static void write_out_dirty() {
+    if (g_dirty_paths.empty()) return;
+    boost::json::object config_out;
+    boost::json::object bindings_out;
+    bool has_bindings = false;
+    for (const auto &path : g_dirty_paths) {
+        if (path == "bindings.actions") {
+            has_bindings = true;
+            continue;
+        }
+        if (path.rfind("preset.", 0) == 0) {
+            // preset selector: config.json -> preset.<cat>
+            std::string cat = path.substr(7);
+            auto &preset_obj = config_out["preset"].is_object() ? config_out["preset"].as_object()
+                               : (config_out["preset"] = boost::json::object()).as_object();
+            auto it = configuration().preset.find(cat);
+            if (it != configuration().preset.end()) preset_obj[cat] = it->second;
+            continue;
+        }
+        boost::json::value v = read_config_value(path);
+        if (!v.is_null()) json_set_path(config_out, path, v);
+    }
+
+    // Write config.json overlay (if any config changes). Merge onto the existing
+    // user overlay so a Save only updates the dirty subset and never drops
+    // previously-saved overrides (preset, audio, physics, etc.).
+    if (!config_out.empty()) {
+        fs::create_directories(VSFileSystem::homedir);
+        const std::string path = VSFileSystem::homedir + "/config.json";
+        boost::json::object existing = read_existing_overlay(path);
+        boost::json::value merged = std::move(existing);
+        json_merge(merged, boost::json::value(std::move(config_out)));
+        std::ofstream out(path);
+        out << boost::json::serialize(merged) << "\n";
+        fprintf(stderr, "[vs-settings-ng] wrote config overlay to %s\n", path.c_str());
+    }
+    // Write bindings.json overlay (if bindings changed).
+    if (has_bindings || g_dirty_paths.count("bindings.axes")) {
+        // Serialize the whole actions map (the bindings dialog commits it wholesale).
+        boost::json::object actions_obj;
+        for (const auto &kv : configuration().actions) {
+            boost::json::object ab;
+            ab["keyboard"] = boost::json::array();
+            ab["mouse"] = boost::json::array();
+            ab["joystick"] = boost::json::array();
+            ab["hat"] = boost::json::array();
+            for (const auto &b : kv.second.keyboard) {
+                boost::json::object kb; kb["key"] = b.key; kb["modifier"] = b.modifier;
+                ab["keyboard"].as_array().push_back(kb);
+            }
+            for (const auto &b : kv.second.mouse) {
+                boost::json::object mb; mb["button"] = b.button; mb["modifier"] = b.modifier;
+                ab["mouse"].as_array().push_back(mb);
+            }
+            for (const auto &b : kv.second.joystick) {
+                boost::json::object jb; jb["joystick"] = b.joystick; jb["button"] = b.button; jb["modifier"] = b.modifier;
+                ab["joystick"].as_array().push_back(jb);
+            }
+            for (const auto &b : kv.second.hat) {
+                boost::json::object hb; hb["joystick"] = b.joystick; hb["hat"] = b.hatswitch; hb["direction"] = b.direction;
+                ab["hat"].as_array().push_back(hb);
+            }
+            actions_obj[kv.first] = ab;
+        }
+        bindings_out["actions"] = actions_obj;
+        // Serialize the axes tree (x/y/z/throttle) so flight-control device
+        // routing (e.g. Mouse -> axes.x.source="mouse") persists to bindings.json.
+        boost::json::object axes_obj;
+        for (const auto &kv : configuration().axes) {
+            boost::json::object ar;
+            ar["source"] = kv.second.source;
+            ar["joystick"] = kv.second.joystick;
+            ar["axis"] = kv.second.axis;
+            ar["inverse"] = kv.second.inverse;
+            axes_obj[kv.first] = ar;
+        }
+        bindings_out["axes"] = axes_obj;
+        fs::create_directories(VSFileSystem::homedir);
+        std::ofstream out(VSFileSystem::homedir + "/bindings.json");
+        out << boost::json::serialize(bindings_out) << "\n";
+        fprintf(stderr, "[vs-settings-ng] wrote bindings overlay to %s/bindings.json\n", VSFileSystem::homedir.c_str());
+    }
+    g_dirty_paths.clear();
+}
+
+// Mouse Settings dialog.
+static void draw_mouse_dialog() {
+    if (!mouse_dialog_open) return;
+    ImGui::SetNextWindowSize(ImVec2(360, 0), ImGuiCond_Appearing);
+    if (ImGui::BeginPopupModal("Mouse Settings", &mouse_dialog_open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        // Flight mode (Mouse preset).
+        ImGui::Text("Flight mode"); ImGui::SameLine(); ImGui::SetNextItemWidth(180);
+        if (ImGui::Combo("##mmode", &mouse_stg.mode_idx, mouse_mode_names, 5)) {
+            cfg().input.mouse_preset = mouse_mode_names[mouse_stg.mode_idx];
+            mark_dirty("input.mouse_preset");
+            dirty = true;
+        }
+        ImGui::Separator();
+        ImGui::Checkbox("Mouse cursor on pan camera", &mouse_stg.cam_pancam);
+        ImGui::Checkbox("Mouse cursor on target pan camera", &mouse_stg.cam_pantgt);
+        ImGui::Checkbox("Mouse cursor on chase camera", &mouse_stg.cam_chasecam);
+        ImGui::Separator();
+        ImGui::Text("Warp zone"); ImGui::SameLine(); ImGui::SetNextItemWidth(90);
+        if (ImGui::InputText("##wz", mouse_stg.warp_zone, sizeof(mouse_stg.warp_zone), ImGuiInputTextFlags_CharsDecimal)) dirty = true;
+        ImGui::Text("Exponent"); ImGui::SameLine(); ImGui::SetNextItemWidth(90);
+        if (ImGui::InputText("##exp", mouse_stg.exponent, sizeof(mouse_stg.exponent), ImGuiInputTextFlags_CharsDecimal)) dirty = true;
+        ImGui::Text("Deadband"); ImGui::SameLine(); ImGui::SetNextItemWidth(90);
+        if (ImGui::InputText("##db", mouse_stg.deadband, sizeof(mouse_stg.deadband), ImGuiInputTextFlags_CharsDecimal)) dirty = true;
+        ImGui::Separator();
+        if (ImGui::Button("Accept")) { mouse_dialog_open = false; dirty = true; ImGui::CloseCurrentPopup(); }
+        ImGui::SameLine();
+        if (ImGui::Button("Close")) { mouse_dialog_open = false; ImGui::CloseCurrentPopup(); }
+        ImGui::EndPopup();
+    }
+}
+
+// Joystick Settings dialog.
+static void draw_joystick_dialog() {
+    if (!joy_dialog_open) return;
+    ImGui::SetNextWindowSize(ImVec2(460, 0), ImGuiCond_Appearing);
+    if (ImGui::BeginPopupModal("Joystick Settings", &joy_dialog_open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text("Deflect an axis to identify it, then bind it to a flight role.");
+        ImGui::Separator();
+        SDL_UpdateJoysticks();   // refresh axis state (also for a just-hotplugged joystick)
+        int n = 0; SDL_JoystickID *ids = SDL_GetJoysticks(&n);
+        // Persistent open handles: open each device once and reuse across frames so a
+        // hotplugged joystick's axis state stays live.
+        static std::map<SDL_JoystickID, SDL_Joystick*> g_joy_open;
+        std::set<SDL_JoystickID> present;
+        for (int i = 0; i < n; ++i) present.insert(ids[i]);
+        // close any handle whose device was removed
+        for (auto it = g_joy_open.begin(); it != g_joy_open.end();) {
+            if (present.find(it->first) == present.end()) { SDL_CloseJoystick(it->second); it = g_joy_open.erase(it); }
+            else ++it;
+        }
+        if (n <= 0 || !ids) {
+            ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f), "No Joystick Detected");
+        } else {
+            static const char *dd[] = { "none", "x", "y", "z", "throttle" };
+            for (int i = 0; i < n; ++i) {
+                SDL_Joystick *joy = g_joy_open[ids[i]];
+                if (!joy) { joy = SDL_OpenJoystick(ids[i]); g_joy_open[ids[i]] = joy; }
+                if (!joy) continue;
+                const char *nm = SDL_GetJoystickName(joy);
+                int na = SDL_GetNumJoystickAxes(joy);
+                for (int a = 0; a < na; ++a) {
+                    float val = SDL_GetJoystickAxis(joy, a) / 32768.0f;
+                    int role = role_for_axis(i, a);
+                    char id[32]; snprintf(id, sizeof(id), "##joy%d_a%d", i, a);
+                    ImGui::Text("%s A%d", nm ? nm : "Joy", a); ImGui::SameLine();
+                    ImGui::SetNextItemWidth(110);
+                    ImGui::BeginDisabled();
+                    ImGui::SliderFloat((std::string(id) + "live").c_str(), &val, -1.0f, 1.0f, "");
+                    ImGui::EndDisabled();
+                    ImGui::SameLine();
+                    int cur = role < 0 ? 0 : role + 1;
+                    ImGui::SetNextItemWidth(90);
+                    if (ImGui::Combo((std::string(id) + "bind").c_str(), &cur, dd, 5)) {
+                        int nr = cur - 1;
+                        for (int r = 0; r < 4; ++r)
+                            if (joy_bind_stick[r] == i && joy_bind_axis[r] == a) { joy_bind_stick[r] = -1; joy_bind_axis[r] = -1; }
+                        if (nr >= 0) { joy_bind_stick[nr] = i; joy_bind_axis[nr] = a; }
+                        dirty = true;
+                    }
+                    ImGui::SameLine();
+                    bool has = role >= 0;
+                    if (!has) ImGui::BeginDisabled();
+                    bool inv = has ? joy_bind_inv[role] : false;
+                    if (ImGui::Checkbox((std::string(id) + "inv").c_str(), &inv) && has) {
+                        joy_bind_inv[role] = inv; dirty = true;
+                    }
+                    if (!has) ImGui::EndDisabled();
+                }
+            }
+        }
+        if (ids) SDL_free(ids);
+        ImGui::Separator();
+        ImGui::Text("Deadband"); ImGui::SameLine(); ImGui::SetNextItemWidth(90);
+        if (ImGui::InputText("##jdb", joy_deadband, sizeof(joy_deadband), ImGuiInputTextFlags_CharsDecimal)) dirty = true;
+        ImGui::SameLine();
+        if (ImGui::Button("Auto Deadband")) { joy_auto_sampling = true; joy_auto_timer = 0.0f; joy_auto_max = 0.0f; }
+        if (joy_auto_sampling) {
+            float m = joy_sample_bound_axes();
+            if (m > joy_auto_max) joy_auto_max = m;
+            joy_auto_timer += ImGui::GetIO().DeltaTime;
+            ImGui::SameLine();
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.4f, 1.0f), "Sampling... keep the stick still");
+            if (joy_auto_timer >= 1.0f) {
+                float db = joy_auto_max + 0.05f;
+                if (db < 0.0f) db = 0.0f; else if (db > 0.5f) db = 0.5f;
+                snprintf(joy_deadband, sizeof(joy_deadband), "%.3f", db);
+                joy_auto_sampling = false; dirty = true;
+            }
+        }
+        if (ImGui::Checkbox("Force feedback", &joy_ffb)) dirty = true;
+        ImGui::Text("FFB device"); ImGui::SameLine(); ImGui::SetNextItemWidth(50);
+        if (ImGui::InputText("##jff", joy_ff_device, sizeof(joy_ff_device), ImGuiInputTextFlags_CharsDecimal)) dirty = true;
+        ImGui::Separator();
+        if (ImGui::Button("Reset Axis")) {
+            for (int r = 0; r < 4; ++r) { joy_bind_stick[r] = -1; joy_bind_axis[r] = -1; joy_bind_inv[r] = false; }
+            dirty = true;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Accept")) { joy_dialog_open = false; dirty = true; ImGui::CloseCurrentPopup(); }
+        ImGui::SameLine();
+        if (ImGui::Button("Close")) { joy_dialog_open = false; ImGui::CloseCurrentPopup(); }
+        ImGui::EndPopup();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bindings (full vs-05 port, against Configuration.actions)
+// ---------------------------------------------------------------------------
+
+// Bind categories (vs-05 BC_*).
+enum { BC_COCKPIT = 0, BC_MOVEMENT, BC_WEAPONS, BC_TARGETING, BC_COMMS, BC_SHIP, BC_MISC, BC_COUNT };
+static const char *bind_cat_names[BC_COUNT] = { "Cockpit / Camera", "Movement / Flight", "Weapons / Combat",
+    "Targeting", "Comms", "Ship / Systems", "Interface / Misc" };
+
+struct BindRow {
+    std::string command, device;   // device: "key" | "mouse" | "joystick"
+    std::string key, button, device_idx, modifier;
+    std::string hat_idx;           // joystick digital-hatswitch index
+    std::string hat_dir;           // joystick digital-hatswitch direction, else ""
+    int  category = BC_MISC;
+    bool remove = false, dirty = false, conflict = false;
+};
+static std::vector<BindRow> bindrows;
+static int  bind_cat = BC_COCKPIT;
+static bool bind_pending = false;
+static bool bind_capture_requested = false;
+static bool cap_valid = false;
+static bool cap_open = false;
+static std::string cap_device, cap_idx, cap_btn, cap_key, cap_modifier;
+static std::string cap_hat_idx, cap_hat_dir;
+static ImVec2 cap_frame_pos, cap_frame_size;
+
+static bool starts_with(const std::string &s, const char *prefix) {
+    size_t n = strlen(prefix);
+    return s.size() >= n && s.compare(0, n, prefix) == 0;
+}
+static int bind_category(const std::string &cmd) {
+    if (starts_with(cmd, "Cockpit::")) return BC_COCKPIT;
+    if (starts_with(cmd, "Thrust") || starts_with(cmd, "Flight:") || starts_with(cmd, "Joystick:")
+        || cmd == "ToggleWarpDrive") return BC_MOVEMENT;
+    if (cmd == "FireKey" || cmd == "MissileKey" || cmd == "WeapSelKey" || cmd == "MisSelKey"
+        || cmd == "ReverseWeapSelKey" || cmd == "ReverseMisSelKey" || cmd == "SheltonKey" || cmd == "ECMKey"
+        || starts_with(cmd, "Turret") || cmd == "SwitchCombatMode" || cmd == "ABKey"
+        || cmd == "AccelKey" || cmd == "DecelKey") return BC_WEAPONS;
+    if (cmd.find("Target") != std::string::npos) return BC_TARGETING;
+    if (starts_with(cmd, "Comm") || cmd == "TextMessage" || cmd == "ChangeCommStatus") return BC_COMMS;
+    if (cmd == "CloakKey" || cmd == "EjectKey" || cmd == "EjectCargoKey" || cmd == "JumpKey"
+        || cmd == "DockKey" || cmd == "UnDockKey" || cmd == "PauseKey" || cmd == "StartKey" || cmd == "StopKey"
+        || cmd == "Respawn" || cmd == "SuicideKey" || cmd == "SwitchSecured" || cmd == "SwitchWebcam"
+        || cmd == "SetVelocityRefKey" || cmd == "SetVelocityNullKey" || cmd == "RequestClearenceKey") return BC_SHIP;
+    return BC_MISC;
+}
+static std::string bind_input(const BindRow &r) {
+    if (r.device == "key") return "k:" + r.key + ":" + r.modifier;
+    if (r.device == "joystick" && !r.hat_dir.empty())
+        return r.device + ":hat:" + r.device_idx + ":" + r.hat_idx + ":" + r.hat_dir;
+    return r.device + ":" + r.device_idx + ":" + r.button;
+}
+static void compute_bind_conflicts(void) {
+    std::map<std::string, std::vector<std::string>> input_cmds;
+    for (auto &r : bindrows) {
+        if (r.remove) continue;
+        std::string in = bind_input(r);
+        if (std::find(input_cmds[in].begin(), input_cmds[in].end(), r.command) == input_cmds[in].end())
+            input_cmds[in].push_back(r.command);
+    }
+    for (auto &r : bindrows) {
+        r.conflict = false;
+        if (r.remove) continue;
+        r.conflict = input_cmds[bind_input(r)].size() > 1;
+    }
+}
+
+// Load Configuration.actions into the staged bindrows.
+static void load_bindings_staging() {
+    bindrows.clear();
+    for (const auto &kv : configuration().actions) {
+        const std::string &cmd = kv.first;
+        const auto &ab = kv.second;
+        for (const auto &b : ab.keyboard) {
+            BindRow r; r.command = cmd; r.category = bind_category(cmd); r.device = "key";
+            r.key = b.key; r.modifier = b.modifier; bindrows.push_back(r);
+        }
+        for (const auto &b : ab.mouse) {
+            BindRow r; r.command = cmd; r.category = bind_category(cmd); r.device = "mouse";
+            r.button = std::to_string(b.button); r.device_idx = "0"; r.modifier = "none"; bindrows.push_back(r);
+        }
+        for (const auto &b : ab.joystick) {
+            BindRow r; r.command = cmd; r.category = bind_category(cmd); r.device = "joystick";
+            r.button = std::to_string(b.button); r.device_idx = std::to_string(b.joystick); r.modifier = "none";
+            bindrows.push_back(r);
+        }
+        for (const auto &b : ab.hat) {
+            BindRow r; r.command = cmd; r.category = bind_category(cmd); r.device = "joystick";
+            r.hat_idx = std::to_string(b.hatswitch); r.hat_dir = b.direction;
+            r.device_idx = std::to_string(b.joystick); r.modifier = "none"; bindrows.push_back(r);
+        }
+    }
+    compute_bind_conflicts();
+}
+
+// Commit the staged bindrows to Configuration.actions (on Accept).
+static void apply_bindrows_to_config() {
+    auto &actions = cfg().actions;
+    actions.clear();   // rebuild from the staged rows
+    for (const auto &r : bindrows) {
+        if (r.remove) continue;
+        auto &ab = actions[r.command];
+        vega_config::Configuration::ActionBinding b;
+        b.modifier = "none";
+        if (r.device == "key") {
+            b.key = r.key; b.modifier = r.modifier; ab.keyboard.push_back(b);
+        } else if (r.device == "mouse") {
+            b.button = atoi(r.button.c_str()); b.is_mouse = true; b.joystick = -1; ab.mouse.push_back(b);
+        } else if (!r.hat_dir.empty()) {
+            b.hatswitch = atoi(r.hat_idx.c_str()); b.direction = r.hat_dir;
+            b.joystick = atoi(r.device_idx.c_str()); ab.hat.push_back(b);
+        } else {
+            b.button = atoi(r.button.c_str()); b.joystick = atoi(r.device_idx.c_str()); ab.joystick.push_back(b);
+        }
+    }
+    // Bindings changed -> mark the whole actions tree dirty (written out as bindings.json).
+    mark_dirty("bindings.actions");
+}
+
+// Mark every bind row sharing the currently-captured input (other actions) as removed.
+static void clear_other_binds(void) {
+    std::string in;
+    if (cap_device == "key") in = "k:" + cap_key + ":" + cap_modifier;
+    else if (cap_device == "joystick" && !cap_hat_dir.empty())
+        in = "joystick:hat:" + cap_idx + ":" + cap_hat_idx + ":" + cap_hat_dir;
+    else in = cap_device + ":" + cap_idx + ":" + cap_btn;
+    if (in.empty()) return;
+    for (auto &r : bindrows) {
+        if (r.remove || r.command == bind_capture_cmd) continue;
+        if (bind_input(r) == in) { r.remove = true; r.dirty = true; }
+    }
+    compute_bind_conflicts();
+}
+
+// Actions already bound to the currently-captured input (excluding the target action).
+static std::vector<std::string> capture_conflicts(void) {
+    std::string in;
+    if (cap_device == "key") in = "k:" + cap_key + ":" + cap_modifier;
+    else if (cap_device == "joystick" && !cap_hat_dir.empty())
+        in = "joystick:hat:" + cap_idx + ":" + cap_hat_idx + ":" + cap_hat_dir;
+    else in = cap_device + ":" + cap_idx + ":" + cap_btn;
+    if (in.empty()) return {};
+    std::vector<std::string> out;
+    for (auto &r : bindrows) {
+        if (r.remove || r.command == bind_capture_cmd) continue;
+        if (bind_input(r) == in)
+            if (std::find(out.begin(), out.end(), r.command) == out.end())
+                out.push_back(r.command);
+    }
+    return out;
+}
+
+// Map an SDL3 keycode to the config's key-name convention.
+static const char *config_key_name(SDL_Keycode key) {
+    switch (key) {
+        case SDLK_RETURN: return "return";
+        case SDLK_ESCAPE: return "esc";
+        case SDLK_TAB: return "tab";
+        case SDLK_SPACE: return "space";
+        case SDLK_BACKSPACE: return "backspace";
+        case SDLK_LEFT: return "cursor-left";
+        case SDLK_RIGHT: return "cursor-right";
+        case SDLK_UP: return "cursor-up";
+        case SDLK_DOWN: return "cursor-down";
+        case SDLK_HOME: return "cursor-home";
+        case SDLK_END: return "cursor-end";
+        case SDLK_PAGEUP: return "cursor-pageup";
+        case SDLK_PAGEDOWN: return "cursor-pagedown";
+        case SDLK_INSERT: return "cursor-insert";
+        case SDLK_DELETE: return "cursor-delete";
+        case SDLK_CAPSLOCK: return "capslock";
+        case SDLK_SCROLLLOCK: return "scrollock";
+        case SDLK_NUMLOCKCLEAR: return "keypad-numlock";
+        default: {
+            if (key >= SDLK_F1 && key <= SDLK_F15) {
+                static char b[16]; snprintf(b, sizeof(b), "function-%d", (int)(key - SDLK_F1) + 1);
+                return b;
+            }
+            if (key >= ' ' && key <= '~') {
+                static char b[2]; b[0] = (char)key; b[1] = 0; return b;
+            }
+            return NULL;
+        }
+    }
+}
+
+// Convert an SDL joystick instance ID to its index in SDL_GetJoysticks().
+static int joystick_index_of(SDL_JoystickID which) {
+    int n = 0; SDL_JoystickID *ids = SDL_GetJoysticks(&n);
+    int idx = -1;
+    for (int i = 0; i < n; i++) if (ids[i] == which) { idx = i; break; }
+    SDL_free(ids);
+    return idx;
+}
+
+// Map an SDL_HAT_* bitmask to its direction name; NULL for CENTERED.
+static const char *hat_value_name(Uint8 v) {
+    switch (v) {
+        case SDL_HAT_UP:       return "up";
+        case SDL_HAT_RIGHT:    return "right";
+        case SDL_HAT_DOWN:     return "down";
+        case SDL_HAT_LEFT:     return "left";
+        case SDL_HAT_RIGHTUP:  return "rightup";
+        case SDL_HAT_RIGHTDOWN: return "rightdown";
+        case SDL_HAT_LEFTUP:   return "leftup";
+        case SDL_HAT_LEFTDOWN: return "leftdown";
+        default:               return NULL;
+    }
+}
+
+// Commit a captured input to a new/replaced bind row for the current action.
+static void accept_capture(void) {
+    BindRow nr;
+    nr.command = bind_capture_cmd; nr.category = bind_category(bind_capture_cmd);
+    nr.remove = false; nr.dirty = true; nr.conflict = false;
+    nr.device = cap_device;
+    if (cap_device == "key") { nr.key = cap_key; nr.modifier = cap_modifier; }
+    else if (cap_device == "joystick" && !cap_hat_dir.empty()) {
+        nr.hat_idx = cap_hat_idx; nr.hat_dir = cap_hat_dir; nr.device_idx = cap_idx;
+    }
+    else { nr.button = cap_btn; nr.device_idx = cap_idx; }
+    if (bind_rebind_row >= 0 && bind_rebind_row < (int)bindrows.size()) {
+        BindRow &r = bindrows[bind_rebind_row];
+        r.key.clear(); r.button.clear(); r.device_idx.clear(); r.modifier = "none";
+        r.hat_idx.clear(); r.hat_dir.clear();
+        r.device = nr.device; r.key = nr.key; r.button = nr.button;
+        r.device_idx = nr.device_idx; r.modifier = nr.modifier;
+        r.hat_idx = nr.hat_idx; r.hat_dir = nr.hat_dir;
+        r.dirty = true;
+    } else {
+        bindrows.push_back(nr);
+    }
+    bind_rebind_row = -1;
+    cap_valid = false;
+    compute_bind_conflicts();
+}
+
+// Handle SDL events for binding capture + joystick hotplug.
+static void handle_bindings_event(const SDL_Event *event) {
+    if (bind_capturing && cap_open && !bind_capture_cmd.empty()) {
+        if (event->type == SDL_EVENT_KEY_DOWN) {
+            SDL_Keycode kc = event->key.key;
+            if (kc == SDLK_LSHIFT || kc == SDLK_RSHIFT || kc == SDLK_LCTRL || kc == SDLK_RCTRL
+                || kc == SDLK_LALT || kc == SDLK_RALT || kc == SDLK_LGUI || kc == SDLK_RGUI)
+                return;
+            const char *nm = config_key_name(kc);
+            if (nm) {
+                std::string k = nm;
+                if ((event->key.mod & SDL_KMOD_SHIFT) && k.size() == 1 && k[0] >= 'a' && k[0] <= 'z')
+                    k[0] = (char)(k[0] - 'a' + 'A');
+                cap_device = "key"; cap_key = k;
+                cap_modifier = (event->key.mod & SDL_KMOD_CTRL) ? "ctrl"
+                             : ((event->key.mod & SDL_KMOD_ALT) ? "alt" : "none");
+                cap_valid = true;
+            }
+            return;
+        }
+        if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+            bool inframe = event->button.x >= cap_frame_pos.x && event->button.x <= cap_frame_pos.x + cap_frame_size.x
+                        && event->button.y >= cap_frame_pos.y && event->button.y <= cap_frame_pos.y + cap_frame_size.y;
+            if (inframe) {
+                cap_device = "mouse"; cap_btn = std::to_string(event->button.button);
+                cap_idx = "0"; cap_modifier = "none"; cap_valid = true;
+                return;
+            }
+        }
+        if (event->type == SDL_EVENT_JOYSTICK_BUTTON_DOWN) {
+            int idx = joystick_index_of(event->jbutton.which);
+            cap_device = "joystick"; cap_btn = std::to_string(event->jbutton.button);
+            cap_idx = (idx < 0) ? std::to_string(event->jbutton.which) : std::to_string(idx);
+            cap_modifier = "none"; cap_valid = true;
+            return;
+        }
+        if (event->type == SDL_EVENT_JOYSTICK_HAT_MOTION) {
+            const char *dir = hat_value_name(event->jhat.value);
+            if (dir) {
+                int idx = joystick_index_of(event->jhat.which);
+                cap_device = "joystick";
+                cap_idx = (idx < 0) ? std::to_string(event->jhat.which) : std::to_string(idx);
+                cap_hat_idx = std::to_string(event->jhat.hat);
+                cap_hat_dir = dir;
+                cap_btn.clear();
+                cap_valid = true;
+            }
+            return;
+        }
+    }
+    if (event->type == SDL_EVENT_JOYSTICK_ADDED || event->type == SDL_EVENT_JOYSTICK_REMOVED)
+        SDL_UpdateJoysticks();
+}
+
+// Capture Binding modal.
+static void draw_capture_dialog(void) {
+    if (bind_capture_requested) { ImGui::OpenPopup("Capture Binding"); bind_capture_requested = false; }
+    cap_open = ImGui::BeginPopupModal("Capture Binding", &bind_capturing, ImGuiWindowFlags_AlwaysAutoResize);
+    if (cap_open) {
+        ImGui::Text("Capture binding for %s", bind_capture_cmd.c_str());
+        ImGui::Text("Press a key, joystick button, or move a hat (anywhere),");
+        ImGui::Text("or click the frame below for a mouse button:");
+        ImGui::BeginChild("capframe", ImVec2(280, 56), ImGuiChildFlags_Borders);
+        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.3f, 1.0f), "    click here for a mouse bind");
+        cap_frame_pos = ImGui::GetWindowPos(); cap_frame_size = ImGui::GetWindowSize();
+        ImGui::EndChild();
+        if (cap_valid) {
+            std::string disp;
+            if (cap_device == "key")
+                disp = cap_key + (cap_modifier == "none" ? "" : " " + cap_modifier);
+            else if (cap_device == "joystick" && !cap_hat_dir.empty())
+                disp = "joystick hat-" + cap_hat_idx + " " + cap_hat_dir;
+            else
+                disp = cap_device + " " + cap_btn;
+            ImGui::Text("Captured: %s", disp.c_str());
+            auto conflicts = capture_conflicts();
+            if (!conflicts.empty()) {
+                ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "! This input is already bound to:");
+                for (auto &c : conflicts)
+                    ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "    - %s", c.c_str());
+                ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "  Accepting will share the input (not recommended).");
+                if (ImGui::Button("Clear other Bind")) clear_other_binds();
+            }
+        }
+        ImGui::Separator();
+        if (cap_valid && ImGui::Button("Accept")) { accept_capture(); bind_pending = true; dirty = true; bind_capturing = false; ImGui::CloseCurrentPopup(); }
+        if (cap_valid) ImGui::SameLine();
+        if (ImGui::Button("Retry")) { cap_valid = false; cap_hat_dir.clear(); cap_hat_idx.clear(); }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel")) { bind_capturing = false; cap_valid = false; ImGui::CloseCurrentPopup(); }
+        ImGui::EndPopup();
+    }
+}
+
+// Bindings dialog: category column on the left; binds table on the right.
+static void draw_bindings_dialog(void) {
+    ImGui::SetNextWindowSize(ImVec2(960, 540), ImGuiCond_Appearing);
+    if (ImGui::BeginPopupModal("Bindings", &bind_dialog_open)) {
+        ImGui::BeginChild("catcol", ImVec2(220, 440), ImGuiChildFlags_Borders);
+        for (int c = 0; c < BC_COUNT; ++c)
+            if (ImGui::Selectable(bind_cat_names[c], bind_cat == c, 0, ImVec2(210, 0))) bind_cat = c;
+        ImGui::EndChild();
+        ImGui::SameLine();
+        float tbl_w = ImGui::GetContentRegionAvail().x;
+        ImGui::BeginChild("bindlist", ImVec2(tbl_w, 440), ImGuiChildFlags_Borders,
+                          ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_AlwaysHorizontalScrollbar);
+        if (bindrows.empty()) {
+            ImGui::TextWrapped("No bindings loaded (Configuration has no actions).");
+        } else {
+            std::vector<std::string> cmds;
+            for (auto &r : bindrows)
+                if (std::find(cmds.begin(), cmds.end(), r.command) == cmds.end()) cmds.push_back(r.command);
+            std::sort(cmds.begin(), cmds.end());
+            if (ImGui::BeginTable("bindtable", 5,
+                    ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingFixedFit)) {
+                ImGui::TableSetupColumn("Action");
+                ImGui::TableSetupColumn("Input");
+                ImGui::TableSetupColumn("Binding");
+                ImGui::TableSetupColumn("Add");
+                ImGui::TableSetupColumn("Delete");
+                ImGui::TableHeadersRow();
+                int row = 0;
+                for (auto &cmd : cmds) {
+                    if (bind_category(cmd) != bind_cat) continue;
+                    bool any = false;
+                    for (size_t i = 0; i < bindrows.size(); ++i) {
+                        BindRow &r = bindrows[i];
+                        if (r.command != cmd || r.remove) continue;
+                        any = true;
+                        std::string dev = (r.device == "key") ? "keyboard" : r.device;
+                        std::string disp;
+                        if (r.device == "key")
+                            disp = r.key + (r.modifier == "none" ? "" : " " + r.modifier);
+                        else if (r.device == "joystick" && !r.hat_dir.empty())
+                            disp = "hat-" + r.hat_idx + " " + r.hat_dir;
+                        else
+                            disp = "btn " + r.button;
+                        ImGui::TableNextRow();
+                        ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted(cmd.c_str());
+                        ImGui::TableSetColumnIndex(1); ImGui::TextUnformatted(dev.c_str());
+                        ImGui::TableSetColumnIndex(2);
+                        char bid[24]; snprintf(bid, sizeof(bid), "##bind%d", row);
+                        if (r.conflict) ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+                        if (ImGui::Button((disp + bid).c_str())) {
+                            bind_capture_cmd = cmd; bind_rebind_row = (int)i;
+                            bind_capturing = true; cap_valid = false; cap_hat_dir.clear(); cap_hat_idx.clear();
+                            bind_capture_requested = true;
+                        }
+                        if (r.conflict) ImGui::PopStyleColor();
+                        ImGui::TableSetColumnIndex(3);
+                        char aid[24]; snprintf(aid, sizeof(aid), "+##%d", row);
+                        if (ImGui::Button(aid)) { bind_capture_cmd = cmd; bind_rebind_row = -1; bind_capturing = true; cap_valid = false; cap_hat_dir.clear(); cap_hat_idx.clear(); bind_capture_requested = true; }
+                        ImGui::TableSetColumnIndex(4);
+                        char xid[24]; snprintf(xid, sizeof(xid), "X##%d", row);
+                        if (ImGui::Button(xid)) { r.remove = true; r.dirty = true; compute_bind_conflicts(); }
+                        row++;
+                    }
+                    if (!any) {
+                        ImGui::TableNextRow();
+                        ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted(cmd.c_str());
+                        ImGui::TableSetColumnIndex(1); ImGui::Text("(none)");
+                        ImGui::TableSetColumnIndex(2);
+                        ImGui::TableSetColumnIndex(3);
+                        char aid[24]; snprintf(aid, sizeof(aid), "+##%d", row);
+                        if (ImGui::Button(aid)) { bind_capture_cmd = cmd; bind_rebind_row = -1; bind_capturing = true; cap_valid = false; cap_hat_dir.clear(); cap_hat_idx.clear(); bind_capture_requested = true; }
+                        row++;
+                    }
+                }
+                ImGui::EndTable();
+            }
+        }
+        ImGui::EndChild();
+        ImGui::Separator();
+        if (ImGui::Button("Accept")) { bind_pending = true; dirty = true; apply_bindrows_to_config(); bind_capturing = false; bind_dialog_open = false; ImGui::CloseCurrentPopup(); }
+        ImGui::SameLine();
+        if (ImGui::Button("Close")) { bind_capturing = false; bind_dialog_open = false; ImGui::CloseCurrentPopup(); }
+        draw_capture_dialog();
+        ImGui::EndPopup();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Presets (dropdowns from engine.json presets; record selectors in
+// Configuration.preset).
+// ---------------------------------------------------------------------------
+
+struct PresetOptionInfo {
+    std::string name;
+    std::vector<std::pair<std::string,std::string>> vars;   // (var-name, value)
+};
+struct PresetGroupInfo {
+    std::string key;              // config.json preset key (lowercase, e.g. "computer")
+    std::string label;            // display name (e.g. "Computer")
+    std::vector<PresetOptionInfo> options;  // options + the vars each sets
+};
+
+static std::vector<PresetGroupInfo> g_preset_groups;
+static bool g_presets_loaded = false;
+
+// Map an engine.json preset category name (e.g. "MusicAndVolume", "FactionTextures")
+// to the config.json preset key (lowercase snake_case: "music", "faction_textures").
+// Known exceptions first (MusicAndVolume -> music), then camelCase -> snake_case.
+static std::string preset_key_for_category(const std::string &cat) {
+    if (cat == "MusicAndVolume") return "music";
+    std::string key;
+    key.reserve(cat.size() + 4);
+    for (size_t i = 0; i < cat.size(); ++i) {
+        char c = cat[i];
+        if (c >= 'A' && c <= 'Z') {
+            if (i > 0) key += '_';
+            key += (char)(c - 'A' + 'a');
+        } else {
+            key += c;
+        }
+    }
+    return key;
+}
+
+// Load preset categories/options from engine.json -> presets (via VSFileSystem::datadir).
+static void load_presets() {
+    if (g_presets_loaded) return;
+    g_preset_groups.clear();
+    std::ifstream in(VSFileSystem::datadir + "/engine.json");
+    if (!in) return;
+    std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    try {
+        boost::json::value root = boost::json::parse(text);
+        const boost::json::value *presets = root.if_object() ? root.as_object().if_contains("presets") : nullptr;
+        if (presets && presets->is_object()) {
+            for (const auto &kv : presets->as_object()) {
+                if (!kv.value().is_object() || kv.value().as_object().empty()) continue;
+                std::string key = preset_key_for_category(kv.key());
+                // Skip the hand-rolled display/input/degenerate groups (as vs-05 does).
+                if (key == "resolution" || key == "mouse" || key == "text"
+                    || key == "accelerated_visual" || key == "color" || key == "joystick") continue;
+                PresetGroupInfo g;
+                g.key = key; g.label = kv.key();
+                for (const auto &okv : kv.value().as_object()) {
+                    PresetOptionInfo o;
+                    o.name = okv.key();
+                    if (okv.value().is_object()) {
+                        for (const auto &vv : okv.value().as_object()) {
+                            if (vv.value().is_string())
+                                o.vars.push_back({vv.key(), boost::json::value_to<std::string>(vv.value())});
+                        }
+                    }
+                    g.options.push_back(o);
+                }
+                if (!g.options.empty()) g_preset_groups.push_back(g);
+            }
+        }
+    } catch (...) {}
+    g_presets_loaded = true;
+}
+
+// ---- Single source of truth: config path <-> Configuration field ----
+//
+// C++ has no reflection, so every direction of config traffic (preset apply,
+// write-back serialize, dirty-path tracking) used to hand-encode the same
+// path<->field relationship as three separate if/else chains that could drift
+// apart (and did: graphics.bases.max_*, graphics.screen, graphics.font and
+// graphics.font_antialias were marked dirty but not readable, so they never
+// persisted). This table is the only place that maps a dotted config path to its
+// Configuration field.
+
+struct ConfigAccessor {
+    const char* path;   // dotted config.json path, e.g. "graphics.fog"
+    // Read the field's current value (used by write_out_dirty). Never null.
+    boost::json::value (*get)(const vega_config::Configuration&);
+    // Apply a preset string value (used by apply_preset_var). Null if the key is
+    // not settable from a preset (it is set by a dedicated apply_* function).
+    void (*set)(vega_config::Configuration&, const std::string&);
+};
+
+static const ConfigAccessor kConfigAccessors[] = {
+    // ---- graphics ----
+    {"graphics.fog",                     [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.fog;},                   [](vega_config::Configuration&c,const std::string&v){c.graphics.fog=(v=="true"||v=="1");}},
+    {"graphics.background",              [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.background;},            [](vega_config::Configuration&c,const std::string&v){c.graphics.background=(v=="true"||v=="1");}},
+    {"graphics.blend_panels",            [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.blend_panels;},          [](vega_config::Configuration&c,const std::string&v){c.graphics.blend_panels=(v=="true"||v=="1");}},
+    {"graphics.cockpit",                 [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.cockpit;},               [](vega_config::Configuration&c,const std::string&v){c.graphics.cockpit=(v=="true"||v=="1");}},
+    {"graphics.color_depth",             [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.color_depth;},           [](vega_config::Configuration&c,const std::string&v){c.graphics.color_depth=atoi(v.c_str());}},
+    {"graphics.force_lighting",          [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.force_lighting;},        [](vega_config::Configuration&c,const std::string&v){c.graphics.force_lighting=(v=="true"||v=="1");}},
+    {"graphics.full_screen",             [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.full_screen;},           [](vega_config::Configuration&c,const std::string&v){c.graphics.full_screen=(v=="true"||v=="1");}},
+    {"graphics.reflection",              [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.reflection;},            [](vega_config::Configuration&c,const std::string&v){c.graphics.reflection=(v=="true"||v=="1");}},
+    {"graphics.smooth_lines",            [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.smooth_lines;},          [](vega_config::Configuration&c,const std::string&v){c.graphics.smooth_lines=(v=="true"||v=="1");}},
+    {"graphics.star_blend",              [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.star_blend;},            [](vega_config::Configuration&c,const std::string&v){c.graphics.star_blend=(v=="true"||v=="1");}},
+    {"graphics.draw_star_body",          [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.draw_star_body;},        [](vega_config::Configuration&c,const std::string&v){c.graphics.draw_star_body=(v=="true"||v=="1");}},
+    {"graphics.draw_star_glow",          [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.draw_star_glow;},        [](vega_config::Configuration&c,const std::string&v){c.graphics.draw_star_glow=(v=="true"||v=="1");}},
+    {"graphics.high_quality_font",       [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.high_quality_font;},     [](vega_config::Configuration&c,const std::string&v){c.graphics.high_quality_font=(v=="true"||v=="1");}},
+    {"graphics.high_quality_font_computer",[](const vega_config::Configuration&c)->boost::json::value{return c.graphics.high_quality_font_computer;},[](vega_config::Configuration&c,const std::string&v){c.graphics.high_quality_font_computer=(v=="true"||v=="1");}},
+    {"graphics.high_quality_sprites",    [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.high_quality_sprites;},  [](vega_config::Configuration&c,const std::string&v){c.graphics.high_quality_sprites=(v=="true"||v=="1");}},
+    {"graphics.per_pixel_lighting",      [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.per_pixel_lighting;},    [](vega_config::Configuration&c,const std::string&v){c.graphics.per_pixel_lighting=(v=="true"||v=="1");}},
+    {"graphics.specmap_with_reflection", [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.specmap_with_reflection;},[](vega_config::Configuration&c,const std::string&v){c.graphics.specmap_with_reflection=(v=="true"||v=="1");}},
+    {"graphics.gl_accelerated_visual",   [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.gl_accelerated_visual;}, [](vega_config::Configuration&c,const std::string&v){c.graphics.gl_accelerated_visual=(v=="true"||v=="1");}},
+    {"graphics.aspect",                  [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.aspect_flt;},            [](vega_config::Configuration&c,const std::string&v){c.graphics.aspect_flt=(float)atof(v.c_str());c.graphics.aspect_dbl=atof(v.c_str());}},
+    {"graphics.font_point",              [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.font_point_flt;},        [](vega_config::Configuration&c,const std::string&v){c.graphics.font_point_flt=(float)atof(v.c_str());c.graphics.font_point_dbl=atof(v.c_str());}},
+    {"graphics.model_detail",            [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.model_detail_flt;},      [](vega_config::Configuration&c,const std::string&v){c.graphics.model_detail_flt=(float)atof(v.c_str());c.graphics.model_detail_dbl=atof(v.c_str());}},
+    {"graphics.mipmap_detail",           [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.mipmap_detail;},         [](vega_config::Configuration&c,const std::string&v){c.graphics.mipmap_detail=atoi(v.c_str());}},
+    {"graphics.planet_detail_level",     [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.planet_detail_level;},   [](vega_config::Configuration&c,const std::string&v){c.graphics.planet_detail_level=atoi(v.c_str());}},
+    {"graphics.resolution_x",            [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.resolution_x;},          [](vega_config::Configuration&c,const std::string&v){c.graphics.resolution_x=atoi(v.c_str());}},
+    {"graphics.resolution_y",            [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.resolution_y;},          [](vega_config::Configuration&c,const std::string&v){c.graphics.resolution_y=atoi(v.c_str());}},
+    {"graphics.max_cubemap_size",        [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.max_cubemap_size;},      [](vega_config::Configuration&c,const std::string&v){c.graphics.max_cubemap_size=atoi(v.c_str());}},
+    {"graphics.max_movie_dimension",     [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.max_movie_dimension;},   [](vega_config::Configuration&c,const std::string&v){c.graphics.max_movie_dimension=atoi(v.c_str());}},
+    {"graphics.max_texture_dimension",   [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.max_texture_dimension;}, [](vega_config::Configuration&c,const std::string&v){c.graphics.max_texture_dimension=atoi(v.c_str());}},
+    {"graphics.technique_set",           [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.graphics.technique_set);},         [](vega_config::Configuration&c,const std::string&v){c.graphics.technique_set=v;}},
+    {"graphics.mac_shader_name",         [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.graphics.mac_shader_name);},       [](vega_config::Configuration&c,const std::string&v){c.graphics.mac_shader_name=v;}},
+    {"graphics.default_full_technique",  [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.graphics.default_full_technique);},[](vega_config::Configuration&c,const std::string&v){c.graphics.default_full_technique=v;}},
+    {"graphics.default_simple_technique",[](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.graphics.default_simple_technique);},[](vega_config::Configuration&c,const std::string&v){c.graphics.default_simple_technique=v;}},
+    {"graphics.faction_dependent_textures",[](const vega_config::Configuration&c)->boost::json::value{return c.graphics.faction_dependent_textures;},[](vega_config::Configuration&c,const std::string&v){c.graphics.faction_dependent_textures=(v=="true"||v=="1");}},
+    {"graphics.draw_rendered_crosshairs",[](const vega_config::Configuration&c)->boost::json::value{return c.graphics.draw_rendered_crosshairs;},nullptr},
+    {"graphics.bases.max_width",         [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.bases.max_width;},        nullptr},
+    {"graphics.bases.max_height",        [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.bases.max_height;},       nullptr},
+    {"graphics.font",                    [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.graphics.font);},                  nullptr},
+    {"graphics.font_antialias",          [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.font_antialias;},        nullptr},
+    {"graphics.screen",                  [](const vega_config::Configuration&c)->boost::json::value{return c.graphics.screen;},                nullptr},
+    // ---- audio ----
+    {"audio.ai_sound",                   [](const vega_config::Configuration&c)->boost::json::value{return c.audio.ai_sound;},                 [](vega_config::Configuration&c,const std::string&v){c.audio.ai_sound=(v=="true"||v=="1");}},
+    {"audio.every_other_mount",          [](const vega_config::Configuration&c)->boost::json::value{return c.audio.every_other_mount;},        [](vega_config::Configuration&c,const std::string&v){c.audio.every_other_mount=(v=="true"||v=="1");}},
+    {"audio.music",                      [](const vega_config::Configuration&c)->boost::json::value{return c.audio.music;},                    [](vega_config::Configuration&c,const std::string&v){c.audio.music=(v=="true"||v=="1");}},
+    {"audio.sound",                      [](const vega_config::Configuration&c)->boost::json::value{return c.audio.sound;},                    [](vega_config::Configuration&c,const std::string&v){c.audio.sound=(v=="true"||v=="1");}},
+    {"audio.positional",                 [](const vega_config::Configuration&c)->boost::json::value{return c.audio.positional;},               [](vega_config::Configuration&c,const std::string&v){c.audio.positional=(v=="true"||v=="1");}},
+    {"audio.music_volume",               [](const vega_config::Configuration&c)->boost::json::value{return c.audio.music_volume_flt;},         [](vega_config::Configuration&c,const std::string&v){c.audio.music_volume_flt=(float)atof(v.c_str());c.audio.music_volume_dbl=atof(v.c_str());}},
+    {"audio.volume",                     [](const vega_config::Configuration&c)->boost::json::value{return c.audio.volume_flt;},               [](vega_config::Configuration&c,const std::string&v){c.audio.volume_flt=(float)atof(v.c_str());c.audio.volume_dbl=atof(v.c_str());}},
+    {"audio.max_single_sounds",          [](const vega_config::Configuration&c)->boost::json::value{return c.audio.max_single_sounds;},        [](vega_config::Configuration&c,const std::string&v){c.audio.max_single_sounds=atoi(v.c_str());}},
+    {"audio.max_total_sounds",           [](const vega_config::Configuration&c)->boost::json::value{return c.audio.max_total_sounds;},         [](vega_config::Configuration&c,const std::string&v){c.audio.max_total_sounds=atoi(v.c_str());}},
+    {"audio.sounds_extension_1",         [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.cockpit_audio.sounds_extension_1);},[](vega_config::Configuration&c,const std::string&v){c.cockpit_audio.sounds_extension_1=v;}},
+    {"audio.sounds_extension_2",         [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.cockpit_audio.sounds_extension_2);},[](vega_config::Configuration&c,const std::string&v){c.cockpit_audio.sounds_extension_2=v;}},
+    // ---- physics ----
+    {"physics.game_speed",               [](const vega_config::Configuration&c)->boost::json::value{return c.physics.game_speed_flt;},         [](vega_config::Configuration&c,const std::string&v){c.physics.game_speed_flt=(float)atof(v.c_str());c.physics.game_speed_dbl=atof(v.c_str());}},
+    {"physics.game_accel",               [](const vega_config::Configuration&c)->boost::json::value{return c.physics.game_accel_flt;},         [](vega_config::Configuration&c,const std::string&v){c.physics.game_accel_flt=(float)atof(v.c_str());c.physics.game_accel_dbl=atof(v.c_str());}},
+    {"physics.inactive_system_time",     [](const vega_config::Configuration&c)->boost::json::value{return c.physics.inactive_system_time_flt;},[](vega_config::Configuration&c,const std::string&v){c.physics.inactive_system_time_flt=(float)atof(v.c_str());c.physics.inactive_system_time_dbl=atof(v.c_str());}},
+    {"physics.num_running_systems",      [](const vega_config::Configuration&c)->boost::json::value{return c.physics.num_running_systems;},    [](vega_config::Configuration&c,const std::string&v){c.physics.num_running_systems=atoi(v.c_str());}},
+    // ---- general ----
+    {"general.num_old_systems",          [](const vega_config::Configuration&c)->boost::json::value{return c.general.num_old_systems;},        [](vega_config::Configuration&c,const std::string&v){c.general.num_old_systems=atoi(v.c_str());}},
+    {"general.simulation_atom",          [](const vega_config::Configuration&c)->boost::json::value{return c.general.simulation_atom_flt;},    [](vega_config::Configuration&c,const std::string&v){c.general.simulation_atom_flt=(float)atof(v.c_str());c.general.simulation_atom_dbl=atof(v.c_str());}},
+    // ---- joystick (input.joystick) ----
+    {"input.joystick.mouse_cursor",      [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_cursor;},          [](vega_config::Configuration&c,const std::string&v){c.joystick.mouse_cursor=(v=="true"||v=="1");}},
+    {"input.joystick.mouse_sensitivity", [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_sensitivity_flt;}, [](vega_config::Configuration&c,const std::string&v){c.joystick.mouse_sensitivity_flt=(float)atof(v.c_str());c.joystick.mouse_sensitivity_dbl=atof(v.c_str());}},
+    {"input.joystick.reverse_mouse_spr", [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.reverse_mouse_spr;},     [](vega_config::Configuration&c,const std::string&v){c.joystick.reverse_mouse_spr=(v=="true"||v=="1");}},
+    {"input.joystick.warp_mouse",        [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.warp_mouse;},            [](vega_config::Configuration&c,const std::string&v){c.joystick.warp_mouse=(v=="true"||v=="1");}},
+    {"input.joystick.force_use_of_joystick",[](const vega_config::Configuration&c)->boost::json::value{return c.joystick.force_use_of_joystick;},[](vega_config::Configuration&c,const std::string&v){c.joystick.force_use_of_joystick=(v=="true"||v=="1");}},
+    {"input.joystick.mouse_cursor_pancam",[](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_cursor_pancam;},  nullptr},
+    {"input.joystick.mouse_cursor_pantgt",[](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_cursor_pantgt;},  nullptr},
+    {"input.joystick.mouse_cursor_chasecam",[](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_cursor_chasecam;},nullptr},
+    {"input.joystick.warp_mouse_zone",   [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.warp_mouse_zone;},       nullptr},
+    {"input.joystick.mouse_exponent",    [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_exponent_flt;},   nullptr},
+    {"input.joystick.mouse_deadband",    [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.mouse_deadband_flt;},   nullptr},
+    {"input.joystick.deadband",          [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.deadband_flt;},         nullptr},
+    {"input.joystick.force_feedback",    [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.force_feedback;},       nullptr},
+    {"input.joystick.ff_device",         [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.ff_device;},            nullptr},
+    {"input.joystick.enabled",           [](const vega_config::Configuration&c)->boost::json::value{return c.joystick.enabled;},              nullptr},
+    // ---- input ----
+    {"input.device",                     [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.input.device);},                  nullptr},
+    {"input.mouse_preset",               [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.input.mouse_preset);},            nullptr},
+    {"input.mouse.enabled",              [](const vega_config::Configuration&c)->boost::json::value{return c.mouse.enabled;},                 nullptr},
+    {"input.mouse.inverse_x",            [](const vega_config::Configuration&c)->boost::json::value{return c.mouse.inverse_x;},               nullptr},
+    {"input.mouse.inverse_y",            [](const vega_config::Configuration&c)->boost::json::value{return c.mouse.inverse_y;},               nullptr},
+    // ---- splash / test ----
+    {"splash.loading_sprite",            [](const vega_config::Configuration&c)->boost::json::value{return boost::json::value(c.splash.loading_sprite);},          [](vega_config::Configuration&c,const std::string&v){c.splash.loading_sprite=v;}},
+    {"test.autodocker",                  [](const vega_config::Configuration&c)->boost::json::value{return c.test.autodocker;},                [](vega_config::Configuration&c,const std::string&v){c.test.autodocker=(v=="true"||v=="1");}},
+};
+
+static const ConfigAccessor* by_path(const std::string &path) {
+    for (const auto &a : kConfigAccessors) {
+        if (path == a.path) return &a;
+    }
+    return nullptr;
+}
+
+// Resolve a bare preset variable name (e.g. "fog") to its accessor by matching
+// the leaf of the dotted path. Preset names are always the path leaf; a few leaves
+// are ambiguous ("enabled": input.mouse vs input.joystick) but those are never
+// preset-applied (their set is null), so leaf lookup is unambiguous for the
+// preset set.
+static const ConfigAccessor* by_leaf(const std::string &leaf) {
+    for (const auto &a : kConfigAccessors) {
+        std::string p(a.path);
+        if (p.substr(p.find_last_of('.') + 1) == leaf) return &a;
+    }
+    return nullptr;
+}
+
+// Read the current value of a Configuration field given its dotted path. Returns
+// a JSON value, or null if unknown.
+static boost::json::value read_config_value(const std::string &path) {
+    const ConfigAccessor* a = by_path(path);
+    return a ? a->get(configuration()) : boost::json::value(nullptr);
+}
+
+// Apply one preset variable (name,value) to the engine's Configuration, using
+// the field names the engine's load_config reads. Returns true if it set something.
+static bool apply_preset_var(const std::string &name, const std::string &value) {
+    const ConfigAccessor* a = by_leaf(name);
+    if (!a || !a->set) return false;
+    a->set(cfg(), value);
+    // Persist the resolved value to config.json via its real dotted path (so it
+    // survives a restart), not the synthetic preset_var.<name> path.
+    mark_dirty(a->path);
+    return true;
+}
+
+// Apply the currently-selected option's vars for every displayed preset group
+// (the active preset selection), so the displayed presets are always persisted
+// to config.json on Save — not only when the user happens to change a combo.
+// Called from the Save/apply_all path.
+static void apply_presets_to_config() {
+    for (const auto &g : g_preset_groups) {
+        std::string cur = configuration().preset.count(g.key) ? configuration().preset.at(g.key) : "";
+        if (cur.empty()) continue;
+        for (const auto &o : g.options) {
+            if (o.name == cur) {
+                for (const auto &kv : o.vars) apply_preset_var(kv.first, kv.second);
+                break;
+            }
+        }
+    }
+}
+
+// Draw the preset grid (vs-05 layout: group + combo, centered, 3 columns).
+static void draw_presets_frame() {
+    load_presets();
+    if (g_preset_groups.empty()) {
+        ImGui::TextWrapped("No presets loaded (engine.json presets not found).");
+        return;
+    }
+    int cols = 3;
+    // Wrap the grid in its own bordered frame (own frame, above the button bar).
+    // Auto-scale with the window: more columns when there's width, and the
+    // frame fills the vertical space down to the bottom button bar.
+    const float avail_w = ImGui::GetContentRegionAvail().x;
+    if (avail_w < 700) cols = 1;
+    else if (avail_w < 1200) cols = 2;
+    else cols = 3;
+    cols = std::min(cols, (int)g_preset_groups.size());
+    int rows = (int)ceil((double)g_preset_groups.size() / (double)cols);
+    float row_h = ImGui::GetFrameHeight() + ImGui::GetTextLineHeight()
+                  + ImGui::GetStyle().ItemSpacing.y;
+    float content_h = rows * row_h + ImGui::GetStyle().WindowPadding.y * 2;
+    // Fill the space between here and the bottom button bar (which reserves one
+    // button row + separator at the bottom, btn_h). The frame should reach the
+    // buttons so there is no dead space, and be tall enough that all presets are
+    // visible without a scrollbar.
+    float btn_h = ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
+    float avail_h = ImGui::GetContentRegionAvail().y - btn_h
+                    - ImGui::GetStyle().WindowPadding.y;
+    float pres_h = fmaxf(content_h, avail_h);
+    ImGui::BeginChild("presetsframe", ImVec2(-1.0f, pres_h), ImGuiChildFlags_Borders);
+    std::vector<float> colw(cols, 0.0f);
+    for (size_t i = 0; i < g_preset_groups.size(); i++) {
+        auto &g = g_preset_groups[i];
+        float cw = 0;
+        for (auto &o : g.options) cw = fmaxf(cw, ImGui::CalcTextSize(o.name.c_str()).x);
+        cw += ImGui::GetFrameHeight() + ImGui::GetStyle().ItemInnerSpacing.x;
+        cw = fmaxf(cw, ImGui::CalcTextSize(g.label.c_str()).x);
+        colw[i % cols] = fmaxf(colw[i % cols], cw);
+    }
+    float total_w = 0;
+    for (auto c : colw) total_w += c;
+    ImGui::SetCursorPosX(fmaxf(0.0f, (ImGui::GetContentRegionAvail().x - total_w) * 0.5f));
+    if (ImGui::BeginTable("modern_presets", cols, ImGuiTableFlags_SizingFixedFit)) {
+        for (size_t i = 0; i < g_preset_groups.size(); i++) {
+            auto &g = g_preset_groups[i];
+            ImGui::TableNextColumn();
+            ImGui::Text("%s", g.label.c_str());
+            std::string cur = configuration().preset.count(g.key) ? configuration().preset.at(g.key) : "";
+            int sel = 0;
+            for (size_t j = 0; j < g.options.size(); ++j)
+                if (g.options[j].name == cur) { sel = (int)j; break; }
+            float cw = 0;
+            for (auto &o : g.options) cw = fmaxf(cw, ImGui::CalcTextSize(o.name.c_str()).x);
+            ImGui::SetNextItemWidth(cw + ImGui::GetFrameHeight() + ImGui::GetStyle().ItemInnerSpacing.x);
+            std::vector<const char *> items;
+            for (auto &o : g.options) items.push_back(o.name.c_str());
+            std::string lbl = "##mpre_" + g.key;
+            if (ImGui::Combo(lbl.c_str(), &sel, items.data(), (int)items.size())) {
+                if (sel >= 0) {
+                    cfg().preset[g.key] = g.options[sel].name;
+                    mark_dirty("preset." + g.key);
+                    // Apply the preset's vars to Configuration.
+                    for (auto &kv : g.options[sel].vars) apply_preset_var(kv.first, kv.second);
+                }
+            }
+        }
+        ImGui::EndTable();
+    }
+    ImGui::EndChild();   // end presetsframe
+}
+
+} // namespace
+
+void DrawConfigScreen() {
+    // Load flight-control mode from the persisted input.device once.
+    static bool s_loaded = false;
+    if (!s_loaded) {
+        s_loaded = true;
+        const std::string &dev = configuration().input.device;
+        flight_control = (dev == "mouse") ? FC_MOUSE : (dev == "joystick") ? FC_JOYSTICK : FC_KEYBOARD;
+        if (flight_control == FC_MOUSE) load_mouse_staging();
+        else if (flight_control == FC_JOYSTICK) load_joystick_staging();
+    }
+    // Cover the whole screen (game resolution), not a floating window.
+    ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(configuration().graphics.resolution_x,
+                                    configuration().graphics.resolution_y), ImGuiCond_Always);
+    ImGui::Begin("Config", nullptr,
+                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
+                 ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoCollapse);
+    ImGui::Text("vs-settings-ng — Configuration");
+    ImGui::Separator();
+
+    draw_display_frame();
+
+    // Fullscreen / windowed toggle (live-applied on Save).
+    if (ImGui::Checkbox("Fullscreen", &cfg_full_screen)) dirty = true;
+
+    // Rendered crosshair toggle (vs-05 had it in the display/button area).
+    if (ImGui::Checkbox("Rendered Crosshair", &rendered_crosshair)) dirty = true;
+
+    ImGui::Separator();
+    ImGui::TextUnformatted(dirty ? "(unsaved changes)" : "(saved)");
+
+    // Presets frame (own frame, above the button bar).
+    ImGui::Separator();
+    draw_presets_frame();
+
+    // Bottom button bar, pinned to the bottom of the window and centered.
+    auto apply_all = [&]() {
+        apply_display_to_config();
+        apply_presets_to_config();
+        apply_flight_to_config();
+        apply_mouse_to_config();
+        apply_joystick_to_config();
+        // Live-apply input bindings/axes/device: re-run the bind path so key,
+        // mouse, joystick and flight-device changes take effect immediately
+        // (not just after a restart). Only when an input-related setting changed.
+        static const char *input_prefixes[] = {"bindings.", "input.", nullptr};
+        bool input_changed = false;
+        for (const auto &path : g_dirty_paths) {
+            for (const char **p = input_prefixes; *p; ++p) {
+                if (path.rfind(*p, 0) == 0) { input_changed = true; break; }
+            }
+            if (input_changed) break;
+        }
+        if (input_changed && vs_config != nullptr) {
+            vs_config->bindKeys();   // virtual: GameVegaConfig::bindKeys()
+        }
+    };
+    auto close_overlay = [&]() {
+        if (_Universe) _Universe->ToggleOptionsActive();   // close; hide cursor on inactive
+    };
+    float btnw = ImGui::CalcTextSize("Save").x + ImGui::GetStyle().FramePadding.x * 2 + 20;
+    float btn_h = ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
+    // Reserve space at the bottom for the button row (separator + buttons), just
+    // tall enough to contain the buttons, centered.
+    ImGui::SetCursorPosY(ImGui::GetWindowHeight() - btn_h);
+    float avail = ImGui::GetContentRegionAvail().x;
+    ImGui::SetCursorPosX(fmaxf(0.0f, (avail - (btnw * 2 + ImGui::GetStyle().ItemSpacing.x)) * 0.5f));
+    ImGui::Separator();
+
+    // Save (green when dirty): apply + persist, stay open. Only Close closes.
+    const bool save_was_dirty = dirty;
+    if (save_was_dirty) {
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.10f, 0.45f, 0.22f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.15f, 0.55f, 0.30f, 1.0f));
+    }
+    if (ImGui::Button("Save", ImVec2(btnw, 0))) {
+        if (dirty) {
+            apply_all();
+            write_out_dirty();   // persist the dirty paths to the user overlay
+            dirty = false;
+            // Stay open: the player can keep tweaking and Save again.
+        }
+    }
+    if (save_was_dirty) ImGui::PopStyleColor(2);
+    ImGui::SameLine();
+
+    // Close (red when dirty): don't save anything, just close.
+    if (dirty) {
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.80f, 0.25f, 0.25f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.90f, 0.35f, 0.35f, 1.0f));
+    }
+    if (ImGui::Button("Close", ImVec2(btnw, 0))) {
+        // Don't save anything; just close. Dirty state is intentionally discarded.
+        close_overlay();
+    }
+    if (dirty) ImGui::PopStyleColor(2);
+
+    // Input dialogs (open as modals on top).
+    if (mouse_dialog_open) ImGui::OpenPopup("Mouse Settings");
+    if (joy_dialog_open) ImGui::OpenPopup("Joystick Settings");
+    draw_mouse_dialog();
+    draw_joystick_dialog();
+
+    // Bindings dialog (modal on top).
+    if (bind_dialog_open) ImGui::OpenPopup("Bindings");
+    draw_bindings_dialog();
+
+    ImGui::End();
+}
+
+void HandleConfigEvent(const SDL_Event *event) {
+    // Binding capture + joystick hotplug (only meaningful while the config screen is open).
+    handle_bindings_event(event);
+}
+
+} // namespace vs_settings_ng

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -17,6 +17,7 @@
 #include "vegadisk/vsfilesystem.h"
 #include "root_generic/vs_globals.h"
 #include "config_xml.h"
+#include "gfxlib.h"
 #include "cmd/music.h"
 #include "src/audiolib.h"
 #include <boost/json.hpp>
@@ -708,6 +709,9 @@ static void reinit_from_saved_config() {
     // Graphics: g_game feature flags + gl_options + GL viewport (reuses initfov
     // and reapply_gl_options, the same copy code as bootstrap).
     GFXReinitConfig();
+    // Shader: re-read the configured shader name and recompile (a stale
+    // hifiProgramName otherwise yields funky colors until restart).
+    GFXApplyShaderSetting();
     // Audio/volume: re-apply the live volume functions from the new config.
     AUDReapplyConfig();
     Music::SetVolume(configuration().audio.music_volume_flt, -1, false);

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -20,6 +20,7 @@
 #include "gfxlib.h"
 #include "cmd/music.h"
 #include "src/audiolib.h"
+#include "src/vs_exit.h"
 #include <boost/json.hpp>
 #include <boost/filesystem.hpp>
 #include "imgui/imgui.h"
@@ -1681,11 +1682,14 @@ void DrawConfigScreen() {
     float btnw = ImGui::CalcTextSize("Save").x + ImGui::GetStyle().FramePadding.x * 2 + 20;
     float btn_h = ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
     // Reserve space at the bottom for the button row (separator + buttons), just
-    // tall enough to contain the buttons, centered.
+    // Reserve space at the bottom for the button row (separator + buttons).
     ImGui::SetCursorPosY(ImGui::GetWindowHeight() - btn_h);
-    float avail = ImGui::GetContentRegionAvail().x;
-    ImGui::SetCursorPosX(fmaxf(0.0f, (avail - (btnw * 2 + ImGui::GetStyle().ItemSpacing.x)) * 0.5f));
     ImGui::Separator();
+    // Center the three buttons (Save + Close + Quit). SetCursorPosX must be applied
+    // AFTER the Separator, which resets the cursor X to the left margin.
+    float avail = ImGui::GetContentRegionAvail().x;
+    float buttons_w = btnw * 3 + ImGui::GetStyle().ItemSpacing.x * 2;
+    ImGui::SetCursorPosX(fmaxf(0.0f, (avail - buttons_w) * 0.5f));
 
     // Save (green when dirty): apply + persist, stay open. Only Close closes.
     const bool save_was_dirty = dirty;
@@ -1728,6 +1732,16 @@ void DrawConfigScreen() {
         close_overlay();
     }
     if (dirty) ImGui::PopStyleColor(2);
+    ImGui::SameLine();
+
+    // Quit (red): exit the game entirely. Unsaved changes are discarded. The full
+    // cleanup path (flush logs, save game, close audio/window) is VSExit(0).
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.80f, 0.25f, 0.25f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.90f, 0.35f, 0.35f, 1.0f));
+    if (ImGui::Button("Quit", ImVec2(btnw, 0))) {
+        VSExit(0);
+    }
+    ImGui::PopStyleColor(2);
 
     // Input dialogs (open as modals on top).
     if (mouse_dialog_open) ImGui::OpenPopup("Mouse Settings");

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -12,10 +12,13 @@
 
 #include "configuration/configuration.h"
 #include "gldrv/winsys.h"
+#include "gldrv/gl_init.h"
 #include "universe.h"
 #include "vegadisk/vsfilesystem.h"
 #include "root_generic/vs_globals.h"
 #include "config_xml.h"
+#include "cmd/music.h"
+#include "src/audiolib.h"
 #include <boost/json.hpp>
 #include <boost/filesystem.hpp>
 #include "imgui/imgui.h"
@@ -693,6 +696,21 @@ static boost::json::object read_existing_overlay(const std::string &path) {
         } catch (...) { /* corrupt/partial — start fresh */ }
     }
     return obj;
+}
+
+// Re-initialize the runtime from the in-memory configuration() after an in-game
+// settings Save. The game historically assumed the config never changes in-game:
+// config->runtime copies (g_game feature flags, gl_options, GL viewport, legacy
+// font metrics, audio/music volume) ran once at bootstrap and went stale on an
+// in-game change. This re-binds them so the change takes effect without a restart.
+// A brief re-orient pause is expected (and acceptable). See gldrv/gl_init.h.
+static void reinit_from_saved_config() {
+    // Graphics: g_game feature flags + gl_options + GL viewport (reuses initfov
+    // and reapply_gl_options, the same copy code as bootstrap).
+    GFXReinitConfig();
+    // Audio/volume: re-apply the live volume functions from the new config.
+    AUDReapplyConfig();
+    Music::SetVolume(configuration().audio.music_volume_flt, -1, false);
 }
 
 // Write the accumulated dirty config paths out to the user config files
@@ -1705,6 +1723,13 @@ void DrawConfigScreen() {
         if (dirty) {
             apply_all();
             write_out_dirty();   // persist the dirty paths to the user overlay
+            // Re-initialize the runtime from the updated in-memory configuration().
+            // The game assumed config never changes in-game, so config->runtime
+            // copies (g_game feature flags, gl_options, GL viewport, legacy font
+            // metrics, audio volume) ran only at bootstrap and went stale on an
+            // in-game change. This re-binds them so the change takes effect
+            // without a restart. A brief re-orient pause is expected.
+            reinit_from_saved_config();
             dirty = false;
             // Stay open: the player can keep tweaking and Save again.
         }

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -509,6 +509,13 @@ static void apply_flight_to_config() {
     cfg().input.device = (flight_control == FC_MOUSE) ? "mouse"
                        : (flight_control == FC_JOYSTICK) ? "joystick" : "keyboard";
     mark_dirty("input.device");
+    // The enabled flags reflect the active flight-control device (mutually exclusive),
+    // so the cursor logic (mouse.enabled) and bindKeys gating stay consistent on
+    // hot-apply, matching a restart with the saved mode.
+    cfg().mouse.enabled = (flight_control == FC_MOUSE);
+    j.enabled = (flight_control == FC_JOYSTICK);
+    mark_dirty("input.mouse.enabled");
+    mark_dirty("input.joystick.enabled");
     if (flight_control == FC_MOUSE) {
         j.force_use_of_joystick = false;
         j.warp_mouse = true;

--- a/engine/src/gui/config_screen.cpp
+++ b/engine/src/gui/config_screen.cpp
@@ -18,9 +18,9 @@
 #include "config_xml.h"
 #include <boost/json.hpp>
 #include <boost/filesystem.hpp>
-#include <imgui.h>
+#include "imgui/imgui.h"
 #include "libraries/gui/gui.h"
-#include <SDL3/SDL.h>
+#include <SDL2/SDL.h>
 #include <algorithm>
 #include <vector>
 #include <string>
@@ -40,7 +40,7 @@ namespace {
 // Display frame state (mirrors vs-05 modern_ui.cpp)
 // ---------------------------------------------------------------------------
 int  sel_monitor = 0;
-SDL_DisplayID sel_display_id = 0;
+int  sel_display_id = 0;
 int  sel_res_w = 0, sel_res_h = 0;
 std::string monitor_text, resolution_text;
 char text_height_buf[16] = "16";
@@ -154,20 +154,23 @@ static int suggested_bitmap_size(int family) {
     return best;
 }
 
-static bool highest_monitor_resolution(SDL_DisplayID id, int &w, int &h) {
-    int cnt = 0;
-    SDL_DisplayMode **modes = SDL_GetFullscreenDisplayModes(id, &cnt);
-    if (!modes || cnt == 0) {
-        const SDL_DisplayMode *cm = SDL_GetCurrentDisplayMode(id);
-        if (cm) { w = cm->w; h = cm->h; return true; }
+static bool highest_monitor_resolution(int id, int &w, int &h) {
+    int cnt = SDL_GetNumDisplayModes(id);
+    if (cnt <= 0) {
+        SDL_DisplayMode cm;
+        if (SDL_GetCurrentDisplayMode(id, &cm) == 0) { w = cm.w; h = cm.h; return true; }
         return false;
     }
     int best_i = 0, best_area = -1;
     for (int i = 0; i < cnt; i++) {
-        int area = modes[i]->w * modes[i]->h;
+        SDL_DisplayMode mode;
+        if (SDL_GetDisplayMode(id, i, &mode) != 0) continue;
+        int area = mode.w * mode.h;
         if (area > best_area) { best_area = area; best_i = i; }
     }
-    w = modes[best_i]->w; h = modes[best_i]->h;
+    SDL_DisplayMode best;
+    if (SDL_GetDisplayMode(id, best_i, &best) != 0) return false;
+    w = best.w; h = best.h;
     return true;
 }
 
@@ -220,13 +223,12 @@ static void load_display_from_config() {
     snprintf(text_height_buf, sizeof(text_height_buf), "%d", fp);
     // screen (monitor) index.
     sel_monitor = g.screen;
-    int nd = 0; SDL_DisplayID *ids = SDL_GetDisplays(&nd);
+    int nd = SDL_GetNumVideoDisplays();
     if (nd < 1) nd = 1;
     if (sel_monitor >= nd) sel_monitor = 0;
-    sel_display_id = ids ? ids[sel_monitor] : 0;
-    const char *nm = sel_display_id ? SDL_GetDisplayName(sel_display_id) : NULL;
+    sel_display_id = sel_monitor;
+    const char *nm = sel_display_id >= 0 ? SDL_GetDisplayName(sel_display_id) : NULL;
     monitor_text = std::to_string(sel_monitor) + "  " + (nm ? nm : "(unnamed)");
-    if (ids) SDL_free(ids);
     // Font type from high_quality_font + font_antialias (vector AA / vector / bitmap).
     if (!g.high_quality_font && g.font_antialias) sel_font_type = FONT_AA_VEC;
     else if (!g.high_quality_font && !g.font_antialias) sel_font_type = FONT_VEC;
@@ -326,41 +328,39 @@ void draw_display_frame() {
     if (ImGui::Button("Monitor")) ImGui::OpenPopup("##pick_mon");
     ImGui::SameLine(); ImGui::TextUnformatted(monitor_text.c_str());
     if (ImGui::BeginPopup("##pick_mon")) {
-        int nd = 0; SDL_DisplayID *ids = SDL_GetDisplays(&nd);
+        int nd = SDL_GetNumVideoDisplays();
         for (int i = 0; i < nd; ++i) {
-            const char *nm = SDL_GetDisplayName(ids[i]);
+            const char *nm = SDL_GetDisplayName(i);
             char lbl[160]; snprintf(lbl, sizeof(lbl), "%d  %s", i, nm ? nm : "(unnamed)");
             if (ImGui::MenuItem(lbl)) {
-                sel_monitor = i; sel_display_id = ids[i];
+                sel_monitor = i; sel_display_id = i;
                 monitor_text = lbl; dirty = true;
-                const SDL_DisplayMode *cm = SDL_GetCurrentDisplayMode(ids[i]);
-                if (cm) { sel_res_w = cm->w; sel_res_h = cm->h;
-                    resolution_text = std::to_string(cm->w) + "x" + std::to_string(cm->h);
+                SDL_DisplayMode cm;
+                if (SDL_GetCurrentDisplayMode(i, &cm) == 0) { sel_res_w = cm.w; sel_res_h = cm.h;
+                    resolution_text = std::to_string(cm.w) + "x" + std::to_string(cm.h);
                     if (sel_screen_aspect < 0) refresh_screen_aspect_text(); }
             }
         }
-        if (ids) SDL_free(ids);
         ImGui::EndPopup();
     }
     // Resolution selector (detected fullscreen modes, deduplicated).
     if (ImGui::Button("Resolution")) ImGui::OpenPopup("##pick_res");
     ImGui::SameLine(); ImGui::TextUnformatted(resolution_text.c_str());
     if (ImGui::BeginPopup("##pick_res")) {
-        int cnt = 0; SDL_DisplayMode **modes = SDL_GetFullscreenDisplayModes(sel_display_id, &cnt);
-        if (modes) {
-            std::vector<std::string> seen;
-            for (int i = 0; i < cnt; ++i) {
-                char lbl[32]; snprintf(lbl, sizeof(lbl), "%dx%d", modes[i]->w, modes[i]->h);
-                if (std::find(seen.begin(), seen.end(), lbl) != seen.end()) continue;
-                seen.push_back(lbl);
-                if (ImGui::MenuItem(lbl)) {
-                    sel_res_w = modes[i]->w; sel_res_h = modes[i]->h;
-                    resolution_text = lbl; prefill_text_height(); dirty = true;
-                    if (sel_screen_aspect < 0) refresh_screen_aspect_text();
-                }
+        int cnt = SDL_GetNumDisplayModes(sel_display_id);
+        std::vector<std::string> seen;
+        for (int i = 0; i < cnt; ++i) {
+            SDL_DisplayMode mode;
+            if (SDL_GetDisplayMode(sel_display_id, i, &mode) != 0) continue;
+            char lbl[32]; snprintf(lbl, sizeof(lbl), "%dx%d", mode.w, mode.h);
+            if (std::find(seen.begin(), seen.end(), lbl) != seen.end()) continue;
+            seen.push_back(lbl);
+            if (ImGui::MenuItem(lbl)) {
+                sel_res_w = mode.w; sel_res_h = mode.h;
+                resolution_text = lbl; prefill_text_height(); dirty = true;
+                if (sel_screen_aspect < 0) refresh_screen_aspect_text();
             }
         }
-        if (modes) SDL_free(modes);
         ImGui::EndPopup();
     }
     // Screen aspect.
@@ -479,19 +479,18 @@ static int role_for_axis(int stick, int axis) {
 // Sample the bound axes for Auto Deadband (max deflection over ~1s).
 static float joy_sample_bound_axes() {
     float m = 0.0f;
-    SDL_UpdateJoysticks();
-    int n = 0; SDL_JoystickID *ids = SDL_GetJoysticks(&n);
+    SDL_JoystickUpdate();
+    int n = SDL_NumJoysticks();
     for (int r = 0; r < 4; ++r) {
         int s = joy_bind_stick[r];
         if (s < 0 || s >= n || joy_bind_axis[r] < 0) continue;
-        SDL_Joystick *joy = SDL_OpenJoystick(ids[s]);
+        SDL_Joystick *joy = SDL_JoystickOpen(s);
         if (!joy) continue;
-        float v = SDL_GetJoystickAxis(joy, joy_bind_axis[r]) / 32768.0f;
+        float v = SDL_JoystickGetAxis(joy, joy_bind_axis[r]) / 32768.0f;
         if (v < 0) v = -v;
         if (v > m) m = v;
-        SDL_CloseJoystick(joy);
+        SDL_JoystickClose(joy);
     }
-    if (ids) SDL_free(ids);
     return m;
 }
 
@@ -821,30 +820,23 @@ static void draw_joystick_dialog() {
     if (ImGui::BeginPopupModal("Joystick Settings", &joy_dialog_open, ImGuiWindowFlags_AlwaysAutoResize)) {
         ImGui::Text("Deflect an axis to identify it, then bind it to a flight role.");
         ImGui::Separator();
-        SDL_UpdateJoysticks();   // refresh axis state (also for a just-hotplugged joystick)
-        int n = 0; SDL_JoystickID *ids = SDL_GetJoysticks(&n);
+        SDL_JoystickUpdate();   // refresh axis state (also for a just-hotplugged joystick)
+        int n = SDL_NumJoysticks();
         // Persistent open handles: open each device once and reuse across frames so a
         // hotplugged joystick's axis state stays live.
-        static std::map<SDL_JoystickID, SDL_Joystick*> g_joy_open;
-        std::set<SDL_JoystickID> present;
-        for (int i = 0; i < n; ++i) present.insert(ids[i]);
-        // close any handle whose device was removed
-        for (auto it = g_joy_open.begin(); it != g_joy_open.end();) {
-            if (present.find(it->first) == present.end()) { SDL_CloseJoystick(it->second); it = g_joy_open.erase(it); }
-            else ++it;
-        }
-        if (n <= 0 || !ids) {
+        static std::map<int, SDL_Joystick*> g_joy_open;
+        if (n <= 0) {
             ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f), "No Joystick Detected");
         } else {
             static const char *dd[] = { "none", "x", "y", "z", "throttle" };
             for (int i = 0; i < n; ++i) {
-                SDL_Joystick *joy = g_joy_open[ids[i]];
-                if (!joy) { joy = SDL_OpenJoystick(ids[i]); g_joy_open[ids[i]] = joy; }
+                SDL_Joystick *joy = g_joy_open[i];
+                if (!joy) { joy = SDL_JoystickOpen(i); g_joy_open[i] = joy; }
                 if (!joy) continue;
-                const char *nm = SDL_GetJoystickName(joy);
-                int na = SDL_GetNumJoystickAxes(joy);
+                const char *nm = SDL_JoystickName(joy);
+                int na = SDL_JoystickNumAxes(joy);
                 for (int a = 0; a < na; ++a) {
-                    float val = SDL_GetJoystickAxis(joy, a) / 32768.0f;
+                    float val = SDL_JoystickGetAxis(joy, a) / 32768.0f;
                     int role = role_for_axis(i, a);
                     char id[32]; snprintf(id, sizeof(id), "##joy%d_a%d", i, a);
                     ImGui::Text("%s A%d", nm ? nm : "Joy", a); ImGui::SameLine();
@@ -873,7 +865,6 @@ static void draw_joystick_dialog() {
                 }
             }
         }
-        if (ids) SDL_free(ids);
         ImGui::Separator();
         ImGui::Text("Deadband"); ImGui::SameLine(); ImGui::SetNextItemWidth(90);
         if (ImGui::InputText("##jdb", joy_deadband, sizeof(joy_deadband), ImGuiInputTextFlags_CharsDecimal)) dirty = true;
@@ -1061,7 +1052,7 @@ static std::vector<std::string> capture_conflicts(void) {
     return out;
 }
 
-// Map an SDL3 keycode to the config's key-name convention.
+// Map an SDL keycode to the config's key-name convention.
 static const char *config_key_name(SDL_Keycode key) {
     switch (key) {
         case SDLK_RETURN: return "return";
@@ -1095,13 +1086,9 @@ static const char *config_key_name(SDL_Keycode key) {
     }
 }
 
-// Convert an SDL joystick instance ID to its index in SDL_GetJoysticks().
-static int joystick_index_of(SDL_JoystickID which) {
-    int n = 0; SDL_JoystickID *ids = SDL_GetJoysticks(&n);
-    int idx = -1;
-    for (int i = 0; i < n; i++) if (ids[i] == which) { idx = i; break; }
-    SDL_free(ids);
-    return idx;
+// In SDL2 a joystick device index is already a list index (0..NumJoysticks-1).
+static int joystick_index_of(Sint32 which) {
+    return which >= 0 && which < SDL_NumJoysticks() ? which : -1;
 }
 
 // Map an SDL_HAT_* bitmask to its direction name; NULL for CENTERED.
@@ -1149,24 +1136,24 @@ static void accept_capture(void) {
 // Handle SDL events for binding capture + joystick hotplug.
 static void handle_bindings_event(const SDL_Event *event) {
     if (bind_capturing && cap_open && !bind_capture_cmd.empty()) {
-        if (event->type == SDL_EVENT_KEY_DOWN) {
-            SDL_Keycode kc = event->key.key;
+        if (event->type == SDL_KEYDOWN) {
+            SDL_Keycode kc = event->key.keysym.sym;
             if (kc == SDLK_LSHIFT || kc == SDLK_RSHIFT || kc == SDLK_LCTRL || kc == SDLK_RCTRL
                 || kc == SDLK_LALT || kc == SDLK_RALT || kc == SDLK_LGUI || kc == SDLK_RGUI)
                 return;
             const char *nm = config_key_name(kc);
             if (nm) {
                 std::string k = nm;
-                if ((event->key.mod & SDL_KMOD_SHIFT) && k.size() == 1 && k[0] >= 'a' && k[0] <= 'z')
+                if ((event->key.keysym.mod & KMOD_SHIFT) && k.size() == 1 && k[0] >= 'a' && k[0] <= 'z')
                     k[0] = (char)(k[0] - 'a' + 'A');
                 cap_device = "key"; cap_key = k;
-                cap_modifier = (event->key.mod & SDL_KMOD_CTRL) ? "ctrl"
-                             : ((event->key.mod & SDL_KMOD_ALT) ? "alt" : "none");
+                cap_modifier = (event->key.keysym.mod & KMOD_CTRL) ? "ctrl"
+                             : ((event->key.keysym.mod & KMOD_ALT) ? "alt" : "none");
                 cap_valid = true;
             }
             return;
         }
-        if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+        if (event->type == SDL_MOUSEBUTTONDOWN) {
             bool inframe = event->button.x >= cap_frame_pos.x && event->button.x <= cap_frame_pos.x + cap_frame_size.x
                         && event->button.y >= cap_frame_pos.y && event->button.y <= cap_frame_pos.y + cap_frame_size.y;
             if (inframe) {
@@ -1175,14 +1162,14 @@ static void handle_bindings_event(const SDL_Event *event) {
                 return;
             }
         }
-        if (event->type == SDL_EVENT_JOYSTICK_BUTTON_DOWN) {
+        if (event->type == SDL_JOYBUTTONDOWN) {
             int idx = joystick_index_of(event->jbutton.which);
             cap_device = "joystick"; cap_btn = std::to_string(event->jbutton.button);
             cap_idx = (idx < 0) ? std::to_string(event->jbutton.which) : std::to_string(idx);
             cap_modifier = "none"; cap_valid = true;
             return;
         }
-        if (event->type == SDL_EVENT_JOYSTICK_HAT_MOTION) {
+        if (event->type == SDL_JOYHATMOTION) {
             const char *dir = hat_value_name(event->jhat.value);
             if (dir) {
                 int idx = joystick_index_of(event->jhat.which);
@@ -1196,8 +1183,8 @@ static void handle_bindings_event(const SDL_Event *event) {
             return;
         }
     }
-    if (event->type == SDL_EVENT_JOYSTICK_ADDED || event->type == SDL_EVENT_JOYSTICK_REMOVED)
-        SDL_UpdateJoysticks();
+    if (event->type == SDL_JOYDEVICEADDED || event->type == SDL_JOYDEVICEREMOVED)
+        SDL_JoystickUpdate();
 }
 
 // Capture Binding modal.

--- a/engine/src/gui/config_screen.h
+++ b/engine/src/gui/config_screen.h
@@ -1,0 +1,25 @@
+// config_screen.h — in-game configuration screen for vs-settings-ng.
+//
+// Port of the vs-05 modern UI frames into the engine, drawn inside the in-game
+// ImGui overlay (DrawConfigOverlay / Alt+C). Reads and writes the engine's
+// Configuration object directly — no parallel config model.
+//
+// Temporary module; will become the engine's settings UI.
+#ifndef VS_SETTINGS_NG_CONFIG_SCREEN_H
+#define VS_SETTINGS_NG_CONFIG_SCREEN_H
+
+#include <SDL3/SDL.h>
+
+namespace vs_settings_ng {
+
+// Draw the in-game config screen. Call inside an active ImGui frame (between
+// NewFrame and Render). Draws nothing unless the config screen is active.
+void DrawConfigScreen();
+
+// Handle an SDL event (binding capture, joystick hotplug). Call from the event
+// loop. No-op unless the config screen is active.
+void HandleConfigEvent(const SDL_Event *event);
+
+} // namespace vs_settings_ng
+
+#endif

--- a/engine/src/gui/config_screen.h
+++ b/engine/src/gui/config_screen.h
@@ -8,7 +8,7 @@
 #ifndef VS_SETTINGS_NG_CONFIG_SCREEN_H
 #define VS_SETTINGS_NG_CONFIG_SCREEN_H
 
-#include <SDL3/SDL.h>
+#include <SDL2/SDL.h>
 
 namespace vs_settings_ng {
 

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -305,7 +305,15 @@ void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
     // relative stick). Without this the cursor drifts to the edges and reads as
     // absolute (glide). This is what makes warp kick in whenever the cursor
     // moves away from center, not just at the screen edge.
-    if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()) {
+    //
+    // Warp is only active in free flight: whenever the cursor is shown (settings
+    // app, docked/base, nav screen, glide-mode crosshair) warp is disabled and
+    // the mouse reads absolute (glide-like) so UI/hud interactions aren't
+    // disrupted by recentering. Cursor visibility is the single robust signal
+    // for "something else is on screen"; the game shows the cursor in those
+    // contexts and hides it only in flight.
+    if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()
+            && SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE) {
         int w = 0, h = 0;
         SDL_GetWindowSize(SDL_GL_GetCurrentWindow(), &w, &h);
         SetMousePosition(w / 2, h / 2);

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -40,6 +40,16 @@
 #include "src/in_mouse.h"
 
 #include "root_generic/options.h"
+
+// ANGLE-BASED warp-mouse scale: accumulate this many pixels of physical mouse
+// travel to reach a full -1..1 deflection (at the baseline sensitivity of 50).
+// Kept resolution-independent so a mouse movement means the same ship turn on
+// any display. Tunable like the other response vars.
+static const float MOUSE_PIXELS_PER_FULL = 250.0f;
+// Warp mouse decay time constant (seconds): the accumulated deflection decays
+// exponentially back toward center with this time constant, so the turn eases
+// off over a couple of seconds regardless of frame rate.
+static const float WARP_DECAY_TAU = 0.4f;
 #include <SDL2/SDL_joystick.h>
 #include "configuration/configuration.h"
 #include "gldrv/mouse_cursor.h"
@@ -288,13 +298,75 @@ struct mouseData {
 extern void GetMouseXY(int &mousex, int &mousey);
 
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
-    std::pair<double, double> pair = GetJoystickFromMouse();
     // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
-    // axis per mouse move). Glide uses absolute position; warp reads deltas via
-    // DealWithWarp (in_mouse.cpp), which keeps the cursor centered as needed.
+    // axis per mouse move).
     const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
-    x = static_cast<float>(pair.first) * sensitivity;
-    y = static_cast<float>(pair.second) * sensitivity;
+    if (configuration().joystick.warp_mouse) {
+        // Warp (relative mouse): the mouse movement (delta) deflects a virtual
+        // stick away from center; that deflection then decays back toward center
+        // each frame. The flight controller reads joy_axis as a continuous -1..1
+        // deflection and turns the ship toward it, so as the deflection decays the
+        // ship stops when it reaches center. This gives "move to deflect, then
+        // decay toward a stop" instead of turning forever.
+        //
+        // model:  warp += (delta * gain) [movement builds it, angle-based]
+        //         warp *= decay        [spring back to center]
+        //         clamp to -1..1
+        // The mouse_exponent shapes the response curve, and mouse_deadband gives a
+        // neutral zone so tiny jitter doesn't move the ship.
+        int dx = 0, dy = 0;
+        GetMouseDelta(dx, dy);
+        // ANGLE-BASED: map a fixed physical mouse travel to a fixed deflection,
+        // independent of screen resolution. The deflection is the NET accumulated
+        // relative mouse displacement: moving in one direction builds it, moving
+        // back subtracts it (cancels), so the ship steers to where the cursor
+        // has "displaced" regardless of absolute position.
+        const float gain = sensitivity / MOUSE_PIXELS_PER_FULL;
+        warp_x += static_cast<float>(dx) * gain;
+        warp_y += static_cast<float>(dy) * gain;
+        // Clamp the accumulated displacement to +/-5 so a huge flick doesn't
+        // overdrive the ship, while still letting the deflection move freely
+        // toward/past zero so opposite movement cancels it (the actual turn rate
+        // is clamped to -1..1 downstream in flyjoystick).
+        if (warp_x > 5.0f) { warp_x = 5.0f; }
+        if (warp_x < -5.0f) { warp_x = -5.0f; }
+        if (warp_y > 5.0f) { warp_y = 5.0f; }
+        if (warp_y < -5.0f) { warp_y = -5.0f; }
+        // Time-based decay toward center (frame-rate independent): the deflection
+        // eases back to center over WARP_DECAY_TAU seconds regardless of frame
+        // rate. This is separate from the cancel behavior (opposite movement
+        // subtracts via the accumulation above).
+        const float dt = static_cast<float>(GetElapsedTime());
+        const float decay = std::exp(-dt / WARP_DECAY_TAU);
+        warp_x *= decay;
+        warp_y *= decay;
+        // Dead-band (noise floor) and the response curve. Apply a smooth
+        // deadband that nips tiny jitter but lets the value cross through center
+        // freely so opposite movement cancels symmetrically. Use the full
+        // mouse_exponent as the response curve (warp-only knob; mouse_sensitivity
+        // is shared with glide).
+        const float dead = configuration().joystick.mouse_deadband_flt;
+        const float mexp = configuration().joystick.mouse_exponent_flt > 0.0f
+                ? configuration().joystick.mouse_exponent_flt : 1.0f;
+        auto shape = [&](float v) {
+            float a = std::fabs(v);
+            if (a <= dead) { return 0.0f; }              // neutral/noise floor
+            float s = a - dead;
+            return (v < 0.0f ? -1.0f : 1.0f) * std::pow(s, mexp);
+        };
+        // Do NOT clamp the virtual deflection tightly here: a large displacement
+        // can exceed a full deflection (so it decays over a longer time), and
+        // crucially the value must be able to move freely toward and past zero so
+        // opposite movement cancels it. The actual ship turn rate is clamped to
+        // -1..1 downstream in flyjoystick.
+        x = shape(warp_x) * sensitivity;
+        y = shape(warp_y) * sensitivity;
+    } else {
+        // Glide (absolute) mode: axis = normalized absolute cursor position.
+        std::pair<double, double> pair = GetJoystickFromMouse();
+        x = static_cast<float>(pair.first) * sensitivity;
+        y = static_cast<float>(pair.second) * sensitivity;
+    }
     z = 0;
     joy_axis[0] = x;
     joy_axis[1] = y;

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -288,13 +288,43 @@ struct mouseData {
 extern void GetMouseXY(int &mousex, int &mousey);
 
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
-    std::pair<double, double> pair = GetJoystickFromMouse();
     // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
-    // axis per mouse move). Glide uses absolute position; warp reads deltas via
-    // DealWithWarp (in_mouse.cpp), which keeps the cursor centered as needed.
+    // axis per mouse move).
     const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
-    x = static_cast<float>(pair.first) * sensitivity;
-    y = static_cast<float>(pair.second) * sensitivity;
+    // Warp (relative) mouse is only active in free flight (cursor hidden, and
+    // not while the config overlay is open), so anything on screen (settings,
+    // docked/base, nav, glide-mode crosshair) reads absolute like glide.
+    const bool warp_active = configuration().joystick.warp_mouse
+            && !winsys_config_overlay_active()
+            && SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE;
+    if (warp_active) {
+        // Warp (relative) mode: integrate the movement deltas into a virtual
+        // stick deflection, and decay it back toward neutral each frame. The
+        // flight controller reads joy_axis as a continuous -1..1 deflection, so
+        // a real stick held at a deflection gives continuous turning. Using the
+        // raw delta directly would produce a single one-shot pulse per motion
+        // event ("one step" behavior). Deltas are independent of absolute
+        // cursor position (works at screen edges) and never move the OS cursor.
+        int dx = 0, dy = 0;
+        GetMouseDelta(dx, dy);
+        warp_x += static_cast<float>(dx) / (native_resolution_x / 2.0F);
+        warp_y += static_cast<float>(dy) / (native_resolution_y / 2.0F);
+        // Decay toward neutral (stick returns to center as you stop moving).
+        warp_x *= 0.82F;
+        warp_y *= 0.82F;
+        // Clamp to valid deflection range.
+        if (warp_x > 1.0F) { warp_x = 1.0F; }
+        if (warp_x < -1.0F) { warp_x = -1.0F; }
+        if (warp_y > 1.0F) { warp_y = 1.0F; }
+        if (warp_y < -1.0F) { warp_y = -1.0F; }
+        x = warp_x * sensitivity;
+        y = warp_y * sensitivity;
+    } else {
+        // Glide (absolute) mode: axis = normalized absolute cursor position.
+        std::pair<double, double> pair = GetJoystickFromMouse();
+        x = static_cast<float>(pair.first) * sensitivity;
+        y = static_cast<float>(pair.second) * sensitivity;
+    }
     z = 0;
     joy_axis[0] = x;
     joy_axis[1] = y;

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -288,43 +288,13 @@ struct mouseData {
 extern void GetMouseXY(int &mousex, int &mousey);
 
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
+    std::pair<double, double> pair = GetJoystickFromMouse();
+    // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
+    // axis per mouse move). Glide uses absolute position; warp reads deltas via
+    // DealWithWarp (in_mouse.cpp), which keeps the cursor centered as needed.
     const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
-    const bool warp_active = configuration().joystick.warp_mouse
-            && !winsys_config_overlay_active()
-            && SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE;   // only in free flight (cursor hidden)
-    const int half_w = configuration().graphics.resolution_x / 2 > 0
-            ? configuration().graphics.resolution_x / 2 : 1;
-    const int half_h = configuration().graphics.resolution_y / 2 > 0
-            ? configuration().graphics.resolution_y / 2 : 1;
-    if (warp_active) {
-        // Warp (relative) mouse: integrate the movement deltas into a virtual
-        // stick deflection, and decay it back toward neutral each frame. The
-        // flight controller reads joy_axis as a continuous -1..1 deflection, so
-        // a real stick held at a deflection gives continuous turning. Using the
-        // raw delta directly would produce a single one-shot pulse per motion
-        // event ("one step" behavior). Deltas are independent of absolute
-        // cursor position (works at screen edges) and never move the OS cursor
-        // -- the cursor moves freely; the deflection decays toward center.
-        int dx = 0, dy = 0;
-        GetMouseDelta(dx, dy);
-        warp_x += static_cast<float>(dx) / static_cast<float>(half_w);
-        warp_y += static_cast<float>(dy) / static_cast<float>(half_h);
-        // Decay toward neutral (stick returns to center as you stop moving).
-        warp_x *= 0.82F;
-        warp_y *= 0.82F;
-        // Clamp to valid deflection range.
-        if (warp_x > 1.0F) warp_x = 1.0F;
-        if (warp_x < -1.0F) warp_x = -1.0F;
-        if (warp_y > 1.0F) warp_y = 1.0F;
-        if (warp_y < -1.0F) warp_y = -1.0F;
-        x = warp_x * sensitivity;
-        y = warp_y * sensitivity;
-    } else {
-        // Glide (absolute) mode: axis = normalized absolute cursor position.
-        std::pair<double, double> pair = GetJoystickFromMouse();
-        x = static_cast<float>(pair.first) * sensitivity;
-        y = static_cast<float>(pair.second) * sensitivity;
-    }
+    x = static_cast<float>(pair.first) * sensitivity;
+    y = static_cast<float>(pair.second) * sensitivity;
     z = 0;
     joy_axis[0] = x;
     joy_axis[1] = y;

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -288,36 +288,48 @@ struct mouseData {
 extern void GetMouseXY(int &mousex, int &mousey);
 
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
-    std::pair<double, double> pair = GetJoystickFromMouse();
-    // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
-    // axis per mouse move). Glide uses absolute position; warp recenters the
-    // cursor each frame so the next read is relative to center.
     const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
-    x = static_cast<float>(pair.first) * sensitivity;
-    y = static_cast<float>(pair.second) * sensitivity;
+    const bool warp_active = configuration().joystick.warp_mouse
+            && !winsys_config_overlay_active()
+            && SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE;   // only in free flight (cursor hidden)
+    const int half_w = configuration().graphics.resolution_x / 2 > 0
+            ? configuration().graphics.resolution_x / 2 : 1;
+    const int half_h = configuration().graphics.resolution_y / 2 > 0
+            ? configuration().graphics.resolution_y / 2 : 1;
+    if (warp_active) {
+        // Warp (relative) mouse: integrate the movement deltas into a virtual
+        // stick deflection, and decay it back toward neutral each frame. The
+        // flight controller reads joy_axis as a continuous -1..1 deflection, so
+        // a real stick held at a deflection gives continuous turning. Using the
+        // raw delta directly would produce a single one-shot pulse per motion
+        // event ("one step" behavior). Deltas are independent of absolute
+        // cursor position (works at screen edges) and never move the OS cursor
+        // -- the cursor moves freely; the deflection decays toward center.
+        int dx = 0, dy = 0;
+        GetMouseDelta(dx, dy);
+        warp_x += static_cast<float>(dx) / static_cast<float>(half_w);
+        warp_y += static_cast<float>(dy) / static_cast<float>(half_h);
+        // Decay toward neutral (stick returns to center as you stop moving).
+        warp_x *= 0.82F;
+        warp_y *= 0.82F;
+        // Clamp to valid deflection range.
+        if (warp_x > 1.0F) warp_x = 1.0F;
+        if (warp_x < -1.0F) warp_x = -1.0F;
+        if (warp_y > 1.0F) warp_y = 1.0F;
+        if (warp_y < -1.0F) warp_y = -1.0F;
+        x = warp_x * sensitivity;
+        y = warp_y * sensitivity;
+    } else {
+        // Glide (absolute) mode: axis = normalized absolute cursor position.
+        std::pair<double, double> pair = GetJoystickFromMouse();
+        x = static_cast<float>(pair.first) * sensitivity;
+        y = static_cast<float>(pair.second) * sensitivity;
+    }
     z = 0;
     joy_axis[0] = x;
     joy_axis[1] = y;
     joy_axis[2] = z = 0;
     buttons = getMouseButtonStatus();
-    // Warp (relative) mouse: recenter the OS cursor to the window center each
-    // frame so the deflection read next frame is relative to center (continuous
-    // relative stick). Without this the cursor drifts to the edges and reads as
-    // absolute (glide). This is what makes warp kick in whenever the cursor
-    // moves away from center, not just at the screen edge.
-    //
-    // Warp is only active in free flight: whenever the cursor is shown (settings
-    // app, docked/base, nav screen, glide-mode crosshair) warp is disabled and
-    // the mouse reads absolute (glide-like) so UI/hud interactions aren't
-    // disrupted by recentering. Cursor visibility is the single robust signal
-    // for "something else is on screen"; the game shows the cursor in those
-    // contexts and hides it only in flight.
-    if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()
-            && SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE) {
-        int w = 0, h = 0;
-        SDL_GetWindowSize(SDL_GL_GetCurrentWindow(), &w, &h);
-        SetMousePosition(w / 2, h / 2);
-    }
 }
 
 void JoyStick::GetJoyStick(float &x, float &y, float &z, int &buttons) {

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -38,13 +38,6 @@
 #include "src/in_joystick.h"
 #include "src/config_xml.h"
 #include "src/in_mouse.h"
-#ifndef HAVE_SDL
-#include "gldrv/gl_include.h"
-#if (GLUT_API_VERSION >= 4 || GLUT_XLIB_IMPLEMENTATION >= 13)
-#else
-#define NO_SDL_JOYSTICK
-#endif
-#endif
 
 #include "root_generic/options.h"
 #include <SDL2/SDL_joystick.h>
@@ -174,33 +167,35 @@ void InitJoystick() {
             }
         }
     }
-#ifndef NO_SDL_JOYSTICK
-#ifdef HAVE_SDL
     num_joysticks = SDL_NumJoysticks();
+    if (num_joysticks > MAX_JOYSTICKS) {
+        num_joysticks = MAX_JOYSTICKS;
+    }
     VS_LOG(info, (boost::format("%1% joysticks were found.\n\n") % num_joysticks));
     VS_LOG(info, "The names of the joysticks are:\n");
-#else
-    //use glut
-    if (glutDeviceGet( GLUT_HAS_JOYSTICK ) || configuration().joystick.force_use_of_joystick) {
-        VS_LOG(info, "setting joystick functionality:: joystick online");
-        glutJoystickFunc( myGlutJoystickCallback, JoystickPollingRate() );
-        num_joysticks = 1;
-    }
-#endif
-#endif
     for (i = 0; i < MAX_JOYSTICKS; i++) {
-#ifndef NO_SDL_JOYSTICK
-#ifdef HAVE_SDL
+        if (i == MOUSE_JOYSTICK) {
+            // The mouse-joystick slot is always created as the mouse.
+            joystick[i] = new JoyStick(i);
+            continue;
+        }
+        // Always create a present physical slot so bindKeys() binds it normally
+        // (no "not available" refusals / inconsistent half-bound state). It
+        // reports available but has a null SDL handle until a real device
+        // attaches via JoyStick::Attach() on hotplug. GetJoyStick guards the null
+        // handle and returns zeros, so reads on an unattached slot are safe.
+        joystick[i] = new JoyStick(i);
+        joystick[i]->joy = nullptr;
+        joystick[i]->joy_available = true;
+        joystick[i]->nr_of_axes = 0;
+        joystick[i]->nr_of_buttons = 0;
+        joystick[i]->nr_of_hats = 0;
+        // A real device present at startup: attach it to this slot (device index
+        // maps directly to slot index for the first N physical devices).
         if (i < num_joysticks) {
             VS_LOG(info, (boost::format("    %1%\n") % SDL_JoystickNameForIndex(i)));
+            joystick[i]->Attach(i);
         }
-#else
-        if (i < num_joysticks) {
-            VS_LOG(info, (boost::format("Glut detects %1% joystick") % (i+1)));
-        }
-#endif
-#endif
-        joystick[i] = new JoyStick(i);         //SDL_Init is done in main.cpp
     }
 }
 
@@ -227,44 +222,37 @@ JoyStick::JoyStick(int which) : mouse(which == MOUSE_JOYSTICK) {
     };
     joy_available = 0;
     joy_x = joy_y = joy_z = 0;
+    joy = nullptr;
     if (which == MOUSE_JOYSTICK) {
         InitMouse(which);
     }
-#if defined (NO_SDL_JOYSTICK)
-    return;
+}
 
-#else
-#ifdef HAVE_SDL
-    num_joysticks = SDL_NumJoysticks();
-    if (which >= num_joysticks) {
-        if (which != MOUSE_JOYSTICK) {
-            joy_available = false;
-        }
-        return;
+JoyStick::~JoyStick() {
+    if (joy != nullptr) {
+        SDL_JoystickClose(joy);
+        joy = nullptr;
     }
-    joy = SDL_JoystickOpen(which);     //joystick nr should be configurable
+}
+
+// Re-point this slot at a real SDL joystick (hotplug attach). Closes any
+// existing/fake handle, opens the new device, and refreshes the axis/button/hat
+// counts. The slot's bindings (keyed by slot index) are untouched.
+void JoyStick::Attach(int device_index) {
+    if (joy != nullptr) {
+        SDL_JoystickClose(joy);
+        joy = nullptr;
+    }
+    joy = SDL_JoystickOpen(device_index);
     if (joy == nullptr) {
-        VS_LOG(warning, (boost::format("warning: no joystick nr %1%\n") % which));
         joy_available = false;
         return;
     }
     joy_available = true;
-    nr_of_axes = SDL_JoystickNumAxes(joy);
-    nr_of_buttons = SDL_JoystickNumButtons(joy);
-    nr_of_hats = SDL_JoystickNumHats(joy);
-#else
-    //WE HAVE GLUT
-    if (which > 0 && which != MOUSE_JOYSTICK) {
-        joy_available = false;
-        return;
-    }
-    joy_available = true;
-    nr_of_axes    = 3;     //glutDeviceGet(GLUT_JOYSTICK_AXES);
-    nr_of_buttons = 15;     //glutDeviceGet(GLUT_JOYSTICK_BUTTONS);
-    nr_of_hats    = 0;
-#endif //we have GLUT
-#endif
-    VS_LOG(info, (boost::format("axes: %1% buttons: %2% hats: %3%\n") % nr_of_axes % nr_of_buttons % nr_of_hats));
+    nr_of_axes = std::min(SDL_JoystickNumAxes(joy), MAX_AXES);
+    nr_of_buttons = std::min(SDL_JoystickNumButtons(joy), MAX_BUTTONS);
+    nr_of_hats = std::min(SDL_JoystickNumHats(joy), MAX_DIGITAL_HATSWITCHES);
+    VS_LOG(important_info, (boost::format("[joy] attached slot: axes=%1% buttons=%2% hats=%3%\n") % nr_of_axes % nr_of_buttons % nr_of_hats));
 }
 
 void JoyStick::InitMouse(int which) {
@@ -312,7 +300,11 @@ void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
 
 void JoyStick::GetJoyStick(float &x, float &y, float &z, int &buttons) {
     //int status;
-    if (!joy_available) {
+    // Unavailable, or a fake slot with no real device attached yet: return zeros
+    // safely so bindings stay bound but produce no input until a real joystick
+    // attaches (JoyStick::Attach). Without the null-joy guard, an unattached
+    // fake slot would crash in the SDL_Joystick* calls below.
+    if (!joy_available || (joy == nullptr && !mouse)) {
         for (int a = 0; a < MAX_AXES; a++) {
             joy_axis[a] = 0;
         }
@@ -324,8 +316,6 @@ void JoyStick::GetJoyStick(float &x, float &y, float &z, int &buttons) {
         return;
     }
     int a;
-#ifndef NO_SDL_JOYSTICK
-#if defined (HAVE_SDL)
     int numaxes = SDL_JoystickNumAxes(joy) < MAX_AXES ? SDL_JoystickNumAxes(joy) : MAX_AXES;
     std::vector<Sint16> axi(numaxes);
     for (a = 0; a < numaxes; a++) {
@@ -347,15 +337,10 @@ void JoyStick::GetJoyStick(float &x, float &y, float &z, int &buttons) {
     }
     modifyDeadZone(this);
     modifyExponent(this);
-#else //we have glut
-    if (JoystickPollingRate() <= 0)
-        glutForceJoystickFunc();
-#endif
     x = joy_axis[0];
     y = joy_axis[1];
     z = joy_axis[2];
     buttons = joy_buttons;
-#endif //we have no joystick
 }
 
 int JoyStick::NumButtons() {

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -289,8 +289,12 @@ extern void GetMouseXY(int &mousex, int &mousey);
 
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
     std::pair<double, double> pair = GetJoystickFromMouse();
-    x = pair.first;
-    y = pair.second;
+    // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
+    // axis per mouse move). Glide uses absolute position; warp reads deltas via
+    // DealWithWarp (in_mouse.cpp), which keeps the cursor centered as needed.
+    const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
+    x = static_cast<float>(pair.first) * sensitivity;
+    y = static_cast<float>(pair.second) * sensitivity;
     z = 0;
     joy_axis[0] = x;
     joy_axis[1] = y;

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -288,43 +288,13 @@ struct mouseData {
 extern void GetMouseXY(int &mousex, int &mousey);
 
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
+    std::pair<double, double> pair = GetJoystickFromMouse();
     // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
-    // axis per mouse move).
+    // axis per mouse move). Glide uses absolute position; warp reads deltas via
+    // DealWithWarp (in_mouse.cpp), which keeps the cursor centered as needed.
     const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
-    // Warp (relative) mouse is only active in free flight (cursor hidden, and
-    // not while the config overlay is open), so anything on screen (settings,
-    // docked/base, nav, glide-mode crosshair) reads absolute like glide.
-    const bool warp_active = configuration().joystick.warp_mouse
-            && !winsys_config_overlay_active()
-            && SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE;
-    if (warp_active) {
-        // Warp (relative) mode: integrate the movement deltas into a virtual
-        // stick deflection, and decay it back toward neutral each frame. The
-        // flight controller reads joy_axis as a continuous -1..1 deflection, so
-        // a real stick held at a deflection gives continuous turning. Using the
-        // raw delta directly would produce a single one-shot pulse per motion
-        // event ("one step" behavior). Deltas are independent of absolute
-        // cursor position (works at screen edges) and never move the OS cursor.
-        int dx = 0, dy = 0;
-        GetMouseDelta(dx, dy);
-        warp_x += static_cast<float>(dx) / (native_resolution_x / 2.0F);
-        warp_y += static_cast<float>(dy) / (native_resolution_y / 2.0F);
-        // Decay toward neutral (stick returns to center as you stop moving).
-        warp_x *= 0.82F;
-        warp_y *= 0.82F;
-        // Clamp to valid deflection range.
-        if (warp_x > 1.0F) { warp_x = 1.0F; }
-        if (warp_x < -1.0F) { warp_x = -1.0F; }
-        if (warp_y > 1.0F) { warp_y = 1.0F; }
-        if (warp_y < -1.0F) { warp_y = -1.0F; }
-        x = warp_x * sensitivity;
-        y = warp_y * sensitivity;
-    } else {
-        // Glide (absolute) mode: axis = normalized absolute cursor position.
-        std::pair<double, double> pair = GetJoystickFromMouse();
-        x = static_cast<float>(pair.first) * sensitivity;
-        y = static_cast<float>(pair.second) * sensitivity;
-    }
+    x = static_cast<float>(pair.first) * sensitivity;
+    y = static_cast<float>(pair.second) * sensitivity;
     z = 0;
     joy_axis[0] = x;
     joy_axis[1] = y;

--- a/engine/src/in_joystick.cpp
+++ b/engine/src/in_joystick.cpp
@@ -290,8 +290,8 @@ extern void GetMouseXY(int &mousex, int &mousey);
 void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
     std::pair<double, double> pair = GetJoystickFromMouse();
     // Sensitivity scales the -1..1 deflection (50 = baseline; higher = more
-    // axis per mouse move). Glide uses absolute position; warp reads deltas via
-    // DealWithWarp (in_mouse.cpp), which keeps the cursor centered as needed.
+    // axis per mouse move). Glide uses absolute position; warp recenters the
+    // cursor each frame so the next read is relative to center.
     const float sensitivity = configuration().joystick.mouse_sensitivity_flt / 50.0F;
     x = static_cast<float>(pair.first) * sensitivity;
     y = static_cast<float>(pair.second) * sensitivity;
@@ -300,6 +300,16 @@ void JoyStick::GetMouse(float &x, float &y, float &z, int &buttons) {
     joy_axis[1] = y;
     joy_axis[2] = z = 0;
     buttons = getMouseButtonStatus();
+    // Warp (relative) mouse: recenter the OS cursor to the window center each
+    // frame so the deflection read next frame is relative to center (continuous
+    // relative stick). Without this the cursor drifts to the edges and reads as
+    // absolute (glide). This is what makes warp kick in whenever the cursor
+    // moves away from center, not just at the screen edge.
+    if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()) {
+        int w = 0, h = 0;
+        SDL_GetWindowSize(SDL_GL_GetCurrentWindow(), &w, &h);
+        SetMousePosition(w / 2, h / 2);
+    }
 }
 
 void JoyStick::GetJoyStick(float &x, float &y, float &z, int &buttons) {

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -94,6 +94,11 @@ public:
     bool axis_inverse[MAX_AXES];
     int axis_axis[MAX_AXES];
     float joy_axis[MAX_AXES];
+    // Warp (relative) mouse deflection accumulator: deltas build up a virtual
+    // target deflection that decays back toward center, so the flight controller
+    // turns the ship toward it and stops when it reaches center.
+    float warp_x = 0.0F;
+    float warp_y = 0.0F;
     JoyStick();
     unsigned char digital_hat[MAX_DIGITAL_HATSWITCHES];
 

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -32,9 +32,7 @@
  */
 #include "src/in_kb_data.h"
 
-#if defined (HAVE_SDL)
 #include <SDL2/SDL.h>
-#endif //defined (HAVE_SDL)
 
 #include "src/vegastrike.h"
 //#include "glob.h"
@@ -77,17 +75,18 @@ class JoyStick {
 public:
 //initializes the joystick
     JoyStick(int);
+    ~JoyStick();
+// Re-point this slot at a real SDL joystick (hotplug attach). Closes any
+// existing/fake handle, opens the new device, refreshes axis/button/hat counts.
+// The slot's bindings (keyed by slot index) are untouched.
+    void Attach(int device_index);
 //engine calls GetJoyStick to get coordinates and buttons
     void GetJoyStick(float &x, float &y, float &z, int &buttons);
     bool isAvailable(void);
     bool is_around(float axe, float hswitch);
     int NumButtons();
 
-#if defined (HAVE_SDL)
     SDL_Joystick *joy;
-#else //defined (HAVE_SDL)
-    void   *otherdata; //bad form to have an ifdef in a struct
-#endif //defined (HAVE_SDL)
     int nr_of_axes, nr_of_buttons, nr_of_hats;
     int hat_margin;
     size_t player;

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -94,11 +94,6 @@ public:
     bool axis_inverse[MAX_AXES];
     int axis_axis[MAX_AXES];
     float joy_axis[MAX_AXES];
-    // Warp (relative) mouse deflection accumulator: deltas build up a virtual
-    // stick position that decays back toward neutral, so the flight controller
-    // sees a continuous -1..1 deflection each frame instead of one-shot pulses.
-    float warp_x = 0.0F;
-    float warp_y = 0.0F;
     JoyStick();
     unsigned char digital_hat[MAX_DIGITAL_HATSWITCHES];
 

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -94,6 +94,11 @@ public:
     bool axis_inverse[MAX_AXES];
     int axis_axis[MAX_AXES];
     float joy_axis[MAX_AXES];
+    // Warp (relative) mouse deflection accumulator: deltas build up a virtual
+    // stick position that decays back toward neutral, so the flight controller
+    // sees a continuous -1..1 deflection each frame instead of one-shot pulses.
+    float warp_x = 0.0F;
+    float warp_y = 0.0F;
     JoyStick();
     unsigned char digital_hat[MAX_DIGITAL_HATSWITCHES];
 

--- a/engine/src/in_joystick.h
+++ b/engine/src/in_joystick.h
@@ -111,6 +111,7 @@ extern JoyStick *joystick[MAX_JOYSTICKS];
 typedef void (*JoyHandler)(KBSTATE, float x, float y, int mod);
 void BindJoyKey(int key, int joystick, KBHandler handler, const KBData &data);
 void UnbindJoyKey(int joystick, int key);
+void RestoreJoystickState();
 
 void UnbindHatswitchKey(int hatswitch, int val_index);
 void BindHatswitchKey(int hatswitch, int val_index, KBHandler handler, const KBData &data);

--- a/engine/src/in_kb.cpp
+++ b/engine/src/in_kb.cpp
@@ -34,6 +34,7 @@
 #include "gldrv/winsys.h"
 #include "src/in_kb_data.h"
 #include "src/universe.h"
+#include "cmd/ai/firekeyboard.h"
 
 
 std::map<std::string, HandlerCall> keyBindings;
@@ -59,6 +60,47 @@ static bool kbHasBinding(int key, int modifiers) {
     const std::string map_key = std::to_string(key) + "-" + std::to_string(modifiers);
     static HandlerCall defaultHandler;
     return keyBindings[map_key].function != defaultHandler.function;
+}
+
+// Global (always-active) actions fire in ANY context (in-flight, docked, nav,
+// text), not just the HUD. Add handlers here as more global actions are needed.
+// Called from winsys_process_events() before the context-specific dispatch so
+// e.g. Alt+C (ConfigKey) opens the settings screen no matter where the player is.
+static const KBHandler kGlobalActionHandlers[] = {
+    FireKeyboard::ToggleConfigScreen,
+};
+
+bool HandleGlobalKey(unsigned int ch, unsigned int mod, bool down, int x, int y) {
+    // Normalize modifiers the same way glut_keyboard_cb does.
+    bool shifton = false, alton = false, ctrlon = false;
+    unsigned int modmask = KB_MOD_MASK;
+    if ((WSK_MOD_LSHIFT == (mod & WSK_MOD_LSHIFT)) || (WSK_MOD_RSHIFT == (mod & WSK_MOD_RSHIFT))) {
+        shifton = true;
+    }
+    if ((WSK_MOD_LALT == (mod & WSK_MOD_LALT)) || (WSK_MOD_RALT == (mod & WSK_MOD_RALT))) {
+        alton = true;
+    }
+    if ((WSK_MOD_LCTRL == (mod & WSK_MOD_LCTRL)) || (WSK_MOD_RCTRL == (mod & WSK_MOD_RCTRL))) {
+        ctrlon = true;
+    }
+    const int curmod = getModifier(alton, ctrlon, shifton) & modmask;
+    const std::string map_key = std::to_string(ch) + "-" + std::to_string(curmod);
+    auto it = keyBindings.find(map_key);
+    if (it == keyBindings.end()) {
+        return false;
+    }
+    bool isGlobal = false;
+    for (KBHandler h : kGlobalActionHandlers) {
+        if (h == it->second.function) {
+            isGlobal = true;
+            break;
+        }
+    }
+    if (!isGlobal) {
+        return false;
+    }
+    kbGetInput(ch, curmod, down, x, y);
+    return true;
 }
 
 static const char _lomap[] = "0123456789-=\';/.,`\\";

--- a/engine/src/in_kb.cpp
+++ b/engine/src/in_kb.cpp
@@ -27,6 +27,7 @@
 
 #include <queue>
 #include <list>
+#include <unordered_set>
 #include "src/vegastrike.h"
 #include "root_generic/vs_globals.h"
 #include "src/in_kb.h"
@@ -66,7 +67,7 @@ static bool kbHasBinding(int key, int modifiers) {
 // text), not just the HUD. Add handlers here as more global actions are needed.
 // Called from winsys_process_events() before the context-specific dispatch so
 // e.g. Alt+C (ConfigKey) opens the settings screen no matter where the player is.
-static const KBHandler kGlobalActionHandlers[] = {
+static const std::unordered_set<KBHandler> kGlobalActionHandlers = {
     FireKeyboard::ToggleConfigScreen,
 };
 
@@ -89,13 +90,7 @@ bool HandleGlobalKey(unsigned int ch, unsigned int mod, bool down, int x, int y)
     if (it == keyBindings.end()) {
         return false;
     }
-    bool isGlobal = false;
-    for (KBHandler h : kGlobalActionHandlers) {
-        if (h == it->second.function) {
-            isGlobal = true;
-            break;
-        }
-    }
+    bool isGlobal = kGlobalActionHandlers.count(it->second.function) != 0;
     if (!isGlobal) {
         return false;
     }

--- a/engine/src/in_kb.h
+++ b/engine/src/in_kb.h
@@ -80,10 +80,13 @@ unsigned int pullActiveModifiers();
 void setActiveModifiers(unsigned int mask);
 
 unsigned int getModifier(const std::string modifier);
+int getModifier(bool alton, bool cntrlon, bool shifton);
 void ProcessKB();
 void BindKey(int key, unsigned int modifiers, unsigned int player, KBHandler handler, const KBData &data);
 void UnbindKey(int key, unsigned int modifiers);
 void InitKB();
 void RestoreKB();
+// Fire a global (always-active) action if the key maps to one; true if handled.
+bool HandleGlobalKey(unsigned int ch, unsigned int mod, bool down, int x, int y);
 
 #endif //VEGA_STRIKE_ENGINE_IN_KB_H

--- a/engine/src/in_mouse.cpp
+++ b/engine/src/in_mouse.cpp
@@ -93,13 +93,49 @@ void AddDelta(int dx, int dy) {
 
 int warpallowage = 2;
 
+// Original warp (relative) mouse: only warp the OS cursor when it reaches the
+// edge warp zone, and compensate the internal mouse/event positions so the
+// delta (`x - mousex`) stays correct. This makes warp flight continuous even at
+// the screen edge (the cursor is pulled back to center so motion keeps flowing)
+// without dragging the cursor around in the middle of the screen.
+//
+// Gated: only in warp_mouse mode, only when the mouse-as-joystick is the active
+// player's controller, and never while the config overlay is open so the
+// config screen's cursor moves freely. When disabled (glide mode) this is a
+// no-op and the mouse reads absolute position (glide).
+void DealWithWarp(int x, int y) {
+    if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()) {
+        if (joystick[MOUSE_JOYSTICK]->player < _Universe->numPlayers()) {
+            if (x < configuration().joystick.warp_mouse_zone
+                    || y < configuration().joystick.warp_mouse_zone
+                    || x > configuration().graphics.resolution_x - configuration().joystick.warp_mouse_zone
+                    || y > configuration().graphics.resolution_y - configuration().joystick.warp_mouse_zone) {
+
+                int delx = -x + configuration().graphics.resolution_x / 2;
+                int dely = -y + configuration().graphics.resolution_y / 2;
+                mousex += delx;
+                mousey += dely;
+                deque<MouseEvent>::iterator i;
+                for (i = eventQueue.begin(); i != eventQueue.end(); i++) {
+                    i->x += delx;
+                    i->y += dely;
+                }
+                if (warpallowage-- >= 0) {
+                    winsys_warp_pointer(configuration().graphics.resolution_x / 2, configuration().graphics.resolution_y / 2);
+                }
+            }
+        }
+    }
+}
 
 void mouseDragQueue(int x, int y) {
     eventQueue.push_back(MouseEvent(MouseEvent::DRAG, -1, -1, -1, x, y));
+    DealWithWarp(x, y);
 }
 
 void mouseMotionQueue(int x, int y) {
     eventQueue.push_back(MouseEvent(MouseEvent::MOTION, -1, -1, -1, x, y));
+    DealWithWarp(x, y);
 }
 
 int lookupMouseButton(int b) {

--- a/engine/src/in_mouse.cpp
+++ b/engine/src/in_mouse.cpp
@@ -196,6 +196,16 @@ void InitMouse() {
     RestoreMouse();
 }
 
+// Clear all mouse button states to RELEASE. Called when the config overlay
+// closes so a button pressed inside it (whose release was swallowed by the
+// overlay input path) doesn't stay DOWN and fire a command continuously (e.g.
+// FireKey looping while polling the mouse/joystick slot).
+void ResetMouseState() {
+    for (int a = 0; a < NUM_BUTTONS + 1; a++) {
+        MouseState[a] = RELEASE;
+    }
+}
+
 void ProcessMouse() {
     warpallowage = 2;
     while (eventQueue.size()) {

--- a/engine/src/in_mouse.cpp
+++ b/engine/src/in_mouse.cpp
@@ -93,49 +93,13 @@ void AddDelta(int dx, int dy) {
 
 int warpallowage = 2;
 
-// Original warp (relative) mouse: only warp the OS cursor when it reaches the
-// edge warp zone, and compensate the internal mouse/event positions so the
-// delta (`x - mousex`) stays correct. This makes warp flight continuous even at
-// the screen edge (the cursor is pulled back to center so motion keeps flowing)
-// without dragging the cursor around in the middle of the screen.
-//
-// Gated: only in warp_mouse mode, only when the mouse-as-joystick is the active
-// player's controller, and never while the config overlay is open so the
-// config screen's cursor moves freely. When disabled (glide mode) this is a
-// no-op and the mouse reads absolute position (glide).
-void DealWithWarp(int x, int y) {
-    if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()) {
-        if (joystick[MOUSE_JOYSTICK]->player < _Universe->numPlayers()) {
-            if (x < configuration().joystick.warp_mouse_zone
-                    || y < configuration().joystick.warp_mouse_zone
-                    || x > configuration().graphics.resolution_x - configuration().joystick.warp_mouse_zone
-                    || y > configuration().graphics.resolution_y - configuration().joystick.warp_mouse_zone) {
-
-                int delx = -x + configuration().graphics.resolution_x / 2;
-                int dely = -y + configuration().graphics.resolution_y / 2;
-                mousex += delx;
-                mousey += dely;
-                deque<MouseEvent>::iterator i;
-                for (i = eventQueue.begin(); i != eventQueue.end(); i++) {
-                    i->x += delx;
-                    i->y += dely;
-                }
-                if (warpallowage-- >= 0) {
-                    winsys_warp_pointer(configuration().graphics.resolution_x / 2, configuration().graphics.resolution_y / 2);
-                }
-            }
-        }
-    }
-}
 
 void mouseDragQueue(int x, int y) {
     eventQueue.push_back(MouseEvent(MouseEvent::DRAG, -1, -1, -1, x, y));
-    DealWithWarp(x, y);
 }
 
 void mouseMotionQueue(int x, int y) {
     eventQueue.push_back(MouseEvent(MouseEvent::MOTION, -1, -1, -1, x, y));
-    DealWithWarp(x, y);
 }
 
 int lookupMouseButton(int b) {

--- a/engine/src/in_mouse.cpp
+++ b/engine/src/in_mouse.cpp
@@ -104,6 +104,12 @@ int warpallowage = 2;
 // config screen's cursor moves freely. When disabled (glide mode) this is a
 // no-op and the mouse reads absolute position (glide).
 void DealWithWarp(int x, int y) {
+    // Warp (relative) mouse: when the OS cursor reaches the edge warp zone, pull
+    // it back toward the center so it can keep feeding deltas (otherwise the
+    // cursor pins at the screen edge and the warp deflection can't grow further).
+    // Compensate mousex/mousey and queued event positions so the delta stays
+    // correct. Gated: only in warp_mouse mode, only when the mouse-as-joystick is
+    // the active player's controller, and never while the config overlay is open.
     if (configuration().joystick.warp_mouse && !winsys_config_overlay_active()) {
         if (joystick[MOUSE_JOYSTICK]->player < _Universe->numPlayers()) {
             if (x < configuration().joystick.warp_mouse_zone

--- a/engine/src/in_mouse.h
+++ b/engine/src/in_mouse.h
@@ -34,6 +34,7 @@ int getMouseButtonStatus();  //returns button status that are bitwise anded (i.e
 void InitMouse();
 void RestoreMouse();
 void ProcessMouse();
+void ResetMouseState();
 void BindKey(int key, MouseHandler handler);
 void UnbindMouse(int key);
 int getMouseDrawFunc();

--- a/engine/src/in_sdl.cpp
+++ b/engine/src/in_sdl.cpp
@@ -99,6 +99,18 @@ void BindHatswitchKey(int joystick, int key, KBHandler handler, const KBData &da
     GenBindJoyKey(HATSWITCH, joystick, key, handler, data);
 }
 
+// Reset every joystick/hatswitch button state to UP. Called when the config
+// overlay closes so a button whose release was swallowed by the overlay input
+// path doesn't stay DOWN and fire a command continuously once flight polling
+// resumes (mirrors RestoreKB for the keyboard).
+void RestoreJoystickState() {
+    for (int sw = 0; sw < NUMSWITCHES; ++sw)
+        for (int j = 0; j < MAXOR(MAX_HATSWITCHES, MAX_JOYSTICKS); ++j)
+            for (int k = 0; k < MAXOR(NUMJBUTTONS, MAXOR(MAX_VALUES,
+                    MAX_DIGITAL_HATSWITCHES * MAX_DIGITAL_VALUES)); ++k)
+                JoystickState[sw][j][k] = UP;
+}
+
 void UnbindDigitalHatswitchKey(int joystick, int key, int dir) {
     GenUnbindJoyKey(DIGHATSWITCH, joystick, key * MAX_DIGITAL_VALUES + dir);
 }

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -346,7 +346,7 @@ int main(int argc, char *argv[]) {
 
     // Override config with command line argument
     if (!mission_name.empty()) {
-        (const_cast<vega_config::Configuration &>(configuration())).game_start.default_mission = mission_name;
+        (configuration()).game_start.default_mission = mission_name;
         VS_LOG(info, (boost::format("MISSION_NAME is empty using : %1%") % mission_name));
     }
 
@@ -884,12 +884,12 @@ std::pair<std::string, std::string> ParseCommandLine(int argc, char **lpCmdLine)
     }
 
     if (cmd_args.count("h")) {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = 1024;
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = 768;
+        (configuration()).graphics.resolution_x = 1024;
+        (configuration()).graphics.resolution_y = 768;
     }
     if (cmd_args.count("v")) {
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_x = 1280;
-        (const_cast<vega_config::Configuration &>(configuration())).graphics.resolution_y = 1024;
+        (configuration()).graphics.resolution_x = 1280;
+        (configuration()).graphics.resolution_y = 1024;
     }
 
     if (cmd_args.count("mission_name")) {

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -726,7 +726,6 @@ void bootstrap_main_loop() {
         // in-game frame).
         if (g_launch_configure) {
             g_launch_configure = false;
-            _Universe->MarkLaunchedWithConfigure();
             _Universe->ToggleOptionsActive();
         }
         _Universe->Loop(main_loop);

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -726,6 +726,7 @@ void bootstrap_main_loop() {
         // in-game frame).
         if (g_launch_configure) {
             g_launch_configure = false;
+            _Universe->MarkLaunchedWithConfigure();
             _Universe->ToggleOptionsActive();
         }
         _Universe->Loop(main_loop);

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -97,6 +97,8 @@ char SERVER = 0;
 
 //false if command line option --net is given to start without network
 static bool ignore_network = true;
+// Open the in-game settings screen at launch (--configure), before the game is shown.
+static bool g_launch_configure = false;
 // legacy_data_dir_mode determines whether the application should require the data directory to be specified on the command-line or not
 // true - no parameter required, application should start regardless of where it's called from
 // false - parameter required, application should only start if specified
@@ -719,6 +721,13 @@ void bootstrap_main_loop() {
         for (unsigned int i = 0; i < _Universe->numPlayers(); ++i) {
             _Universe->AccessCockpit(i)->savegame->LoadSavedMissions();
         }
+        // --configure: open the in-game settings screen once bootstrap finishes,
+        // before the flight HUD draws (the game is paused/overlaid on the first
+        // in-game frame).
+        if (g_launch_configure) {
+            g_launch_configure = false;
+            _Universe->ToggleOptionsActive();
+        }
         _Universe->Loop(main_loop);
         ///return to idle func which now should call main_loop mohahahah
         if (configuration().splash.auto_hide) {
@@ -751,6 +760,7 @@ std::pair<std::string, std::string> ParseCommandLine(int argc, char **lpCmdLine)
         ("version", "Print the version and exit")
         ("debug", boost::program_options::value<char>()->default_value('0'), "Enable debugging output, 1 major warnings, 2 medium, 3 developer notes")
         ("benchmark", boost::program_options::value<double>(), "Benchmark")
+        ("configure", "Open the in-game settings screen at launch (before anything else)")
         ("test-audio", "Run audio tests")  // is handled in readCommandLineOptions, here is serves only for help message
         ("r", "No-op")
         ("f", "No-op")
@@ -792,6 +802,10 @@ std::pair<std::string, std::string> ParseCommandLine(int argc, char **lpCmdLine)
     if (cmd_args.count("version")) {
         std::cout << versionmessage << std::endl;
         exit(0);
+    }
+
+    if (cmd_args.count("configure")) {
+        g_launch_configure = true;
     }
 
     if (cmd_args.count("target")) {

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -864,10 +864,16 @@ void Universe::ToggleOptionsActive() {
         changeCursor(CursorType::arrow);
         showCursor();
     } else {
-        // Back in flight: restore the cursor for the active flight control mode.
-        // Mouse glide -> crosshair, otherwise keep the VS arrow (auto-hide via
-        // the HUD where appropriate).
-        if (configuration().joystick.mouse_cursor) {
+        // Back in the game: the cursor depends on where the player is.
+        // Docked (on a base, e.g. when --configure opens the settings screen at
+        // launch) -> the VS arrow. In-flight -> the flight-control-mode cursor
+        // (mouse glide -> crosshair, otherwise arrow; auto-hidden via the HUD).
+        const Unit *player = _Universe->AccessCockpit() ? _Universe->AccessCockpit()->GetParent() : nullptr;
+        const bool docked = player && (player->docked & (Unit::DOCKED_INSIDE | Unit::DOCKED));
+        if (docked) {
+            changeCursor(CursorType::arrow);
+            showCursor();
+        } else if (configuration().joystick.mouse_cursor) {
             changeCursor(CursorType::crosshairs);
             showCursor();
         } else {

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -870,6 +870,9 @@ void Universe::ToggleOptionsActive() {
         // (mouse glide -> crosshair, otherwise arrow; auto-hidden via the HUD).
         const Unit *player = _Universe->AccessCockpit() ? _Universe->AccessCockpit()->GetParent() : nullptr;
         const bool docked = player && (player->docked & (Unit::DOCKED_INSIDE | Unit::DOCKED));
+        fprintf(stderr, "[config-screen debug] close: player=%p docked=%d dockflag=%d mouse_cursor=%d\n",
+                (void*)player, (int)docked, (player ? (int)player->docked : -1),
+                (int)configuration().joystick.mouse_cursor);
         if (docked) {
             changeCursor(CursorType::arrow);
             showCursor();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -442,11 +442,14 @@ void Universe::StartDraw() {
             activeStarSystem()->Draw();
         }
 
-        // In-game config overlay (Alt+C) on top — no-op unless optionsActive.
-        DrawConfigOverlay();
-
         // ImGui End Frame
         ImGui::End();
+
+        // In-game config overlay (Alt+C) on top — a top-level window (not nested
+        // inside main_window), so it draws as an opaque fullscreen window that
+        // covers the game behind. No-op unless optionsActive.
+        DrawConfigOverlay();
+
         // Rendering
         ImGui::Render();
 

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -465,6 +465,7 @@ void Universe::StartDraw() {
     UpdateTime();
     UpdateTimeCompressionSounds();
     _Universe->SetActiveCockpit(randomInt(_cockpits.size() - 1, 0));
+    if (!optionsActive) {  // config screen open -> freeze the sim, keep rendering
     for (i = 0; i < star_system.size() && i < configuration().physics.num_running_systems; ++i) {
 #if defined(LOG_TIME_TAKEN_DETAILS)
         const double update_star_system_start_time = realTime();
@@ -487,6 +488,7 @@ void Universe::StartDraw() {
            (boost::format("%1%: Time taken by StarSystem::ProcessPendingJumps(): %2%") % __FUNCTION__ % (
                star_system_process_pending_jumps_end_time - star_system_process_pending_jumps_start_time)));
 #endif
+    }
     for (i = 0; i < _cockpits.size(); ++i) {
 #if defined(LOG_TIME_TAKEN_DETAILS)
         const double process_input_start_time = realTime();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -865,15 +865,11 @@ void Universe::ToggleOptionsActive() {
         showCursor();
     } else {
         // Back in the game: the cursor depends on where the player is.
-        // Docked (on a base, e.g. when --configure opens the settings screen at
-        // launch) -> the VS arrow. In-flight -> the flight-control-mode cursor
-        // (mouse glide -> crosshair, otherwise arrow; auto-hidden via the HUD).
-        const Unit *player = _Universe->AccessCockpit() ? _Universe->AccessCockpit()->GetParent() : nullptr;
-        const bool docked = player && (player->docked & (Unit::DOCKED_INSIDE | Unit::DOCKED));
-        fprintf(stderr, "[config-screen debug] close: player=%p docked=%d dockflag=%d mouse_cursor=%d\n",
-                (void*)player, (int)docked, (player ? (int)player->docked : -1),
-                (int)configuration().joystick.mouse_cursor);
-        if (docked) {
+        // If launched with --configure, the settings screen opened on the base,
+        // so closing it goes back to the base -> the VS arrow cursor. Otherwise
+        // restore the flight-control-mode cursor (mouse glide -> crosshair,
+        // else arrow, auto-hidden via the HUD).
+        if (launchedWithConfigure) {
             changeCursor(CursorType::arrow);
             showCursor();
         } else if (configuration().joystick.mouse_cursor) {

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -35,6 +35,7 @@
 #include "gfx/aux_texture.h"
 #include "src/profile.h"
 #include "gfx/cockpit.h"
+#include "cmd/base.h"
 #include "root_generic/galaxy_xml.h"
 #include <algorithm>
 #include "src/config_xml.h"
@@ -863,20 +864,22 @@ void Universe::ToggleOptionsActive() {
         changeCursor(CursorType::arrow);
         showCursor();
     } else {
-        // Back in the game: the cursor depends on where the player is.
-        // If launched with --configure, the settings screen opened on the base,
-        // so closing it goes back to the base -> the VS arrow cursor. Otherwise
-        // restore the flight-control-mode cursor: warp-mode mouse (relative,
+        // Back in the game: the cursor depends on whether we're flying (HUD active)
+        // or not (docked/on a base). "Flying" = a cockpit with a player ship that is
+        // NOT docked. On a base (BaseInterface::CurrentBase or player->docked) we are
+        // not flying, so use the arrow cursor. In flight: warp-mode mouse (relative,
         // recentered) hides the cursor, glide-mode mouse (absolute) shows the
         // crosshair aim point, and joystick/keyboard (mouse not enabled) hides.
-        if (launchedWithConfigure) {
+        // This replaces the earlier --configure launch hack with a real state check,
+        // so Alt+C works everywhere (a bonus) yet the close cursor is always right
+        // whether we opened settings in flight or on a base.
+        const Unit *player_ship = _Universe->AccessCockpit()
+                ? _Universe->AccessCockpit()->GetParent() : nullptr;
+        const bool flying = !BaseInterface::CurrentBase && player_ship
+                && !(player_ship->docked & (Unit::DOCKED_INSIDE | Unit::DOCKED));
+        if (!flying) {
             changeCursor(CursorType::arrow);
             showCursor();
-            // This --configure arrow-on-close applies only the first time the
-            // screen is exited (it opened on the base at launch). Clear it so a
-            // later in-flight open/close (Alt+C in the cockpit) restores the
-            // normal flight-control-mode cursor instead of always giving arrow.
-            launchedWithConfigure = false;
         } else if (configuration().mouse.enabled) {
             if (configuration().joystick.warp_mouse) {
                 hideCursor();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -872,6 +872,11 @@ void Universe::ToggleOptionsActive() {
         if (launchedWithConfigure) {
             changeCursor(CursorType::arrow);
             showCursor();
+            // This --configure arrow-on-close applies only the first time the
+            // screen is exited (it opened on the base at launch). Clear it so a
+            // later in-flight open/close (Alt+C in the cockpit) restores the
+            // normal flight-control-mode cursor instead of always giving arrow.
+            launchedWithConfigure = false;
         } else if (configuration().mouse.enabled) {
             if (configuration().joystick.warp_mouse) {
                 hideCursor();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -75,6 +75,7 @@
 #include "root_generic/options.h"
 
 #include "imgui/imgui.h"
+#include "libraries/gui/gui.h"
 #include "backends/imgui_impl_sdl2.h"
 #include "backends/imgui_impl_opengl3.h"
 #include "backends/imgui_impl_sdlrenderer2.h"
@@ -428,6 +429,7 @@ void Universe::StartDraw() {
         const double update_gfx_end_time = realTime();
 #endif
         // ImGui Init
+        ImGui_ApplyPendingFontSize();  // apply a pending font-size change before laying out
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplSDL2_NewFrame();
         ImGui::NewFrame();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -866,14 +866,19 @@ void Universe::ToggleOptionsActive() {
         // Back in the game: the cursor depends on where the player is.
         // If launched with --configure, the settings screen opened on the base,
         // so closing it goes back to the base -> the VS arrow cursor. Otherwise
-        // restore the flight-control-mode cursor (mouse glide -> crosshair,
-        // else arrow, auto-hidden via the HUD).
+        // restore the flight-control-mode cursor: warp-mode mouse (relative,
+        // recentered) hides the cursor, glide-mode mouse (absolute) shows the
+        // crosshair aim point, and joystick/keyboard (mouse not enabled) hides.
         if (launchedWithConfigure) {
             changeCursor(CursorType::arrow);
             showCursor();
-        } else if (configuration().joystick.mouse_cursor) {
-            changeCursor(CursorType::crosshairs);
-            showCursor();
+        } else if (configuration().mouse.enabled) {
+            if (configuration().joystick.warp_mouse) {
+                hideCursor();
+            } else {
+                changeCursor(CursorType::crosshairs);
+                showCursor();
+            }
         } else {
             changeCursor(CursorType::arrow);
             hideCursor();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -47,6 +47,7 @@
 #include "src/in_kb_data.h"
 #include "src/in_mouse.h"
 #include "src/in_joystick.h"
+#include "gldrv/mouse_cursor.h"
 #include "src/in_main.h"
 #if defined (__APPLE__)
 #import <sys/param.h>
@@ -854,9 +855,24 @@ unsigned int Universe::numPlayers() {
 void Universe::ToggleOptionsActive() {
     optionsActive = !optionsActive;
     fprintf(stderr, "[config-screen debug] ToggleOptionsActive -> %d\n", (int)optionsActive); fflush(stderr);
-    // Show the cursor when the config screen is open (so the user can click),
-    // hide it again when closed. The in-flight HUD keeps the cursor hidden.
-    winsys_show_cursor(optionsActive);
+    // The settings screen shows the VS default (non-crosshair) arrow cursor.
+    // switch the SDL cursor TYPE immediately and show it, not just toggle a
+    // raw OS cursor show/hide (which is why a stale crosshair showed briefly).
+    if (optionsActive) {
+        changeCursor(CursorType::arrow);
+        showCursor();
+    } else {
+        // Back in flight: restore the cursor for the active flight control mode.
+        // Mouse glide -> crosshair, otherwise keep the VS arrow (auto-hide via
+        // the HUD where appropriate).
+        if (configuration().joystick.mouse_cursor) {
+            changeCursor(CursorType::crosshairs);
+            showCursor();
+        } else {
+            changeCursor(CursorType::arrow);
+            hideCursor();
+        }
+    }
     // While the config overlay is open, consume input in winsys (no click-through).
     winsys_set_config_overlay_active(optionsActive);
     // On close, clear any input (mouse/joystick/keyboard) still stuck DOWN

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -45,6 +45,8 @@
 #include "cmd/script/mission.h"
 #include "src/in_kb.h"
 #include "src/in_kb_data.h"
+#include "src/in_mouse.h"
+#include "src/in_joystick.h"
 #include "src/in_main.h"
 #if defined (__APPLE__)
 #import <sys/param.h>
@@ -846,6 +848,16 @@ void Universe::ToggleOptionsActive() {
     // Show the cursor when the config screen is open (so the user can click),
     // hide it again when closed. The in-flight HUD keeps the cursor hidden.
     winsys_show_cursor(optionsActive);
+    // While the config overlay is open, consume input in winsys (no click-through).
+    winsys_set_config_overlay_active(optionsActive);
+    // On close, clear any input (mouse/joystick/keyboard) still stuck DOWN
+    // (its release was swallowed by the overlay input path) so it doesn't fire
+    // a command continuously once flight polling resumes.
+    if (!optionsActive) {
+        ResetMouseState();
+        RestoreJoystickState();
+        RestoreKB();
+    }
 }
 
 void DrawConfigOverlay() {

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -881,13 +881,11 @@ void Universe::ToggleOptionsActive() {
             changeCursor(CursorType::arrow);
             showCursor();
         } else if (configuration().mouse.enabled) {
-            // Only glide mouse modes show a cursor; warp and no_mouse modes hide it.
-            if (configuration().joystick.mouse_cursor) {
-                changeCursor(CursorType::crosshairs);
-                showCursor();
-            } else {
-                hideCursor();
-            }
+            // Glide mouse flight: the in-game crosshair sprite (drawn in
+            // GameCockpit::Draw) renders the cursor so we can scale it within the
+            // deadband and mirror its Y for inverse-glide. Hide the OS cursor to
+            // avoid drawing both. Warp and no_mouse modes hide it too.
+            hideCursor();
         } else {
             changeCursor(CursorType::arrow);
             hideCursor();

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -856,7 +856,6 @@ unsigned int Universe::numPlayers() {
 
 void Universe::ToggleOptionsActive() {
     optionsActive = !optionsActive;
-    fprintf(stderr, "[config-screen debug] ToggleOptionsActive -> %d\n", (int)optionsActive); fflush(stderr);
     // The settings screen shows the VS default (non-crosshair) arrow cursor.
     // switch the SDL cursor TYPE immediately and show it, not just toggle a
     // raw OS cursor show/hide (which is why a stale crosshair showed briefly).

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -38,6 +38,8 @@
 #include "root_generic/galaxy_xml.h"
 #include <algorithm>
 #include "src/config_xml.h"
+#include "gldrv/winsys.h"
+#include "gui/config_screen.h"
 #include "root_generic/vs_globals.h"
 #include "src/audiolib.h"
 #include "cmd/script/mission.h"
@@ -438,6 +440,9 @@ void Universe::StartDraw() {
             activeStarSystem()->Draw();
         }
 
+        // In-game config overlay (Alt+C) on top — no-op unless optionsActive.
+        DrawConfigOverlay();
+
         // ImGui End Frame
         ImGui::End();
         // Rendering
@@ -833,6 +838,20 @@ UnitCollection &Universe::getActiveStarSystemUnitList() {
 
 unsigned int Universe::numPlayers() {
     return _cockpits.size();
+}
+
+void Universe::ToggleOptionsActive() {
+    optionsActive = !optionsActive;
+    // Show the cursor when the config screen is open (so the user can click),
+    // hide it again when closed. The in-flight HUD keeps the cursor hidden.
+    winsys_show_cursor(optionsActive);
+}
+
+void DrawConfigOverlay() {
+    if (!_Universe->isOptionsActive()) {
+        return;
+    }
+    vs_settings_ng::DrawConfigScreen();
 }
 
 

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -438,7 +438,11 @@ void Universe::StartDraw() {
         ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
         ImGui::Begin("main_window", nullptr, window_flags);
 
-        if (!RefreshGUI() && !UniverseUtil::isSplashScreenShowing()) {
+        // When the in-game settings overlay (alt+C) is open, skip drawing the
+        // star system/HUD entirely so ONLY the settings screen is shown (the
+        // game is paused, not just frozen). On 0.10.x the HUD draws via its own
+        // GL method (not ImGui), so an opaque ImGui window alone doesn't stop it.
+        if (!optionsActive && !RefreshGUI() && !UniverseUtil::isSplashScreenShowing()) {
             activeStarSystem()->Draw();
         }
 

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -881,11 +881,12 @@ void Universe::ToggleOptionsActive() {
             changeCursor(CursorType::arrow);
             showCursor();
         } else if (configuration().mouse.enabled) {
-            if (configuration().joystick.warp_mouse) {
-                hideCursor();
-            } else {
+            // Only glide mouse modes show a cursor; warp and no_mouse modes hide it.
+            if (configuration().joystick.mouse_cursor) {
                 changeCursor(CursorType::crosshairs);
                 showCursor();
+            } else {
+                hideCursor();
             }
         } else {
             changeCursor(CursorType::arrow);

--- a/engine/src/universe.cpp
+++ b/engine/src/universe.cpp
@@ -842,6 +842,7 @@ unsigned int Universe::numPlayers() {
 
 void Universe::ToggleOptionsActive() {
     optionsActive = !optionsActive;
+    fprintf(stderr, "[config-screen debug] ToggleOptionsActive -> %d\n", (int)optionsActive); fflush(stderr);
     // Show the cursor when the config screen is open (so the user can click),
     // hide it again when closed. The in-flight HUD keeps the cursor hidden.
     winsys_show_cursor(optionsActive);

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -46,6 +46,7 @@
 class Universe {
     // Fields
     bool optionsActive = false;  // in-game config screen overlay is open (non-blocking pause)
+    bool launchedWithConfigure = false;  // --configure: opened settings at launch; close -> base arrow cursor
 
 public:
     StarDate current_stardate;
@@ -145,6 +146,7 @@ public:
     unsigned int numPlayers();
 
     void ToggleOptionsActive();
+    void MarkLaunchedWithConfigure() { launchedWithConfigure = true; }
     bool isOptionsActive() const { return optionsActive; }
 };
 

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -45,6 +45,8 @@
  */
 class Universe {
     // Fields
+    bool optionsActive = false;  // in-game config screen overlay is open (non-blocking pause)
+
 public:
     StarDate current_stardate;
     vector<StarSystem *> star_system;
@@ -141,6 +143,12 @@ public:
     void LoadFactionXML(const char *factfile);
     UnitCollection &getActiveStarSystemUnitList();
     unsigned int numPlayers();
+
+    void ToggleOptionsActive();
+    bool isOptionsActive() const { return optionsActive; }
 };
+
+// Draw the in-game config overlay (transparent, on top) when optionsActive.
+void DrawConfigOverlay();
 
 #endif //VEGA_STRIKE_ENGINE_UNIVERSE_H

--- a/engine/src/universe.h
+++ b/engine/src/universe.h
@@ -46,7 +46,6 @@
 class Universe {
     // Fields
     bool optionsActive = false;  // in-game config screen overlay is open (non-blocking pause)
-    bool launchedWithConfigure = false;  // --configure: opened settings at launch; close -> base arrow cursor
 
 public:
     StarDate current_stardate;
@@ -146,7 +145,6 @@ public:
     unsigned int numPlayers();
 
     void ToggleOptionsActive();
-    void MarkLaunchedWithConfigure() { launchedWithConfigure = true; }
     bool isOptionsActive() const { return optionsActive; }
 };
 

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -167,6 +167,24 @@ void Movable::UpdatePhysics(const Transformation& trans,
         //clamp velocity
         // TODO: use resource class to do this more elegantly
         ResolveForces(trans, transmat);
+        // Enforce the flight computer's set speed on the RESULTING velocity
+        // magnitude (not per-axis), so turning or moving diagonally cannot push
+        // the ship past the speed the pilot set. This runs after the velocity
+        // integration, so it holds for the frame. Warp (SPEC) is exempt.
+        const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
+        if (graphicOptions.WarpFieldStrength == 1.0) {
+            double limit = unit->computer.set_speed;
+            // If already moving faster than set_speed (e.g. afterburn), allow up
+            // to the afterburner speed so the boost is not cut off abruptly.
+            const double mag = Velocity.Magnitude();
+            if (mag > limit && unit->afterburner.CanConsume()) {
+                limit = unit->MaxAfterburnerSpeed();
+            }
+            if (limit > 0 && mag > limit) {
+                Velocity *= (limit / mag);
+            }
+        }
+        // Hard per-axis physical safety cap (applies in all modes, incl. warp).
         float velocity_max = configuration().physics.velocity_max_flt;
         if (Velocity.i > velocity_max) {
             Velocity.i = velocity_max;

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -682,66 +682,8 @@ Vector Movable::ClampThrust(const Vector &amt1, bool afterburn) {
     if (amt1.k > ablimit) {
         Res.k = ablimit;
     }
-    // Retro (braking) thrust: afterburn also boosts deceleration, so the
-    // afterburner's extra thrust is available when braking just as it is when
-    // accelerating forward. Mirrors the forward ablimit formula.
-    float retro_limit = unit->drive.retro.Value();
-    if (afterburn) {
-        retro_limit =
-                (unit->afterburner.thrust - unit->drive.retro.Value()) * abfuelclamp
-                + unit->drive.retro.Value() * fuelclamp;
-    }
-    if (amt1.k < -retro_limit) {
-        Res.k = -retro_limit;
-    }
-    if (!afterburn) {
-        // At or above the set speed and moving forward, the FCMP may only
-        // REDIRECT the velocity, not accelerate it. After the per-axis
-        // clamps, remove the component of the final thrust parallel to the
-        // current velocity. The remaining thrust is perpendicular to the
-        // velocity: it rotates the velocity toward the intended (forward)
-        // direction while keeping the speed constant, so the total speed can
-        // never overshoot the set point. This continues until all speed is in
-        // the intended direction.
-        //
-        // IMPORTANT: use the FRESH local velocity (UpCoordinateLevel of the
-        // world velocity), exactly as the FCMP does. The raw Velocity member
-        // is not re-expressed when the ship rotates, so it is stale/mixed
-        // after a turn and projecting against it leaves residuals that
-        // accumulate into overshoot.
-        //
-        // If the perpendicular result exceeds a per-axis thruster limit,
-        // scale it down PRESERVING DIRECTION (never re-clamp per-axis, which
-        // would reintroduce the accelerating component).
-        //
-        // Deceleration is never affected: moving backward (Velocity.k < 0)
-        // skips this, and retro thrust is parallel-negative so it is kept.
-        // Afterburn is exempt: it is meant to accelerate.
-        const Vector local_vel = UpCoordinateLevel(GetVelocity());
-        const float speed = local_vel.Magnitude();
-        if (speed >= unit->computer.set_speed && local_vel.k > 0 && speed > 0) {
-            const Vector vhat = local_vel / speed;
-            const double parallel = Res.Dot(vhat);
-            if (parallel > 0) {
-                Res -= vhat * parallel;
-                // Scale the whole vector down (preserving direction) so each
-                // axis stays within its physical thruster limit.
-                float scale = 1.0f;
-                const float lim_i = fabs(fuelclamp * unit->drive.lateral);
-                const float lim_j = fabs(fuelclamp * unit->drive.vertical);
-                const float lim_k = (Res.k > 0) ? ablimit : retro_limit;
-                if (lim_i > 0 && fabs(Res.i) > lim_i) {
-                    scale = std::min(scale, lim_i / fabs(Res.i));
-                }
-                if (lim_j > 0 && fabs(Res.j) > lim_j) {
-                    scale = std::min(scale, lim_j / fabs(Res.j));
-                }
-                if (lim_k > 0 && fabs(Res.k) > lim_k) {
-                    scale = std::min(scale, lim_k / fabs(Res.k));
-                }
-                Res *= scale;
-            }
-        }
+    if (amt1.k < -unit->drive.retro) {
+        Res.k = -unit->drive.retro;
     }
 
     if (afterburn) {

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -167,42 +167,21 @@ void Movable::UpdatePhysics(const Transformation& trans,
         //clamp velocity
         // TODO: use resource class to do this more elegantly
         ResolveForces(trans, transmat);
-        // Enforce the flight computer's set speed on the RESULTING velocity
-        // magnitude (not per-axis), so turning or moving diagonally cannot push
-        // the ship past the speed the pilot set. This runs after the velocity
-        // integration, so it holds for the frame. Warp (SPEC) is exempt.
-        // The limits come from the drive/afterburner Resource values via
-        // MaxSpeed()/MaxAfterburnerSpeed(); the hardcoded velocity_max_flt
-        // per-axis cap is no longer needed.
-        const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
-        if (graphicOptions.WarpFieldStrength == 1.0) {
-            double limit = unit->computer.set_speed;
-            // Allow up to the afterburner speed only when the afterburner is
-            // ACTIVELY engaged (afterburn && CanConsume, set in Movable::Thrust).
-            // A fuel-only proxy (CanConsume) would wrongly lift the limit during
-            // a turn, letting turn overspeed ride up to the afterburn speed.
-            const double mag = Velocity.Magnitude();
-            if (mag > limit) {
-                if (unit->afterburner.active) {
-                    limit = unit->MaxAfterburnerSpeed();
-                }
-                if (mag > limit) {
-                    // Decelerate toward the limit at the max rate the opposing
-                    // thrusters can produce (per-axis drive limits), not an
-                    // instant snap. Overspeed from afterburn release, travel
-                    // mode, or turns bleeds off at the ship's real
-                    // deceleration capability. Use the direction opposite to
-                    // the current velocity so forward motion bleeds via retro
-                    // thrust, sideways via lateral, etc.
-                    const double decel = GetMaxAccelerationInDirectionOf(-Velocity, unit->afterburner.active);
-                    const double bleed = decel * simulation_atom_var;
-                    double newmag = mag - bleed;
-                    if (newmag < limit) {
-                        newmag = limit;
-                    }
-                    Velocity *= (newmag / mag);
-                }
-            }
+        float velocity_max = configuration().physics.velocity_max_flt;
+        if (Velocity.i > velocity_max) {
+            Velocity.i = velocity_max;
+        } else if (Velocity.i < -velocity_max) {
+            Velocity.i = -velocity_max;
+        }
+        if (Velocity.j > velocity_max) {
+            Velocity.j = velocity_max;
+        } else if (Velocity.j < -velocity_max) {
+            Velocity.j = -velocity_max;
+        }
+        if (Velocity.k > velocity_max) {
+            Velocity.k = velocity_max;
+        } else if (Velocity.k < -velocity_max) {
+            Velocity.k = -velocity_max;
         }
     }
 
@@ -765,10 +744,6 @@ void Movable::RollTorque(float amt) {
 void Movable::Thrust(const Vector &amt1, bool afterburn) {
     Unit *unit = vega_dynamic_cast_ptr<Unit>(this);
     afterburn = afterburn && unit->afterburner.CanConsume();
-    // Record whether the afterburner is actively engaged this step. The velocity
-    // clamp in UpdatePhysics reads this to allow afterburn speed only when the
-    // burner is truly active (not merely when fuel exists).
-    unit->afterburner.active = afterburn;
 
     //Unit::Thrust( amt1, afterburn );
     {

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -167,21 +167,42 @@ void Movable::UpdatePhysics(const Transformation& trans,
         //clamp velocity
         // TODO: use resource class to do this more elegantly
         ResolveForces(trans, transmat);
-        float velocity_max = configuration().physics.velocity_max_flt;
-        if (Velocity.i > velocity_max) {
-            Velocity.i = velocity_max;
-        } else if (Velocity.i < -velocity_max) {
-            Velocity.i = -velocity_max;
-        }
-        if (Velocity.j > velocity_max) {
-            Velocity.j = velocity_max;
-        } else if (Velocity.j < -velocity_max) {
-            Velocity.j = -velocity_max;
-        }
-        if (Velocity.k > velocity_max) {
-            Velocity.k = velocity_max;
-        } else if (Velocity.k < -velocity_max) {
-            Velocity.k = -velocity_max;
+        // Enforce the flight computer's set speed on the RESULTING velocity
+        // magnitude (not per-axis), so turning or moving diagonally cannot push
+        // the ship past the speed the pilot set. This runs after the velocity
+        // integration, so it holds for the frame. Warp (SPEC) is exempt.
+        // The limits come from the drive/afterburner Resource values via
+        // MaxSpeed()/MaxAfterburnerSpeed(); the hardcoded velocity_max_flt
+        // per-axis cap is no longer needed.
+        const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
+        if (graphicOptions.WarpFieldStrength == 1.0) {
+            double limit = unit->computer.set_speed;
+            // Allow up to the afterburner speed only when the afterburner is
+            // ACTIVELY engaged (afterburn && CanConsume, set in Movable::Thrust).
+            // A fuel-only proxy (CanConsume) would wrongly lift the limit during
+            // a turn, letting turn overspeed ride up to the afterburn speed.
+            const double mag = Velocity.Magnitude();
+            if (mag > limit) {
+                if (unit->afterburner.active) {
+                    limit = unit->MaxAfterburnerSpeed();
+                }
+                if (mag > limit) {
+                    // Decelerate toward the limit at the max rate the opposing
+                    // thrusters can produce (per-axis drive limits), not an
+                    // instant snap. Overspeed from afterburn release, travel
+                    // mode, or turns bleeds off at the ship's real
+                    // deceleration capability. Use the direction opposite to
+                    // the current velocity so forward motion bleeds via retro
+                    // thrust, sideways via lateral, etc.
+                    const double decel = GetMaxAccelerationInDirectionOf(-Velocity, unit->afterburner.active);
+                    const double bleed = decel * simulation_atom_var;
+                    double newmag = mag - bleed;
+                    if (newmag < limit) {
+                        newmag = limit;
+                    }
+                    Velocity *= (newmag / mag);
+                }
+            }
         }
     }
 
@@ -744,6 +765,10 @@ void Movable::RollTorque(float amt) {
 void Movable::Thrust(const Vector &amt1, bool afterburn) {
     Unit *unit = vega_dynamic_cast_ptr<Unit>(this);
     afterburn = afterburn && unit->afterburner.CanConsume();
+    // Record whether the afterburner is actively engaged this step. The velocity
+    // clamp in UpdatePhysics reads this to allow afterburn speed only when the
+    // burner is truly active (not merely when fuel exists).
+    unit->afterburner.active = afterburn;
 
     //Unit::Thrust( amt1, afterburn );
     {

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -167,24 +167,6 @@ void Movable::UpdatePhysics(const Transformation& trans,
         //clamp velocity
         // TODO: use resource class to do this more elegantly
         ResolveForces(trans, transmat);
-        // Enforce the flight computer's set speed on the RESULTING velocity
-        // magnitude (not per-axis), so turning or moving diagonally cannot push
-        // the ship past the speed the pilot set. This runs after the velocity
-        // integration, so it holds for the frame. Warp (SPEC) is exempt.
-        const Unit *unit = vega_dynamic_const_cast_ptr<const Unit>(this);
-        if (graphicOptions.WarpFieldStrength == 1.0) {
-            double limit = unit->computer.set_speed;
-            // If already moving faster than set_speed (e.g. afterburn), allow up
-            // to the afterburner speed so the boost is not cut off abruptly.
-            const double mag = Velocity.Magnitude();
-            if (mag > limit && unit->afterburner.CanConsume()) {
-                limit = unit->MaxAfterburnerSpeed();
-            }
-            if (limit > 0 && mag > limit) {
-                Velocity *= (limit / mag);
-            }
-        }
-        // Hard per-axis physical safety cap (applies in all modes, incl. warp).
         float velocity_max = configuration().physics.velocity_max_flt;
         if (Velocity.i > velocity_max) {
             Velocity.i = velocity_max;

--- a/libraries/cmd/movable.cpp
+++ b/libraries/cmd/movable.cpp
@@ -682,8 +682,66 @@ Vector Movable::ClampThrust(const Vector &amt1, bool afterburn) {
     if (amt1.k > ablimit) {
         Res.k = ablimit;
     }
-    if (amt1.k < -unit->drive.retro) {
-        Res.k = -unit->drive.retro;
+    // Retro (braking) thrust: afterburn also boosts deceleration, so the
+    // afterburner's extra thrust is available when braking just as it is when
+    // accelerating forward. Mirrors the forward ablimit formula.
+    float retro_limit = unit->drive.retro.Value();
+    if (afterburn) {
+        retro_limit =
+                (unit->afterburner.thrust - unit->drive.retro.Value()) * abfuelclamp
+                + unit->drive.retro.Value() * fuelclamp;
+    }
+    if (amt1.k < -retro_limit) {
+        Res.k = -retro_limit;
+    }
+    if (!afterburn) {
+        // At or above the set speed and moving forward, the FCMP may only
+        // REDIRECT the velocity, not accelerate it. After the per-axis
+        // clamps, remove the component of the final thrust parallel to the
+        // current velocity. The remaining thrust is perpendicular to the
+        // velocity: it rotates the velocity toward the intended (forward)
+        // direction while keeping the speed constant, so the total speed can
+        // never overshoot the set point. This continues until all speed is in
+        // the intended direction.
+        //
+        // IMPORTANT: use the FRESH local velocity (UpCoordinateLevel of the
+        // world velocity), exactly as the FCMP does. The raw Velocity member
+        // is not re-expressed when the ship rotates, so it is stale/mixed
+        // after a turn and projecting against it leaves residuals that
+        // accumulate into overshoot.
+        //
+        // If the perpendicular result exceeds a per-axis thruster limit,
+        // scale it down PRESERVING DIRECTION (never re-clamp per-axis, which
+        // would reintroduce the accelerating component).
+        //
+        // Deceleration is never affected: moving backward (Velocity.k < 0)
+        // skips this, and retro thrust is parallel-negative so it is kept.
+        // Afterburn is exempt: it is meant to accelerate.
+        const Vector local_vel = UpCoordinateLevel(GetVelocity());
+        const float speed = local_vel.Magnitude();
+        if (speed >= unit->computer.set_speed && local_vel.k > 0 && speed > 0) {
+            const Vector vhat = local_vel / speed;
+            const double parallel = Res.Dot(vhat);
+            if (parallel > 0) {
+                Res -= vhat * parallel;
+                // Scale the whole vector down (preserving direction) so each
+                // axis stays within its physical thruster limit.
+                float scale = 1.0f;
+                const float lim_i = fabs(fuelclamp * unit->drive.lateral);
+                const float lim_j = fabs(fuelclamp * unit->drive.vertical);
+                const float lim_k = (Res.k > 0) ? ablimit : retro_limit;
+                if (lim_i > 0 && fabs(Res.i) > lim_i) {
+                    scale = std::min(scale, lim_i / fabs(Res.i));
+                }
+                if (lim_j > 0 && fabs(Res.j) > lim_j) {
+                    scale = std::min(scale, lim_j / fabs(Res.j));
+                }
+                if (lim_k > 0 && fabs(Res.k) > lim_k) {
+                    scale = std::min(scale, lim_k / fabs(Res.k));
+                }
+                Res *= scale;
+            }
+        }
     }
 
     if (afterburn) {

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -2114,10 +2114,17 @@ bool Unit::UnDock(Unit *utdw) {
             // Send notification that a ship has undocked from a station
             _Universe->AccessCockpit()->OnDockEnd(utdw, this);
 
-            // Change mouse cursor to crosshairs
+            // In flight: warp mode (relative mouse, recentered each frame)
+            // hides the cursor; glide mode (absolute mouse) shows the
+            // crosshair at the mouse position as the aim point. Joystick
+            // / keyboard (mouse not enabled) hides it too.
             if(IsPlayerShip()) {
                 if(configuration().mouse.enabled) {
-                    changeCursor(CursorType::crosshairs);
+                    if (configuration().joystick.warp_mouse) {
+                        hideCursor();
+                    } else {
+                        changeCursor(CursorType::crosshairs);
+                    }
                 } else {
                     hideCursor();
                 }

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -2114,16 +2114,15 @@ bool Unit::UnDock(Unit *utdw) {
             // Send notification that a ship has undocked from a station
             _Universe->AccessCockpit()->OnDockEnd(utdw, this);
 
-            // In flight: warp mode (relative mouse, recentered each frame)
-            // hides the cursor; glide mode (absolute mouse) shows the
-            // crosshair at the mouse position as the aim point. Joystick
+            // In flight: only glide mouse modes show the crosshair aim point.
+            // Warp and no_mouse modes (relative/recentered) hide it, and joystick
             // / keyboard (mouse not enabled) hides it too.
             if(IsPlayerShip()) {
                 if(configuration().mouse.enabled) {
-                    if (configuration().joystick.warp_mouse) {
-                        hideCursor();
-                    } else {
+                    if (configuration().joystick.mouse_cursor) {
                         changeCursor(CursorType::crosshairs);
+                    } else {
+                        hideCursor();
                     }
                 } else {
                     hideCursor();

--- a/libraries/cmd/unit_generic.cpp
+++ b/libraries/cmd/unit_generic.cpp
@@ -2116,17 +2116,12 @@ bool Unit::UnDock(Unit *utdw) {
 
             // In flight: only glide mouse modes show the crosshair aim point.
             // Warp and no_mouse modes (relative/recentered) hide it, and joystick
-            // / keyboard (mouse not enabled) hides it too.
+            // / keyboard (mouse not enabled) hides it too. In glide the OS cursor
+            // is hidden and the in-game crosshair sprite (drawn in
+            // GameCockpit::Draw) is shown instead (so it can be deadband-scaled
+            // and Y-mirrored for inverse-glide).
             if(IsPlayerShip()) {
-                if(configuration().mouse.enabled) {
-                    if (configuration().joystick.mouse_cursor) {
-                        changeCursor(CursorType::crosshairs);
-                    } else {
-                        hideCursor();
-                    }
-                } else {
-                    hideCursor();
-                }
+                hideCursor();
             }
 
             return true;

--- a/libraries/cmd/weapon_factory.h
+++ b/libraries/cmd/weapon_factory.h
@@ -28,7 +28,6 @@
 #define VEGA_STRIKE_ENGINE_CMD_WEAPON_FACTORY_H
 
 #include <string>
-#include <boost/json.hpp>
 
 class WeaponFactory {
 public:

--- a/libraries/gui/gui.cpp
+++ b/libraries/gui/gui.cpp
@@ -58,6 +58,12 @@ void InitGui() {
     ImGui_ImplOpenGL3_Init(glsl_version);
 
     ImGuiIO& io = ImGui::GetIO();
+    // The game manages its own cursor (changeCursor/hideCursor/showCursor: arrow in
+    // bases, crosshair in glide mouse, hidden otherwise). By default the ImGui SDL2
+    // backend forces the OS cursor on/off every frame based on ImGui::GetMouseCursor(),
+    // which overrides hideCursor and re-shows the arrow in flight. Stop ImGui from
+    // changing the OS cursor so the game's cursor model wins.
+    io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
     io.Fonts->Clear();
     ImFontConfig cfg;
     cfg.SizePixels = 18.0f;

--- a/libraries/gui/gui.cpp
+++ b/libraries/gui/gui.cpp
@@ -66,18 +66,36 @@ void InitGui() {
     gui_initialized = true;
 }
 
-// Rebuild the ImGui font atlas at the given pixel size (settings screen).
-// 0.10.x has no pending-frame mechanism, so apply it immediately.
+// A pending font-size change, applied synchronously at the NEXT frame start (see
+// ImGui_ApplyPendingFontSize) rather than during the settings Save, so the font
+// texture isn't destroyed/rebuilt mid-frame (which segfaults the GL HUD).
+static float s_pending_font_size = 0.0f;
+
+// Request that the ImGui font atlas be rebuilt at the given pixel size on the
+// next frame. Used by the settings screen font-point control.
 void RequestImGuiFontSize(float fontSize) {
     if (fontSize <= 0.0f) return;
+    s_pending_font_size = fontSize;
+}
+
+// Apply a pending font-size change by rebuilding the font atlas. Call at the
+// start of each ImGui frame, before ImGui::NewFrame(), so the new atlas is in
+// place for the whole frame and no glyphs reference a destroyed texture.
+void ImGui_ApplyPendingFontSize() {
+    if (s_pending_font_size <= 0.0f) {
+        return;
+    }
     ImGuiIO &io = ImGui::GetIO();
     ImGui_ImplOpenGL3_DestroyFontsTexture();
     io.Fonts->Clear();
     ImFontConfig cfg;
-    cfg.SizePixels = fontSize;
+    cfg.SizePixels = s_pending_font_size;
     io.FontDefault = io.Fonts->AddFontDefault(&cfg);
     io.Fonts->Build();
     ImGui_ImplOpenGL3_CreateFontsTexture();
+    // Set the render size explicitly so on-screen text follows the new size.
+    ImGui::GetStyle().FontSizeBase = s_pending_font_size;
+    s_pending_font_size = 0.0f;
 }
 
 void CleanupGui() {

--- a/libraries/gui/gui.cpp
+++ b/libraries/gui/gui.cpp
@@ -66,6 +66,20 @@ void InitGui() {
     gui_initialized = true;
 }
 
+// Rebuild the ImGui font atlas at the given pixel size (settings screen).
+// 0.10.x has no pending-frame mechanism, so apply it immediately.
+void RequestImGuiFontSize(float fontSize) {
+    if (fontSize <= 0.0f) return;
+    ImGuiIO &io = ImGui::GetIO();
+    ImGui_ImplOpenGL3_DestroyFontsTexture();
+    io.Fonts->Clear();
+    ImFontConfig cfg;
+    cfg.SizePixels = fontSize;
+    io.FontDefault = io.Fonts->AddFontDefault(&cfg);
+    io.Fonts->Build();
+    ImGui_ImplOpenGL3_CreateFontsTexture();
+}
+
 void CleanupGui() {
     // Cleanup
     ImGui_ImplOpenGL3_Shutdown();

--- a/libraries/gui/gui.cpp
+++ b/libraries/gui/gui.cpp
@@ -93,8 +93,8 @@ void ImGui_ApplyPendingFontSize() {
     io.FontDefault = io.Fonts->AddFontDefault(&cfg);
     io.Fonts->Build();
     ImGui_ImplOpenGL3_CreateFontsTexture();
-    // Set the render size explicitly so on-screen text follows the new size.
-    ImGui::GetStyle().FontSizeBase = s_pending_font_size;
+    // The glyph size is set by ImFontConfig.SizePixels above (0.10.x ImGui has
+    // no FontSizeBase member), so text renders at the new size via the atlas.
     s_pending_font_size = 0.0f;
 }
 

--- a/libraries/gui/gui.h
+++ b/libraries/gui/gui.h
@@ -36,6 +36,7 @@ extern bool gui_initialized;
 extern SDL_Window* current_window;
 
 void InitGui();
+void RequestImGuiFontSize(float fontSize);
 void CleanupGui();
 
 #endif // VEGA_STRIKE_LIBRARIES_GUI_GUI_H

--- a/libraries/gui/gui.h
+++ b/libraries/gui/gui.h
@@ -37,6 +37,7 @@ extern SDL_Window* current_window;
 
 void InitGui();
 void RequestImGuiFontSize(float fontSize);
+void ImGui_ApplyPendingFontSize();
 void CleanupGui();
 
 #endif // VEGA_STRIKE_LIBRARIES_GUI_GUI_H

--- a/libraries/vegadisk/vsfilesystem.cpp
+++ b/libraries/vegadisk/vsfilesystem.cpp
@@ -869,10 +869,23 @@ void InitPaths(string conf, string subdir) {
         SubDirectories.push_back(vec);
     }
 
-    const boost::filesystem::path config_file_path{datadir + "/config.json"};
-    (const_cast<vega_config::Configuration&>(configuration())).load_config(config_file_path);
-    const boost::filesystem::path config_file_path2{homedir + "/config.json"};
-    (const_cast<vega_config::Configuration&>(configuration())).load_config(config_file_path2);
+    // Load the split config files (config.json + bindings.json + theme.json + engine.json),
+    // merging each into the same configuration singleton. load_config() tolerates missing
+    // files, so if only config.json exists, only that is loaded.
+    //
+    // Precedence (later loads overwrite earlier ones):
+    //   1. All datadir files first (defaults).
+    //   2. All homedir files second (user overrides win over defaults).
+    //   3. Within each group, config.json loads last, so a user-facing setting in config.json
+    //      overwrites the same key in engine.json/theme.json/bindings.json.
+    for (const std::string & config_file_name : {"bindings.json", "theme.json", "engine.json", "config.json"}) {
+        (const_cast<vega_config::Configuration&>(configuration())).load_config(
+            boost::filesystem::path(datadir + "/" + config_file_name));
+    }
+    for (const std::string & config_file_name : {"bindings.json", "theme.json", "engine.json", "config.json"}) {
+        (const_cast<vega_config::Configuration&>(configuration())).load_config(
+            boost::filesystem::path(homedir + "/" + config_file_name));
+    }
 
     LoadConfig(std::move(subdir));
 

--- a/libraries/vegadisk/vsfilesystem.cpp
+++ b/libraries/vegadisk/vsfilesystem.cpp
@@ -879,11 +879,11 @@ void InitPaths(string conf, string subdir) {
     //   3. Within each group, config.json loads last, so a user-facing setting in config.json
     //      overwrites the same key in engine.json/theme.json/bindings.json.
     for (const std::string & config_file_name : {"bindings.json", "theme.json", "engine.json", "config.json"}) {
-        (const_cast<vega_config::Configuration&>(configuration())).load_config(
+        (configuration()).load_config(
             boost::filesystem::path(datadir + "/" + config_file_name));
     }
     for (const std::string & config_file_name : {"bindings.json", "theme.json", "engine.json", "config.json"}) {
-        (const_cast<vega_config::Configuration&>(configuration())).load_config(
+        (configuration()).load_config(
             boost::filesystem::path(homedir + "/" + config_file_name));
     }
 


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

#### Basic Play Test

[](https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation#basic-play-test)

The author of the changes should run the game and do the actions described below. Starting a new game, and completing these steps in this order should take around 10-15 minutes.

- [x] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
- [x] From the Main Menu, start a new Campaign.
- [x] Basic flight.
- [x] Docking to a planet.
- [x] On planet actions:
    - [x] Save the game.
    - [x] Read news.
    - [x] Buy/Sell some goods.
    - [x] Buy/Sell a ship upgrade.
    - [x] Accept a mission from the bulletin board.
    - [x] Talk to someone in the bar.
- [x] Primary and secondary weapon usage.
- [x] Fight (you can fight with Oswald).
- [x] SPEC flight.
- [x] A jump to a different system.
- [x] Docking to a non-planet location (mining base, etc).
- [x] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
- [x] Save the game again.
- [x] Upgrade your new ship.
- [x] Save once more.
- [x] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
- [x] Quit Vega Strike. Make sure it doesn't segfault on exit.
- [x] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.

## Areas of interest

[](https://github.com/vegastrike/Vega-Strike-Engine-Source/wiki/Pull-Request-Validation#areas-of-interest)

While completing those steps, the tester should look for oddities, especially in the areas that he changed. In general the following aspects should be looked at:

- Graphics (textures, light, geometry, etc)
- Audio (noise, volume, synchronisation, etc)
- Physics (momentum, gravity, collision, etc)

---

# Config Screen Play Test — in-game config utility (Alt+C)

**Branch:** `vs-settings-ng-json` (Vega-Strike-Engine-Source)
**Companion assets:** Assets-Production with the split config files (config.json / bindings.json / engine.json)

> Copy of the basic play test above, expanded with a **config-screen-specific** test list.
> Every feature implemented in the config utility needs a test. Open the config screen with **Alt+C**.

## Entry point & navigation

- [x] Alt+C opens the config screen from the main menu.
- [x] Alt+C opens the config screen while in-flight (world paused / non-blocking).
- [x] Alt+C opens the config screen from a base computer / docked.
- [x] Alt+C closes the config screen and returns to the game.
- [x] Mouse cursor is visible and clickable inside the config screen for all frames.
- [x] No click-through: clicking a config control does not fire a game action behind it.
- [x] Config screen does not segfault on repeated open/close cycles.

## Display frame — resolution, aspect, fullscreen, font

- [x] Resolution list populates from the detected display modes.
- [x] Selecting a resolution **applies live** (windowed and fullscreen) without restart.
- [x] Changing resolution toggles between windowed and fullscreen correctly.
- [x] Fullscreen toggle applies live.
- [ ] Monitor selector (if present) works on a multi-display setup.
- [x] Font type selector present and selectable.
- [x] Font size / Text Height applies **live** and resizes text (not just blurs it).
- [x] Ideal font height suggestion scales with horizontal resolution (roughly width/80).
- [x] Font size persists across restart.

## Flight Control device selector — hot-swapping input devices

- [x] Flight control selector lists Keyboard / Mouse / Joystick.
- [x] Selecting the active device enables its settings; the non-active device's settings are greyed out / disabled.
- [x] **Hot-swap** to Keyboard: keyboard flight controls work immediately (no restart).
- [x] **Hot-swap** to Mouse: mouse flight works immediately — GetMouse sensitivity, warp recenter, cursor.
- [x] **Hot-swap** to Joystick: joystick flight works immediately.
- [x] Switching device after Save persists to the next launch.
- [x] No autofire / axis-leakage bug recurs when switching devices (the hotplug/attach fix holds).

## Mouse settings

- [x] Mouse flight mode (glide / warp) selector works.
- [x] Camera-cursor toggle.
- [x] Warp zone slider.
- [x] Mouse exponent slider.
- [x] Mouse deadband.
- [x] Mouse y-inversion derived from the preset (glide/warp invert y) and persisted to `input.mouse.inverse_y`.
- [x] Crosshair cursor visible in the HUD for mouse flight.

## Joystick settings

- [x] Per-axis live binding (assign a physical axis to an in-game axis).
- [x] Joystick hotplug: plug in a joystick after launch and it attaches without re-bind (no autofire).
- [x] Auto Deadband toggle/slider.
- [ ] Force-feedback device selector (if a FFB joystick is available).
- [ ] Joystick device selector.

## Bindings dialog

- [x] Bindings grouped by category.
- [x] Bindings shown per device (keyboard / mouse / joystick / hat).
- [x] **Real capture:** pressing a key/button/hat captures the binding live.
- [x] Add a new binding.
- [x] Delete an existing binding.
- [x] Conflict detection: binding an already-used key warns / blocks.
- [x] Bindings persist across restart.
- [x] Joystick axis unbind persists (a deliberately-unbound axis stays unbound).

## Presets frame

- [x] Preset dropdowns populate from `engine.json -> presets` (Computer, Physics, Geometry, Textures, Shaders, Sound, MusicAndVolume, Text, FactionTextures, Autodocker, Censorship).
- [x] Selecting a preset applies its resolved variables to `Configuration`.
- [x] Preset selection persists to config.json (survives restart).
- [x] Preset dropdowns render above the bottom button bar (not overlapping).
- [x] Presets frame auto-scales with the window.

## Save / Close (write-back)

- [x] Live-apply input bindings/axes/device on Save (re-runs bindKeys() without restart).
- [x] Save applies changes and **stays open** (does not close).
- [x] Close discards unsaved changes and closes.
- [x] Close is red when the screen has unsaved (dirty) changes.
- [x] Save writes a sparse overlay to `~/.vegastrike/config.json` (only overridden keys).
- [x] Save writes bindings to `~/.vegastrike/bindings.json`.
- [x] Unknown keys in config.json are preserved (sparse overlay does not clobber them).

## Persistence across restart

- [x] Every config change survives a full quit + relaunch (Load a saved game, reopen config screen).
- [x] Resolution / fullscreen persists.
- [x] Base aspect persists.
- [x] Font size persists.
- [x] Flight-control device persists.
- [x] Mouse + joystick settings persist.
- [x] Preset selections persist.
- [x] Input bindings persist.
- [x] homedir config.json wins over datadir config.json (user override respected).

## Config-overlay lifecycle (open/close regression)

Bugs fixed on this branch: stuck input states, stuck continuous-press sound, and cursor visibility per control device.
- [x] Open the config overlay, then close it — **no key/button state sticks** (no continuous fire, no stuck mouse button).
- [x] After closing the config overlay, **no continuous-press sound** (e.g. weapon fire/afterburner) keeps playing.
- [x] Flight Control: **Joystick** — config overlay shows **no mouse cursor** (joystick mode never shows a cursor; `mouse_cursor` forced false when switching from mouse back to joystick).
- [x] Flight Control: **Mouse** — config overlay shows the mouse cursor (needed for clicking).
- [x] Repeated Alt+C open/close does not leak input state across cycles.

## Config overlay clobber protection (homedir merge)

- [x] The config overlay **merges** dirty paths into the existing `~/.vegastrike/config.json` — it does **not** replace/overwrite the whole file.
- [x] Existing user-set keys (unrelated to the config screen) are preserved after a Save.
- [x] `bindings.json` overlay likewise merges rather than clobbers.

## Regression / broader integration

- [x] Base computer (ship view / upgrade view) loads without the `KeyError: 'constants'` / `'components'` errors.
- [x] HUD, radar, navscreen render correctly after config changes.
- [ ] Audio volume / mute toggles (if surfaced) apply.
- [x] Colors correct (theme.json) — no white border around base screens.
- [x] No `vegastrike.config` XML reads at runtime.
- [x] Game still loads a save, respawns after death, and exits without segfault after config changes.


Issues:
- Please list any related issues
- - Bases text highlighting was off <- Backported
- - Nav computer freezes input when the game when clicking on the "Nav Comp" button. Existing bug.
- - Crosshairs in glide mode don't resize when in deadband - fixed.
- - Jump immediately recharges - should take quite a while. Existing issue.
- - Overspeeding when turning <-ported.

Purpose:
- What is this pull request trying to do?
- - Add a settings utility for the 0.10 branch
- What release is this for?
- - 0.10
- Is there a project or milestone we should apply this to?
- 0.10
