### PR TITLE
Add macOS 26 Support to 0.10.x

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -30,11 +30,19 @@ jobs:
           - os: macOS-15-intel
             build-type: Debug
             preset-name: macos-pie-enabled-debug
-            python-version: 3.14.0
+            python-version: 3.14.7
           - os: macOS-15-intel
             build-type: RelWithDebInfo
             preset-name: macos-pie-enabled-RelWithDebInfo
-            python-version: 3.14.0
+            python-version: 3.14.7
+          - os: macOS-26-intel
+            build-type: Debug
+            preset-name: macos-pie-enabled-debug
+            python-version: 3.14.7
+          - os: macOS-26-intel
+            build-type: RelWithDebInfo
+            preset-name: macos-pie-enabled-RelWithDebInfo
+            python-version: 3.14.7
 
     steps:
       - name: Setup Python

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -32,7 +32,11 @@ jobs:
           - os: macOS-15-intel
             build-type: RelWithDebInfo
             preset-name: macos-pie-enabled-RelWithDebInfo
-            python-version: 3.14.0
+            python-version: 3.14.7
+          - os: macOS-26-intel
+            build-type: RelWithDebInfo
+            preset-name: macos-pie-enabled-RelWithDebInfo
+            python-version: 3.14.7
 
     steps:
       - name: Setup Python

--- a/script/bootstrap-mac.sh
+++ b/script/bootstrap-mac.sh
@@ -67,6 +67,9 @@ case "${DETECT_MAC_OS_VERSION}" in
     "15.0"|"15.1"|"15.2"|"15.3"|"15.4"|"15.5"|"15.6"|"15.7")
         MAC_OS_NAME="Sequoia"
         ;;
+    "26.0"|"26.1"|"26.2"|"26.3"|"26.4"|"26.5"|"26.6")
+        MAC_OS_NAME="Tahoe"
+        ;;
     *)
         echo "Unknown Mac Release: ${DETECT_MAC_OS_VERSION}"
         exit 1


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [x] Have the PR Validation Tests been run?
  - [x] Demonstrate that the issue is fixed or the feature exercised
    - [ ] Specific testing where a clear, present, demonstrable test can be provided; OR
    - [ ] Unit test(s) showing the exercise of the explicit code; OR
    - [ ] Play test (see below) that demonstrates the feature/issue; OR
    - [x] Build test when things directly impact how the build functions or some part of the build is generated
  - [ ] Play Tests
    - [ ] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
    - [ ] From the Main Menu, start a new Campaign.
    - [ ] Basic flight.
    - [ ] Docking to a planet.
    - [ ] On planet actions:
        - [ ] Save the game.
        - [ ] Read news.
        - [ ] Buy/Sell some goods.
        - [ ] Buy/Sell a ship upgrade.
        - [ ] Accept a mission from the bulletin board.
        - [ ] Talk to someone in the bar.
    - [ ] Primary and secondary weapon usage.
    - [ ] Fight (you can fight with Oswald).
    - [ ] SPEC flight.
    - [ ] A jump to a different system.
    - [ ] Docking to a non-planet location (mining base, etc).
    - [ ] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
    - [ ] Save the game again.
    - [ ] Upgrade your new ship.
    - [ ] Save once more.
    - [ ] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
    - [ ] Quit Vega Strike. Make sure it doesn't segfault on exit.
    - [ ] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
- [ ] This is a documentation change only

Issues Addressed:
- Implements #1728 for 0.10.x

Purpose:
- What is this pull request trying to do? Add macOS 26 support to 0.10.x. Also upgrade to the latest patch release of Python 3.14 while I'm at it.
- What release is this for? 0.10.x
- Is there a project or milestone we should apply this to? 0.10.x
