### PR TITLE
dock: never offer/dock with a sun (isSun guard in dock_utils)

### DIFF
--- a/libraries/cmd/dock_utils.cpp
+++ b/libraries/cmd/dock_utils.cpp
@@ -75,6 +75,12 @@ int CanDock(Unit *dock, Unit *ship, const bool ignore_occupancy) {
         return -1;
     }
 
+    // A sun/star is never dockable, regardless of how it is otherwise typed
+    // (a data file can mislabel a star as a normal body).
+    if (UnitUtil::isSun(dock)) {
+        return -1;
+    }
+
     double range = DistanceTwoTargets(dock, ship);
 
     // Planet Code
@@ -138,6 +144,11 @@ std::string GetDockingText(Unit *unit, Unit *target, double range) {
 
     // Jump point. Exit
     if (!target->pImage->destination.empty()) {
+        return std::string();
+    }
+
+    // A sun/star is never dockable.
+    if (UnitUtil::isSun(target)) {
         return std::string();
     }
 


### PR DESCRIPTION
PR #1104 (Fix Docking) added dock_utils::CanDock(), which docks ANY planet within radius without checking whether it is a sun -- so the player could dock with a star (e.g. Cephid_17 A). Add an early UnitUtil::isSun() guard to both CanDock() and GetDockingText() so a sun is never dockable, regardless of how it is otherwise typed. The old isDockableUnit() path already excluded suns; this aligns the new simple-dock path with it.

Thank you for submitting a pull request and becoming a contributor to the Vega Strike Core Engine.

Please answer the following:

Code Changes:
- [ ] Have the PR Validation Tests been run?
  - [ ] Demonstrate that the issue is fixed or the feature exercised
    - [ ] Specific testing where a clear, present, demonstrable test can be provided; OR
    - [ ] Unit test(s) showing the exercise of the explicit code; OR
    - [ ] Play test (see below) that demonstrates the feature/issue; OR
    - [ ] Build test when things directly impact how the build functions or some part of the build is generated
  - [ ] Play Tests
    - [x] From the Main Menu, view the Introduction and the Credits, and verify the Vega Strike version number(s) displayed on each.
    - [x] From the Main Menu, start a new Campaign.
    - [x] Basic flight.
    - [x] Docking to a planet.
    - [ ] On planet actions:
        - [x] Save the game.
        - [x] Read news.
        - [x] Buy/Sell some goods.
        - [x] Buy/Sell a ship upgrade.
        - [x] Accept a mission from the bulletin board.
        - [x] Talk to someone in the bar.
    - [x] Primary and secondary weapon usage.
    - [x] Fight (you can fight with Oswald).
    - [x] SPEC flight.
    - [x] A jump to a different system.
    - [x] Docking to a non-planet location (mining base, etc).
    - [x] Buy a ship. (If necessary, edit a save file to give yourself enough credits to do so.)
    - [x] Save the game again.
    - [x] Upgrade your new ship.
    - [x] Save once more.
    - [x] Purposely die, and then make sure you can respawn and continue playing without the game crashing or anything.
    - [x] Quit Vega Strike. Make sure it doesn't segfault on exit.
    - [x] Launch Vega Strike again. This time, from the Main Menu, choose Load, and load a previously saved game. Continue where you left off.
- [ ] This is a documentation change only

Issues:
- Please list any related issues
- - https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/1768

Purpose:
- What is this pull request trying to do?
- - Stop suns from being dockable
- What release is this for?
- - 0.11
- Is there a project or milestone we should apply this to?
- - 0.11
